### PR TITLE
fix: include cstdint to allow build on linux x86 to be successful

### DIFF
--- a/src/lib/P11Attributes.cpp
+++ b/src/lib/P11Attributes.cpp
@@ -37,6 +37,7 @@
 #include "AESKey.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <cstdint>
 
 // Constructor
 P11Attribute::P11Attribute(OSObject* inobject)

--- a/src/lib/SoftHSM_cipher.cpp
+++ b/src/lib/SoftHSM_cipher.cpp
@@ -47,6 +47,7 @@
 #include "ECPrivateKey.h"
 #include "SymmetricAlgorithm.h"
 #include "AESKey.h"
+#include <cstdint>
 
 static bool isSymMechanism(CK_MECHANISM_PTR pMechanism)
 {

--- a/src/lib/SoftHSM_slots.cpp
+++ b/src/lib/SoftHSM_slots.cpp
@@ -51,6 +51,7 @@
 #include "SlotManager.h"
 #include "odd.h"
 #include "vendor_mechanisms.h"
+#include <cstdint>
 
 #if defined(WITH_OPENSSL)
 #include "OSSLCryptoFactory.h"


### PR DESCRIPTION
Hi, for some reason I can not explain, I was not able to achieve the native `cmake` build ["Building (Native)"](https://github.com/pqctoday/softhsmv3/blob/dcaf89020b7c903a4e0d71ad67e2b1a8f5acb8c7/README.md?plain=1#L606) on my local environment (x86 Linux laptop).

But thanks to these modifications (and a couple of other modification that I will split into different PRs), I managed to get the native `cmake` build working.

I hope this helps.

## My Build Env

```bash
uname -rom
6.19.10-arch1-1 x86_64 GNU/Linux
```

```bash
openssl -version
OpenSSL 3.6.1 27 Jan 2026 (Library: OpenSSL 3.6.1 27 Jan 2026)
```

```
cmake -version
cmake version 4.3.1
```

```
make -version
GNU Make 4.4.1
```