### PR TITLE
fix(rust): XMSS + ECDSA P-521 + RSA-OAEP wrap + KCV on derive/unwrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,3 @@ rust/pkg_bundler_new/
 rust/pkg_bundler_p521/
 rust/pkg_bundler_v3/
 rust/pkg_nomod/
-
-# KMIP subsystem (separate WIP — not yet ready to track)
-kmip/

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,12 @@ Makefile.in
 .idea/
 rust/target/
 openmls-provider/target/
+
+# Scratch wasm-bindgen iterations (canonical is rust/pkg_bundler/)
+rust/pkg_bundler_new/
+rust/pkg_bundler_p521/
+rust/pkg_bundler_v3/
+rust/pkg_nomod/
+
+# KMIP subsystem (separate WIP — not yet ready to track)
+kmip/

--- a/rust/src/crypto/handlers.rs
+++ b/rust/src/crypto/handlers.rs
@@ -951,8 +951,23 @@ pub fn get_sig_len(mech: u32, hkey: u32) -> u32 {
         CKM_KMAC_128 => 32,
         CKM_KMAC_256 => 64,
         CKM_SHA256_RSA_PKCS | CKM_SHA256_RSA_PKCS_PSS => 512,
-        CKM_ECDSA_SHA256 | CKM_ECDSA_SHA512 | CKM_ECDSA_SHA3_224 | CKM_ECDSA_SHA3_256 => 64,
-        CKM_ECDSA_SHA384 | CKM_ECDSA_SHA3_384 | CKM_ECDSA_SHA3_512 => 96,
+        // ECDSA — sig size = 2 × ⌈curve_bits / 8⌉, independent of the hash. The
+        // SHA384/SHA3-384 hardcode for 96-byte was wrong for P-256 + P-521 etc;
+        // size MUST come from the key's curve, not the hash mechanism.
+        // - P-256 / secp256k1 (256-bit) → 64 bytes (32 + 32)
+        // - P-384            (384-bit) → 96 bytes (48 + 48)
+        // - P-521            (521-bit) → 132 bytes (66 + 66)
+        CKM_ECDSA_SHA256
+        | CKM_ECDSA_SHA384
+        | CKM_ECDSA_SHA512
+        | CKM_ECDSA_SHA3_224
+        | CKM_ECDSA_SHA3_256
+        | CKM_ECDSA_SHA3_384
+        | CKM_ECDSA_SHA3_512 => match ps {
+            CURVE_P521 => 132,
+            CURVE_P384 => 96,
+            _ => 64, // CURVE_P256, CURVE_K256, and default
+        },
         CKM_EDDSA | CKM_EDDSA_PH => 64,
         _ => 512,
     }

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1041,8 +1041,8 @@ pub fn C_GenerateKeyPair(
                 );
                 // PKCS#11 v3.2 §2.1.2 — RSA public key MUST expose CKA_MODULUS and
                 // CKA_PUBLIC_EXPONENT as distinct attributes (not packed into CKA_VALUE).
-                pub_attrs.insert(CKA_MODULUS, n_bytes.to_vec());
-                pub_attrs.insert(CKA_PUBLIC_EXPONENT, e_bytes.to_vec());
+                pub_attrs.insert(CKA_MODULUS, n_bytes.clone());
+                pub_attrs.insert(CKA_PUBLIC_EXPONENT, e_bytes.clone());
                 store_ulong(&mut pub_attrs, CKA_MODULUS_BITS, bits as u32);
                 // SubjectPublicKeyInfo DER (CKA_PUBLIC_KEY_INFO)
                 {
@@ -1051,6 +1051,20 @@ pub fn C_GenerateKeyPair(
                         pub_attrs.insert(CKA_PUBLIC_KEY_INFO, spki_der.as_bytes().to_vec());
                     }
                 }
+                // Internal CKA_VALUE in packed `[n_len:4LE][n_bytes][e_bytes]`
+                // format. This is the Rust engine's per-object cipher-input
+                // convention used by C_Encrypt/C_WrapKey (CKM_RSA_PKCS_OAEP) and
+                // C_Decrypt/C_UnwrapKey. Storing it here means
+                // get_object_value(pub_handle) returns a parsable buffer; without
+                // this, C_WrapKey returns CKR_ARGUMENTS_BAD (0x07) because no
+                // CKA_VALUE exists on the public-key object. The C++ engine
+                // doesn't need this because OpenSSL EVP keys carry both halves
+                // natively; the Rust engine reconstructs from raw modulus/exp.
+                let mut packed = Vec::with_capacity(4 + n_bytes.len() + e_bytes.len());
+                packed.extend_from_slice(&(n_bytes.len() as u32).to_le_bytes());
+                packed.extend_from_slice(&n_bytes);
+                packed.extend_from_slice(&e_bytes);
+                pub_attrs.insert(CKA_VALUE, packed);
                 prv_attrs.insert(CKA_VALUE, sk_der.as_bytes().to_vec());
                 absorb_template_attrs(
                     &mut pub_attrs,
@@ -3428,6 +3442,9 @@ pub fn C_DeriveKey(
             store_bool(&mut attrs, CKA_SENSITIVE, !extractable);
             store_bool(&mut attrs, CKA_EXTRACTABLE, extractable);
 
+            // PKCS#11 v3.2 §4.11: KCV mandatory on derived secret keys.
+            crate::state::compute_kcv(&mut attrs);
+
             *ph_key = allocate_handle(attrs);
             return CKR_OK;
         }
@@ -3923,6 +3940,10 @@ pub fn C_DeriveKey(
         store_bool(&mut attrs, CKA_LOCAL, true); // PKCS#11 v3.2 §4.3 — derived = locally generated
         store_ulong(&mut attrs, CKA_KEY_GEN_MECHANISM, mech_type); // PKCS#11 v3.2 §4.3
         finalize_private_key_attrs(&mut attrs); // sets CKA_ALWAYS_SENSITIVE + CKA_NEVER_EXTRACTABLE
+
+        // PKCS#11 v3.2 §4.11: KCV mandatory on every secret-key derivation result.
+        crate::state::compute_kcv(&mut attrs);
+
         *ph_key = allocate_handle(attrs);
     }
     CKR_OK
@@ -4237,6 +4258,13 @@ pub fn C_UnwrapKey(
             }
         }
 
+        // PKCS#11 v3.2 §4.10.2 / §4.11: CKA_CHECK_VALUE is mandatory on all
+        // secret-key objects regardless of how the key was created. C_UnwrapKey
+        // builds a new secret-key object from the unwrapped bytes, so the KCV
+        // MUST be computed and stored before the handle is exposed. Mirrors
+        // the C++ engine's C_UnwrapKey path (SoftHSM_keygen.cpp §C_UnwrapKey).
+        crate::state::compute_kcv(&mut attrs);
+
         *ph_key = allocate_handle(attrs);
     }
     CKR_OK
@@ -4489,6 +4517,11 @@ pub fn C_UnwrapKeyAuthenticated(
                 store_param_set(&mut attrs, ps);
             }
         }
+
+        // PKCS#11 v3.2 §4.10.2 / §4.11: KCV MUST be populated on every
+        // secret-key object — C_UnwrapKeyAuthenticated counts as a new
+        // object-creation path per §5.18.7.
+        crate::state::compute_kcv(&mut attrs);
 
         *ph_key = allocate_handle(attrs);
     }

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1527,7 +1527,11 @@ pub fn C_GenerateKeyPair(
                 // Public key attributes
                 store_ulong(&mut pub_attrs, CKA_CLASS, CKO_PUBLIC_KEY);
                 store_ulong(&mut pub_attrs, CKA_KEY_TYPE, CKK_XMSS);
-                store_ulong(&mut pub_attrs, CKA_XMSS_PARAM_SET, param_code);
+                // Store the EFFECTIVE xmss_param (with default applied) — not
+                // the raw param_code. xmss_sign / xmss_verify read this attr
+                // and dispatch on it; a stored 0 falls into the catch-all
+                // `_ => Err(CKR_FUNCTION_FAILED)` arm and breaks every sign.
+                store_ulong(&mut pub_attrs, CKA_XMSS_PARAM_SET, xmss_param);
                 store_ulong(&mut pub_attrs, CKA_KEY_GEN_MECHANISM, CKM_XMSS_KEY_PAIR_GEN);
                 store_bool(&mut pub_attrs, CKA_TOKEN, false);
                 store_bool(&mut pub_attrs, CKA_PRIVATE, false);
@@ -1538,7 +1542,7 @@ pub fn C_GenerateKeyPair(
                 // Private key attributes
                 store_ulong(&mut prv_attrs, CKA_CLASS, CKO_PRIVATE_KEY);
                 store_ulong(&mut prv_attrs, CKA_KEY_TYPE, CKK_XMSS);
-                store_ulong(&mut prv_attrs, CKA_XMSS_PARAM_SET, param_code);
+                store_ulong(&mut prv_attrs, CKA_XMSS_PARAM_SET, xmss_param);
                 store_ulong(&mut prv_attrs, CKA_KEY_GEN_MECHANISM, CKM_XMSS_KEY_PAIR_GEN);
                 store_bool(&mut prv_attrs, CKA_TOKEN, false);
                 store_bool(&mut prv_attrs, CKA_PRIVATE, true);

--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -222,13 +222,27 @@ pub fn get_ec_point_sec1(handle: u32) -> Option<Vec<u8>> {
                 .and_then(|attrs| attrs.get(&CKA_EC_POINT).cloned())
         })
         .map(|ec_point| {
-            // DER OCTET STRING short form: tag=0x04, then one length byte.
-            // If byte[1] equals len-2 the buffer carries the DER header; strip it.
-            if ec_point.len() > 2 && ec_point[1] as usize == ec_point.len() - 2 {
-                ec_point[2..].to_vec()
-            } else {
-                ec_point
+            // CKA_EC_POINT stores a DER OCTET STRING wrapping the SEC1 point
+            // (PKCS#11 v3.2 §2.3.3). Strip the header to return the raw SEC1
+            // bytes. Two encodings exist:
+            //   - Short form  : 0x04 <len ≤ 127> <data>            (len = data.len())
+            //   - Long form 1B: 0x04 0x81 <len> <data>             (P-521 path — data=133)
+            // P-256 / P-384 / secp256k1 fit short form (65 / 97 / 65 ≤ 127).
+            // P-521's 133-byte SEC1 point requires long form.
+            if ec_point.len() > 2 && ec_point[0] == 0x04 {
+                if ec_point[1] as usize == ec_point.len() - 2 {
+                    // Short form
+                    return ec_point[2..].to_vec();
+                }
+                if ec_point.len() > 3
+                    && ec_point[1] == 0x81
+                    && ec_point[2] as usize == ec_point.len() - 3
+                {
+                    // Long form, 1-byte length (covers all SEC1 points up to 255 B)
+                    return ec_point[3..].to_vec();
+                }
             }
+            ec_point
         })
 }
 


### PR DESCRIPTION
## Summary

Five PKCS#11 v3.2 compliance gaps in the Rust softhsmv3 engine, surfaced by pqctoday-hub's `HsmAcvpTesting` workshop and `/learn/kms-pqc` Envelope Encryption workshop. All fixes are additive — no caller-visible breakage.

### Commit `d086081` — KCV + RSA public-key value

1. **KCV missing on derived / unwrapped secret keys** — `C_UnwrapKey`, `C_UnwrapKeyAuthenticated`, and `C_DeriveKey` (PKCS#11 v3.2 §5.18.4 / §5.18.7 / §6.5.6) built new secret-key objects but never called `compute_kcv` before `allocate_handle`. §4.10.2 + §4.11 require `CKA_CHECK_VALUE` on every secret-key object regardless of creation path. Mirrors the C++ engine's PR #61 fix.
2. **RSA public key missing CKA_VALUE** — `C_GenerateKeyPair(CKM_RSA_PKCS_KEY_PAIR_GEN)` stored modulus + exponent in the spec-mandated attributes but not in the packed `[n_len:4LE][n_bytes][e_bytes]` form under `CKA_VALUE` that `C_Encrypt` / `C_WrapKey(CKM_RSA_PKCS_OAEP)` parse. Every RSA-OAEP wrap returned `CKR_ARGUMENTS_BAD`.

### Commit `3146344` — XMSS + ECDSA P-521

3. **XMSS `C_Sign` → CKR_FUNCTION_FAILED** — keygen stored the raw `param_code` (0 when caller omitted the params struct), and `xmss_sign` matched it against the `CKP_XMSS_*` enum → catch-all fail. Fixed by storing the effective `xmss_param` (default `CKP_XMSS_SHA2_10_256` applied).
4. **ECDSA P-521 `C_Sign` → CKR_BUFFER_TOO_SMALL** — `get_sig_len(CKM_ECDSA_SHA512, _)` returned a hardcoded 64 B regardless of curve. ECDSA size is `2 × ⌈curve_bits/8⌉` → P-521 needs 132 B. Consolidated all ECDSA mechanism arms into a curve-aware lookup.
5. **P-521 verify-fails-on-own-signature** — `get_ec_point_sec1` only stripped DER OCTET STRING **short-form** length (`0x04 <len ≤ 127> <data>`); P-521's 133-byte SEC1 point requires **long-form** (`0x04 0x81 0x85 <data>`). Keygen correctly emits long-form; strip helper now recognizes it. Short-form path preserved (P-256 / P-384 / secp256k1 unaffected).

## Test plan

- [x] In-browser via pqctoday-hub `HsmAcvpTesting` workshop:
  - XMSS Stateful Sign+Verify: PASS
  - ECDSA P-521 Functional Sign+Verify: PASS
  - ECDSA secp256k1 (regression check): PASS
- [x] In-browser via pqctoday-hub `/learn/kms-pqc` Envelope Encryption:
  - ML-KEM-768 / AES-KW end-to-end with KCV displayed + integrity verified
  - RSA-2048 / RSA-OAEP end-to-end with KCV displayed + integrity verified
- [ ] CI green
- [ ] Reviewer to spot-check the curve-aware `get_sig_len` switch covers all ECDSA mechanism arms

## Build

```
cargo build --target wasm32-unknown-unknown --release  # rustup cargo, not Homebrew
wasm-bindgen --target bundler --no-typescript --out-dir pkg --out-name softhsmrustv3
# + append __wbg_get_memory shim per feedback-wasm-bindgen-bundler-target
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)