### PR TITLE
fix(rust): populate KCV on C_UnwrapKey/C_DeriveKey + store CKA_VALUE on RSA public key

### DIFF
--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1041,8 +1041,8 @@ pub fn C_GenerateKeyPair(
                 );
                 // PKCS#11 v3.2 §2.1.2 — RSA public key MUST expose CKA_MODULUS and
                 // CKA_PUBLIC_EXPONENT as distinct attributes (not packed into CKA_VALUE).
-                pub_attrs.insert(CKA_MODULUS, n_bytes.to_vec());
-                pub_attrs.insert(CKA_PUBLIC_EXPONENT, e_bytes.to_vec());
+                pub_attrs.insert(CKA_MODULUS, n_bytes.clone());
+                pub_attrs.insert(CKA_PUBLIC_EXPONENT, e_bytes.clone());
                 store_ulong(&mut pub_attrs, CKA_MODULUS_BITS, bits as u32);
                 // SubjectPublicKeyInfo DER (CKA_PUBLIC_KEY_INFO)
                 {
@@ -1051,6 +1051,20 @@ pub fn C_GenerateKeyPair(
                         pub_attrs.insert(CKA_PUBLIC_KEY_INFO, spki_der.as_bytes().to_vec());
                     }
                 }
+                // Internal CKA_VALUE in packed `[n_len:4LE][n_bytes][e_bytes]`
+                // format. This is the Rust engine's per-object cipher-input
+                // convention used by C_Encrypt/C_WrapKey (CKM_RSA_PKCS_OAEP) and
+                // C_Decrypt/C_UnwrapKey. Storing it here means
+                // get_object_value(pub_handle) returns a parsable buffer; without
+                // this, C_WrapKey returns CKR_ARGUMENTS_BAD (0x07) because no
+                // CKA_VALUE exists on the public-key object. The C++ engine
+                // doesn't need this because OpenSSL EVP keys carry both halves
+                // natively; the Rust engine reconstructs from raw modulus/exp.
+                let mut packed = Vec::with_capacity(4 + n_bytes.len() + e_bytes.len());
+                packed.extend_from_slice(&(n_bytes.len() as u32).to_le_bytes());
+                packed.extend_from_slice(&n_bytes);
+                packed.extend_from_slice(&e_bytes);
+                pub_attrs.insert(CKA_VALUE, packed);
                 prv_attrs.insert(CKA_VALUE, sk_der.as_bytes().to_vec());
                 absorb_template_attrs(
                     &mut pub_attrs,
@@ -3428,6 +3442,9 @@ pub fn C_DeriveKey(
             store_bool(&mut attrs, CKA_SENSITIVE, !extractable);
             store_bool(&mut attrs, CKA_EXTRACTABLE, extractable);
 
+            // PKCS#11 v3.2 §4.11: KCV mandatory on derived secret keys.
+            crate::state::compute_kcv(&mut attrs);
+
             *ph_key = allocate_handle(attrs);
             return CKR_OK;
         }
@@ -3923,6 +3940,10 @@ pub fn C_DeriveKey(
         store_bool(&mut attrs, CKA_LOCAL, true); // PKCS#11 v3.2 §4.3 — derived = locally generated
         store_ulong(&mut attrs, CKA_KEY_GEN_MECHANISM, mech_type); // PKCS#11 v3.2 §4.3
         finalize_private_key_attrs(&mut attrs); // sets CKA_ALWAYS_SENSITIVE + CKA_NEVER_EXTRACTABLE
+
+        // PKCS#11 v3.2 §4.11: KCV mandatory on every secret-key derivation result.
+        crate::state::compute_kcv(&mut attrs);
+
         *ph_key = allocate_handle(attrs);
     }
     CKR_OK
@@ -4237,6 +4258,13 @@ pub fn C_UnwrapKey(
             }
         }
 
+        // PKCS#11 v3.2 §4.10.2 / §4.11: CKA_CHECK_VALUE is mandatory on all
+        // secret-key objects regardless of how the key was created. C_UnwrapKey
+        // builds a new secret-key object from the unwrapped bytes, so the KCV
+        // MUST be computed and stored before the handle is exposed. Mirrors
+        // the C++ engine's C_UnwrapKey path (SoftHSM_keygen.cpp §C_UnwrapKey).
+        crate::state::compute_kcv(&mut attrs);
+
         *ph_key = allocate_handle(attrs);
     }
     CKR_OK
@@ -4489,6 +4517,11 @@ pub fn C_UnwrapKeyAuthenticated(
                 store_param_set(&mut attrs, ps);
             }
         }
+
+        // PKCS#11 v3.2 §4.10.2 / §4.11: KCV MUST be populated on every
+        // secret-key object — C_UnwrapKeyAuthenticated counts as a new
+        // object-creation path per §5.18.7.
+        crate::state::compute_kcv(&mut attrs);
 
         *ph_key = allocate_handle(attrs);
     }


### PR DESCRIPTION
## Summary

Two PKCS#11 v3.2 compliance gaps in the Rust softhsmv3 engine, both surfaced today in pqctoday-hub's `/learn/kms-pqc` Envelope Encryption workshop:

### 1. KCV missing on derived/unwrapped secret keys

`C_UnwrapKey`, `C_UnwrapKeyAuthenticated`, and both `C_DeriveKey` paths built new secret-key objects but never called `compute_kcv` before `allocate_handle`. PKCS#11 v3.2 §4.10.2 + §4.11 require `CKA_CHECK_VALUE` on every secret-key object regardless of how it was created.

**Symptom:** `C_GetAttributeValue(CKA_CHECK_VALUE)` on an unwrapped AES DEK returned `CKR_ATTRIBUTE_TYPE_INVALID (0x12)`, halting the workshop at the integrity-verify step.

This mirrors the C++ engine's PR #61 work (`SoftHSM_keygen.cpp`). Call sites patched:

- `C_UnwrapKey` (line 4240) — wraps RSA-OAEP + AES-KW recovered keys
- `C_UnwrapKeyAuthenticated` (line 4493) — AES-GCM authenticated unwrap
- `C_DeriveKey` (line 3431) — ECDH / X25519 shared-secret derivation
- `C_DeriveKey` (line 3926) — HKDF / SP800-108 KDF result

### 2. RSA public key missing CKA_VALUE

`C_GenerateKeyPair` for `CKM_RSA_PKCS_KEY_PAIR_GEN` stored modulus + exponent in the spec-mandated `CKA_MODULUS` + `CKA_PUBLIC_EXPONENT` (PKCS#11 v3.2 §2.1.2), but did NOT also stash a packed `[n_len:4LE][n_bytes][e_bytes]` copy under `CKA_VALUE`. The Rust engine's `C_Encrypt` + `C_WrapKey` `CKM_RSA_PKCS_OAEP` path parses from `get_object_value()` which reads `CKA_VALUE`.

**Symptom:** every `C_WrapKey(RSA-OAEP)` call returned `CKR_ARGUMENTS_BAD (0x07)` because `get_object_value` on the public key returned `None`.

The C++ engine doesn't have this issue because `OpenSSL EVP_PKEY` carries both halves natively; the Rust engine reconstructs from raw bytes and needs both packed.

## Non-breaking

Both fixes are additive — they only ADD attributes that weren't there before. Callers that use spec attributes (`CKA_MODULUS` etc.) continue to work; callers that try to read KCV / `CKA_VALUE` on these objects now succeed.

## Build

```bash
cd rust
cargo build --target wasm32-unknown-unknown --release    # rustup cargo, NOT Homebrew
wasm-bindgen --target bundler --no-typescript --out-dir pkg_bundler_new --out-name softhsmrustv3 \
  target/wasm32-unknown-unknown/release/softhsmrustv3.wasm
# Append __wbg_get_memory shim per feedback-wasm-bindgen-bundler-target
```

## Test plan

- [x] Compiles cleanly under `rustup`'s cargo + `wasm32-unknown-unknown` target
- [x] **In-browser verified** via pqctoday-hub `/learn/kms-pqc` Envelope Encryption workshop:
  - ML-KEM-768 / AES-KW flow completes end-to-end with KCV displayed
  - RSA-2048 / RSA-OAEP flow completes (no more `CKR_ARGUMENTS_BAD`)
- [ ] Companion hub PR ships the rebuilt `src/wasm/softhsmrustv3_bg.wasm`

Closes the C_GenerateKey-KCV gap reported in the [Rust engine queue memory note](https://github.com/pqctoday-org/pqctoday-priv/blob/main/memory/project-hsm-rust-engine-queue.md) (well, the C_UnwrapKey half — C_GenerateKey was already populating KCV via the March 29 `ecea263` commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)