### PR TITLE
feat(kmip): Phase 4.6 tri-plane audit scaffold

### DIFF
--- a/kmip/Cargo.toml
+++ b/kmip/Cargo.toml
@@ -74,7 +74,7 @@ sha2        = "0.10"
 uuid = { version = "1", features = ["v4"] }
 
 # Time
-time = { version = "0.3", features = ["serde", "formatting"] }
+time = { version = "0.3", features = ["serde", "formatting", "parsing", "serde-well-known"] }
 
 # Error handling
 thiserror = "1"

--- a/kmip/src/auditlog/composite.rs
+++ b/kmip/src/auditlog/composite.rs
@@ -1,0 +1,72 @@
+//! [`CompositeSink`] — fan an event out to multiple sinks in declaration
+//! order. Typical wiring:
+//!
+//! ```ignore
+//! let ring  = Arc::new(RingSink::new(16_384));
+//! let jsonl = Arc::new(JsonlSink::open("/var/log/pqctoday/audit.jsonl")?);
+//! let sink  = Arc::new(CompositeSink::new(vec![ring.clone(), jsonl]));
+//! engine.set_sink(sink);
+//! ```
+//!
+//! The `ring` handle stays callable for the Hub UI's `/audit/tail` endpoint
+//! while the `jsonl` writer accumulates durable forensic history.
+
+use std::sync::Arc;
+
+use super::event::AuditEvent;
+use super::sink::AuditSink;
+
+pub struct CompositeSink {
+    sinks: Vec<Arc<dyn AuditSink>>,
+}
+
+impl CompositeSink {
+    pub fn new(sinks: Vec<Arc<dyn AuditSink>>) -> Self {
+        Self { sinks }
+    }
+}
+
+impl AuditSink for CompositeSink {
+    fn emit(&self, event: AuditEvent) {
+        for sink in &self.sinks {
+            // Clone on each fan-out leg so each sink owns its own copy.
+            // Cheap — `AuditEvent` is small and the payload variants are
+            // String + a few u32s.
+            sink.emit(event.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::event::{DecisionSummary, EventPayload, Plane};
+    use super::super::ring::RingSink;
+    use time::OffsetDateTime;
+
+    #[test]
+    fn fan_out_to_two_rings() {
+        let a = Arc::new(RingSink::new(8));
+        let b = Arc::new(RingSink::new(8));
+        let comp: Arc<dyn AuditSink> = Arc::new(CompositeSink::new(vec![
+            a.clone(),
+            b.clone(),
+        ]));
+        comp.emit(AuditEvent::at(
+            OffsetDateTime::UNIX_EPOCH,
+            Plane::Agility,
+            "c1",
+            EventPayload::PolicyDecided {
+                op: "Sign".into(),
+                algorithm: None,
+                outcome: DecisionSummary::Allow {
+                    algorithm_override: None,
+                    substituted_by_rule: None,
+                },
+                policy_fingerprint: "sha256:0".into(),
+            },
+        ));
+        assert_eq!(a.snapshot().len(), 1);
+        assert_eq!(b.snapshot().len(), 1);
+    }
+}

--- a/kmip/src/auditlog/event.rs
+++ b/kmip/src/auditlog/event.rs
@@ -1,0 +1,259 @@
+//! [`AuditEvent`] — the common envelope that every plane emits.
+//!
+//! Every plane (P1 agility engine, P2 KMIP dispatcher + ops, P3 PKCS#11
+//! bridge) emits its events through an [`super::AuditSink`] wrapped in this
+//! envelope. The Hub UI consumes the resulting stream — no per-plane
+//! parser, no correlation logic in the UI: it groups by `correlation_id`
+//! and orders by `ts`.
+//!
+//! ## Envelope shape (wire-format committed)
+//!
+//! ```json
+//! {
+//!   "ts":              "2026-06-07T14:32:11.482Z",
+//!   "plane":           "p1" | "p2" | "p3",
+//!   "correlation_id":  "<opaque uuid-ish string>",
+//!   "event":           { … plane-specific payload … }
+//! }
+//! ```
+//!
+//! The Hub UI binds against `plane` + `event.type` to pick rendering
+//! components (badge colour, icon, expand/collapse layout).
+//!
+//! ## Why one envelope across all planes
+//!
+//! Multiple planes need to fan into the same JSONL file / SSE stream / Hub
+//! viewer with **no joiner step in between**. A single envelope means:
+//!
+//! - The Phase-7 server can serve `GET /audit/tail` as a raw passthrough.
+//! - The Hub UI parses one schema, regardless of which plane emitted.
+//! - `correlation_id` always lives in the same field.
+//! - Adding a future plane (e.g. a KMS replication peer) costs a new
+//!   `EventPayload` variant — no envelope migration.
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+/// Which plane emitted this event. Wire-format string is the
+/// `#[serde(rename)]` value — Hub UI binds against these literals.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Plane {
+    /// Plane 1 — Crypto Agility Management (policy engine).
+    #[serde(rename = "p1")]
+    Agility,
+    /// Plane 2 — KMIP 3.0 dispatcher + op handlers.
+    #[serde(rename = "p2")]
+    Kmip,
+    /// Plane 3 — PKCS#11 bridge to softhsmrustv3.
+    #[serde(rename = "p3")]
+    Pkcs11,
+}
+
+impl Plane {
+    /// Short symbolic name (`"p1"`, `"p2"`, `"p3"`). Same as the serde rename.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Plane::Agility => "p1",
+            Plane::Kmip => "p2",
+            Plane::Pkcs11 => "p3",
+        }
+    }
+}
+
+/// Opaque per-request identifier shared across all three planes for one
+/// inbound KMIP request. The Phase-7 server allocates one at request
+/// ingress; everything downstream (engine, dispatcher, op handler, bridge)
+/// stamps the same value on every event it emits.
+pub type CorrelationId = String;
+
+/// Common envelope for every emitted event.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AuditEvent {
+    /// Emission timestamp. UTC.
+    #[serde(with = "time::serde::rfc3339")]
+    pub ts: OffsetDateTime,
+
+    /// Which plane emitted this event.
+    pub plane: Plane,
+
+    /// Per-request correlation. Shared across all three planes for one
+    /// inbound request.
+    pub correlation_id: CorrelationId,
+
+    /// Plane-specific payload.
+    pub event: EventPayload,
+}
+
+impl AuditEvent {
+    /// Construct an event with `ts = now()`.
+    pub fn new(
+        plane: Plane,
+        correlation_id: impl Into<CorrelationId>,
+        event: EventPayload,
+    ) -> Self {
+        Self {
+            ts: OffsetDateTime::now_utc(),
+            plane,
+            correlation_id: correlation_id.into(),
+            event,
+        }
+    }
+
+    /// Convenience: build an event with an explicit `ts`. Tests use this
+    /// to pin a deterministic clock; production should prefer [`Self::new`].
+    pub fn at(
+        ts: OffsetDateTime,
+        plane: Plane,
+        correlation_id: impl Into<CorrelationId>,
+        event: EventPayload,
+    ) -> Self {
+        Self {
+            ts,
+            plane,
+            correlation_id: correlation_id.into(),
+            event,
+        }
+    }
+}
+
+/// Plane-specific event payload. Wire format: `{ "type": "<variant>", … }`
+/// (serde's adjacently-tagged form maps cleanly to the Hub UI's component
+/// dispatch).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum EventPayload {
+    // ── Plane 1 — agility engine ──────────────────────────────────────────
+    /// A new policy was activated (operator edit or startup load).
+    PolicyActivated {
+        policy_name: String,
+        new_fingerprint: String,
+        prior_fingerprint: Option<String>,
+        warnings: Vec<String>,
+    },
+    /// Engine evaluated a request and returned a decision.
+    PolicyDecided {
+        op: String,
+        algorithm: Option<String>,
+        outcome: DecisionSummary,
+        policy_fingerprint: String,
+    },
+    /// Engine planned a rekey — dispatcher (Phase 5) executes.
+    RekeyPlanned {
+        original_uid: String,
+        from_algorithm: String,
+        new_algorithm: String,
+        triggered_by_rule: usize,
+        policy_fingerprint: String,
+    },
+
+    // ── Plane 2 — KMIP ────────────────────────────────────────────────────
+    /// KMIP request landed at the dispatcher. Phase 5 emits.
+    KmipRequestReceived {
+        op: String,
+        request_summary: String,
+        client_cn: Option<String>,
+    },
+    /// KMIP response about to leave the dispatcher. Phase 5 emits.
+    KmipResponseSent {
+        op: String,
+        result: KmipOpResult,
+        latency_ms: u32,
+    },
+    /// Managed-object lifecycle transition (PreActive → Active, etc.).
+    /// Phase 6 emits when the store FSM fires.
+    KmipObjectStateChanged {
+        uid: String,
+        from_state: String,
+        to_state: String,
+        reason: String,
+    },
+
+    // ── Plane 3 — PKCS#11 ─────────────────────────────────────────────────
+    /// One PKCS#11 entry-point call. Phase 5 (op handlers) emits per call.
+    Pkcs11Call {
+        function: String, // "C_GenerateKeyPair", "C_Sign", "C_EncapsulateKey", ...
+        mechanism: Option<String>, // CKM_* symbolic name, when applicable
+        slot: Option<u32>,
+        session: Option<u32>,
+        rv: u32, // CK_RV — 0 for CKR_OK
+        rv_name: String, // "CKR_OK", "CKR_ARGUMENTS_BAD", ...
+        latency_ms: u32,
+    },
+    /// PKCS#11 session opened / closed. Phase 4 bridge emits when wired.
+    Pkcs11SessionLifecycle {
+        action: String, // "open" | "close"
+        slot: u32,
+        session: u32,
+    },
+}
+
+/// Compact projection of `policy::Decision` for the audit envelope.
+/// Wire-format committed: Hub UI renders by `outcome.type`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum DecisionSummary {
+    Allow {
+        algorithm_override: Option<String>,
+        substituted_by_rule: Option<usize>,
+    },
+    Deny {
+        reason: String,
+        fired_rule_index: usize,
+    },
+    Rekey {
+        new_algorithm: String,
+        original_uid: String,
+    },
+}
+
+/// Compact KMIP response status for the audit envelope.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum KmipOpResult {
+    Success,
+    OperationFailed { reason: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plane_serde_round_trip() {
+        for p in [Plane::Agility, Plane::Kmip, Plane::Pkcs11] {
+            let s = serde_json::to_string(&p).unwrap();
+            let back: Plane = serde_json::from_str(&s).unwrap();
+            assert_eq!(p, back);
+        }
+        // Wire-format pin.
+        assert_eq!(serde_json::to_string(&Plane::Agility).unwrap(), "\"p1\"");
+        assert_eq!(serde_json::to_string(&Plane::Kmip).unwrap(), "\"p2\"");
+        assert_eq!(serde_json::to_string(&Plane::Pkcs11).unwrap(), "\"p3\"");
+    }
+
+    #[test]
+    fn envelope_serialises_with_iso_timestamp() {
+        let ev = AuditEvent::at(
+            OffsetDateTime::from_unix_timestamp(1_780_000_000).unwrap(),
+            Plane::Agility,
+            "corr-1",
+            EventPayload::PolicyDecided {
+                op: "Sign".into(),
+                algorithm: Some("ML-DSA-87".into()),
+                policy_fingerprint: "sha256:abc".into(),
+                outcome: DecisionSummary::Allow {
+                    algorithm_override: None,
+                    substituted_by_rule: None,
+                },
+            },
+        );
+        let json = serde_json::to_string(&ev).unwrap();
+        assert!(json.contains("\"plane\":\"p1\""));
+        assert!(json.contains("\"correlation_id\":\"corr-1\""));
+        assert!(json.contains("\"type\":\"PolicyDecided\""));
+        // Round-trip.
+        let back: AuditEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.correlation_id, "corr-1");
+        assert_eq!(back.plane, Plane::Agility);
+    }
+}

--- a/kmip/src/auditlog/jsonl.rs
+++ b/kmip/src/auditlog/jsonl.rs
@@ -1,0 +1,111 @@
+//! [`JsonlSink`] — append-only JSON-Lines file writer.
+//!
+//! One line per event, terminated with `\n`. Production sandbox runs wire
+//! this alongside a [`super::RingSink`] (via [`super::CompositeSink`]) so
+//! the Hub UI tails the ring while the JSONL accumulates durable history.
+//!
+//! Failure mode: any I/O error is logged via `tracing::error!` and the
+//! event is silently dropped — audit MUST NEVER take down a production
+//! request. The next event retries the write.
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use super::event::AuditEvent;
+use super::sink::AuditSink;
+
+pub struct JsonlSink {
+    path: PathBuf,
+    file: Mutex<File>,
+}
+
+impl JsonlSink {
+    /// Open or create `path` for append-write. Parent directory must exist.
+    pub fn open(path: impl Into<PathBuf>) -> std::io::Result<Self> {
+        let path = path.into();
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)?;
+        Ok(Self {
+            path,
+            file: Mutex::new(file),
+        })
+    }
+
+    /// Underlying file path. Hub UI / operators reference this when
+    /// downloading the durable forensic record.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl AuditSink for JsonlSink {
+    fn emit(&self, event: AuditEvent) {
+        let line = match serde_json::to_string(&event) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(target: "audit", "serialise failed: {e}");
+                return;
+            }
+        };
+        let mut file = match self.file.lock() {
+            Ok(f) => f,
+            Err(_) => {
+                tracing::error!(target: "audit", "jsonl sink mutex poisoned");
+                return;
+            }
+        };
+        if let Err(e) = writeln!(file, "{line}") {
+            tracing::error!(target: "audit", "jsonl write failed: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::event::{DecisionSummary, EventPayload, Plane};
+    use time::OffsetDateTime;
+
+    fn tmp_file(suffix: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "pqctoday-audit-{}-{}.jsonl",
+            suffix,
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    #[test]
+    fn writes_one_line_per_event() {
+        let path = tmp_file("one-per-line");
+        let sink = JsonlSink::open(&path).unwrap();
+        for i in 0..3 {
+            sink.emit(AuditEvent::at(
+                OffsetDateTime::UNIX_EPOCH,
+                Plane::Kmip,
+                format!("c{i}"),
+                EventPayload::PolicyDecided {
+                    op: "Sign".into(),
+                    algorithm: None,
+                    outcome: DecisionSummary::Allow {
+                        algorithm_override: None,
+                        substituted_by_rule: None,
+                    },
+                    policy_fingerprint: "sha256:0".into(),
+                },
+            ));
+        }
+        drop(sink); // release file handle so we can read
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 3);
+        for line in &lines {
+            let _back: AuditEvent = serde_json::from_str(line)
+                .expect("each line must be valid JSON");
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/kmip/src/auditlog/mod.rs
+++ b/kmip/src/auditlog/mod.rs
@@ -1,7 +1,43 @@
-//! Cross-plane audit log — async JSONL writer.
+//! Cross-plane audit log surface.
 //!
-//! One line per plane-event per request. All entries for a single application
-//! request share a `correlation_id` so policy / KMIP / PKCS#11 events can be
-//! joined into a forensic trace.
+//! Every plane — Plane 1 (agility engine), Plane 2 (KMIP dispatcher + ops),
+//! Plane 3 (PKCS#11 bridge) — emits its events through an [`AuditSink`].
+//! The Hub UI is a **passive viewer** that tails the resulting stream and
+//! renders rows grouped by [`event::CorrelationId`]. There is no joiner,
+//! no enrichment, no correlation logic on the UI side.
 //!
-//! Phase 0 (bootstrap): module declared, no implementation. Lands in Phase 9.
+//! ## Layered architecture
+//!
+//! ```text
+//!   Plane 1 ── emit() ─┐
+//!   Plane 2 ── emit() ─┼─► Arc<dyn AuditSink> ─► CompositeSink ─┬─► RingSink   (Hub UI tail)
+//!   Plane 3 ── emit() ─┘                                        └─► JsonlSink  (durable file)
+//! ```
+//!
+//! Each plane is constructed with an `Arc<dyn AuditSink>`. Production
+//! wires all three to the same sink. Tests wire each to its own
+//! [`RingSink`] for isolation. The trait is `Send + Sync` so one sink
+//! safely fans across concurrent emissions.
+//!
+//! ## What each plane emits (today vs planned)
+//!
+//! | Plane | Events | Status |
+//! |-------|--------|--------|
+//! | P1 — agility | `PolicyActivated`, `PolicyDecided`, `RekeyPlanned` | ✅ wired (this phase) |
+//! | P2 — KMIP    | `KmipRequestReceived`, `KmipResponseSent`, `KmipObjectStateChanged` | ⏳ Phase 5–6 |
+//! | P3 — PKCS#11 | `Pkcs11Call`, `Pkcs11SessionLifecycle` | ⏳ Phase 5 (when ops drive the bridge) |
+//!
+//! Variant shape is committed wire-format — Phase 5 / 6 emitters fill in
+//! the payload fields, no schema change.
+
+pub mod composite;
+pub mod event;
+pub mod jsonl;
+pub mod ring;
+pub mod sink;
+
+pub use composite::CompositeSink;
+pub use event::{AuditEvent, CorrelationId, DecisionSummary, EventPayload, KmipOpResult, Plane};
+pub use jsonl::JsonlSink;
+pub use ring::RingSink;
+pub use sink::{AuditSink, NullSink};

--- a/kmip/src/auditlog/ring.rs
+++ b/kmip/src/auditlog/ring.rs
@@ -1,0 +1,149 @@
+//! [`RingSink`] — bounded in-memory audit ring.
+//!
+//! Default sink for sandbox / tests / the Hub UI's "recent activity"
+//! panel. When the ring is full, the oldest event is evicted.
+//!
+//! Query API ([`Self::snapshot`], [`Self::filter_correlation_id`],
+//! [`Self::filter_plane`]) is what the Phase-7 server's `GET /audit?...`
+//! endpoint will wrap. Hub UI tails by polling `snapshot()` periodically
+//! (or by subscribing to a future SSE wrapper, separate workstream).
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+use super::event::{AuditEvent, Plane};
+use super::sink::AuditSink;
+
+pub struct RingSink {
+    inner: Mutex<VecDeque<AuditEvent>>,
+    capacity: usize,
+}
+
+impl RingSink {
+    /// Allocate a ring with `capacity` slots. Production default: 16 384.
+    /// Tests typically use 64–256.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Mutex::new(VecDeque::with_capacity(capacity.min(1024))),
+            capacity,
+        }
+    }
+
+    /// Snapshot the current ring. Cheap-ish — clones the deque.
+    pub fn snapshot(&self) -> Vec<AuditEvent> {
+        self.inner
+            .lock()
+            .expect("ring poisoned")
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Return all events sharing `correlation_id`, in insertion order.
+    /// Used by the Hub UI to render the full three-plane trace for one
+    /// request when the user clicks on a row.
+    pub fn filter_correlation_id(&self, correlation_id: &str) -> Vec<AuditEvent> {
+        self.inner
+            .lock()
+            .expect("ring poisoned")
+            .iter()
+            .filter(|e| e.correlation_id == correlation_id)
+            .cloned()
+            .collect()
+    }
+
+    /// Return all events from one plane, in insertion order.
+    pub fn filter_plane(&self, plane: Plane) -> Vec<AuditEvent> {
+        self.inner
+            .lock()
+            .expect("ring poisoned")
+            .iter()
+            .filter(|e| e.plane == plane)
+            .cloned()
+            .collect()
+    }
+
+    /// Drain the ring (used by tests that want a fresh state).
+    pub fn clear(&self) {
+        self.inner.lock().expect("ring poisoned").clear();
+    }
+
+    /// Current size of the ring.
+    pub fn len(&self) -> usize {
+        self.inner.lock().expect("ring poisoned").len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl AuditSink for RingSink {
+    fn emit(&self, event: AuditEvent) {
+        let mut q = self.inner.lock().expect("ring poisoned");
+        if q.len() == self.capacity {
+            q.pop_front();
+        }
+        q.push_back(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::event::{DecisionSummary, EventPayload};
+    use time::OffsetDateTime;
+
+    fn ev(plane: Plane, corr: &str) -> AuditEvent {
+        AuditEvent::at(
+            OffsetDateTime::UNIX_EPOCH,
+            plane,
+            corr,
+            EventPayload::PolicyDecided {
+                op: "Sign".into(),
+                algorithm: Some("ML-DSA-87".into()),
+                outcome: DecisionSummary::Allow {
+                    algorithm_override: None,
+                    substituted_by_rule: None,
+                },
+                policy_fingerprint: "sha256:0".into(),
+            },
+        )
+    }
+
+    #[test]
+    fn ring_evicts_oldest_when_full() {
+        let ring = RingSink::new(3);
+        for i in 0..5 {
+            ring.emit(ev(Plane::Agility, &format!("c{i}")));
+        }
+        let snap = ring.snapshot();
+        assert_eq!(snap.len(), 3);
+        // Oldest two evicted; remaining are c2, c3, c4.
+        assert_eq!(snap[0].correlation_id, "c2");
+        assert_eq!(snap[2].correlation_id, "c4");
+    }
+
+    #[test]
+    fn filter_by_correlation_id() {
+        let ring = RingSink::new(10);
+        ring.emit(ev(Plane::Agility, "X"));
+        ring.emit(ev(Plane::Kmip,    "Y"));
+        ring.emit(ev(Plane::Pkcs11,  "X"));
+        let x = ring.filter_correlation_id("X");
+        assert_eq!(x.len(), 2);
+        assert_eq!(x[0].plane, Plane::Agility);
+        assert_eq!(x[1].plane, Plane::Pkcs11);
+    }
+
+    #[test]
+    fn filter_by_plane() {
+        let ring = RingSink::new(10);
+        ring.emit(ev(Plane::Agility, "a"));
+        ring.emit(ev(Plane::Agility, "b"));
+        ring.emit(ev(Plane::Kmip, "c"));
+        assert_eq!(ring.filter_plane(Plane::Agility).len(), 2);
+        assert_eq!(ring.filter_plane(Plane::Kmip).len(), 1);
+        assert_eq!(ring.filter_plane(Plane::Pkcs11).len(), 0);
+    }
+}

--- a/kmip/src/auditlog/sink.rs
+++ b/kmip/src/auditlog/sink.rs
@@ -1,0 +1,58 @@
+//! [`AuditSink`] — the trait every emitter writes through.
+//!
+//! Three concrete implementations ship in this module:
+//!
+//! - [`super::RingSink`] — bounded in-memory ring, default for sandbox /
+//!   tests / Hub UI history panel.
+//! - [`super::JsonlSink`] — append-only file writer, JSONL format, default
+//!   for production runs.
+//! - [`super::CompositeSink`] — fan-out to multiple sinks (typical wiring:
+//!   `Composite(Ring, Jsonl)` so the Hub UI can tail recent history from
+//!   the ring while the JSONL file accumulates durable forensic records).
+//!
+//! The trait is `Send + Sync` so a single sink can be cloned (via `Arc`)
+//! to every plane.
+
+use super::event::AuditEvent;
+
+/// Object-safe sink trait. `emit` is best-effort: a sink that's full /
+/// closed / errored MUST NOT panic — it should log internally and drop
+/// the event. Audit MUST NEVER take down a production request.
+pub trait AuditSink: Send + Sync {
+    /// Append one event. Best-effort; never panics.
+    fn emit(&self, event: AuditEvent);
+}
+
+/// No-op sink. Useful when audit is disabled at startup or in benchmarks.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NullSink;
+
+impl AuditSink for NullSink {
+    fn emit(&self, _event: AuditEvent) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::event::{EventPayload, Plane};
+    use time::OffsetDateTime;
+
+    #[test]
+    fn null_sink_swallows_events() {
+        let sink = NullSink;
+        sink.emit(AuditEvent::at(
+            OffsetDateTime::UNIX_EPOCH,
+            Plane::Agility,
+            "corr",
+            EventPayload::PolicyDecided {
+                op: "Sign".into(),
+                algorithm: None,
+                outcome: super::super::event::DecisionSummary::Allow {
+                    algorithm_override: None,
+                    substituted_by_rule: None,
+                },
+                policy_fingerprint: "sha256:0".into(),
+            },
+        ));
+    }
+}

--- a/kmip/src/policy/audit.rs
+++ b/kmip/src/policy/audit.rs
@@ -1,87 +1,64 @@
-//! [`PolicyAudit`] — Plane-1 in-memory audit ring.
+//! [`PolicyAudit`] — Plane-1 facade over the cross-plane [`AuditSink`].
 //!
-//! Captures three event classes the Hub UI and Phase 9 audit CLI both need:
+//! Phase 4.6 retrofit: PolicyAudit no longer owns its own bespoke ring +
+//! event enum. It is now a thin typed wrapper that:
 //!
-//! - **PolicyActivated** — every successful [`super::Engine::activate`] call.
-//!   Carries the new policy's fingerprint, the prior fingerprint (so an
-//!   operator can diff which YAML was just swapped in), and any loader
-//!   warnings.
-//! - **Decision** — one row per `evaluate` call: the request shape +
-//!   resulting [`super::Decision`] + the active policy fingerprint at the
-//!   time. Lets the operator answer "why was this Sign denied at 09:14:32?"
-//!   without replaying the request.
-//! - **RekeyPlanned** — synthesised when an `evaluate` returns
-//!   [`super::Decision::RekeyAndProceed`]. Same info as the Decision row
-//!   plus the rekey-specific fields, separated so the rekey audit view in
-//!   the Hub doesn't have to walk every Decision row.
+//! 1. Holds a backing [`crate::auditlog::RingSink`] for its existing
+//!    `snapshot()` API (Hub UI's "Plane-1 history" panel).
+//! 2. Optionally fans every event ALSO into a global
+//!    [`crate::auditlog::AuditSink`] (typically a
+//!    [`crate::auditlog::CompositeSink`] that also drives Plane 2 + 3).
+//!    This is how the Hub UI gets the tri-plane correlated stream.
 //!
-//! Storage is a bounded ring buffer (default 1024 entries) — sufficient
-//! for a sandbox-grade engine and the per-request "what just happened?"
-//! UI. Phase 9 wires this to the SQLite audit log for durable history.
+//! Engine code is unchanged — `record_activation`, `record_decision`,
+//! `snapshot` keep the same call shape.
 
-use std::collections::VecDeque;
-use std::sync::Mutex;
+use std::sync::Arc;
 use time::OffsetDateTime;
+
+use crate::auditlog::{
+    AuditEvent, AuditSink, CompositeSink, DecisionSummary, EventPayload, Plane, RingSink,
+};
 
 use super::decision::Decision;
 use super::request::PolicyRequest;
 
-#[derive(Clone, Debug)]
-pub enum AuditEvent {
-    PolicyActivated {
-        ts: OffsetDateTime,
-        policy_name: String,
-        new_fingerprint: String,
-        prior_fingerprint: Option<String>,
-        warnings: Vec<String>,
-    },
-    Decision {
-        ts: OffsetDateTime,
-        op: String,
-        algorithm: Option<String>,
-        correlation_id: String,
-        policy_fingerprint: String,
-        outcome: AuditDecision,
-    },
-    RekeyPlanned {
-        ts: OffsetDateTime,
-        correlation_id: String,
-        original_uid: String,
-        from_algorithm: String,
-        new_algorithm: String,
-        triggered_by_rule: usize,
-        policy_fingerprint: String,
-    },
-}
-
-/// Compact projection of [`Decision`] suitable for log persistence.
-#[derive(Clone, Debug)]
-pub enum AuditDecision {
-    Allow {
-        algorithm_override: Option<String>,
-        substituted_by_rule: Option<usize>,
-    },
-    Deny {
-        reason: String,
-        fired_rule_index: usize,
-    },
-    Rekey {
-        new_algorithm: String,
-        original_uid: String,
-    },
-}
-
+/// Plane-1 audit facade. The backing [`RingSink`] is exposed via
+/// [`Self::snapshot`] so existing callers (engine tests, Hub UI Plane-1
+/// panel) keep working.
 pub struct PolicyAudit {
-    inner: Mutex<VecDeque<AuditEvent>>,
-    capacity: usize,
+    /// Where Plane-1 events land. Always at least the backing ring; if a
+    /// global sink was provided it's wrapped in a [`CompositeSink`].
+    sink: Arc<dyn AuditSink>,
+    /// Backing in-memory ring — keeps the [`Self::snapshot`] API working.
+    ring: Arc<RingSink>,
 }
 
 impl PolicyAudit {
+    /// Standalone ring with `capacity` slots — no cross-plane fan-out.
+    /// Default for unit tests and engines constructed via
+    /// [`super::Engine::deny_all`] / [`super::Engine::permissive`].
     pub fn new(capacity: usize) -> Self {
+        let ring = Arc::new(RingSink::new(capacity));
         Self {
-            inner: Mutex::new(VecDeque::with_capacity(capacity)),
-            capacity,
+            sink: ring.clone(),
+            ring,
         }
+    }
+
+    /// Cross-plane wiring: events land in this local ring AND in the
+    /// supplied global sink. Production engines built by the Phase-7
+    /// server call this with the composite sink that also drives Plane 2
+    /// + Plane 3 emitters.
+    pub fn with_global_sink(capacity: usize, global: Arc<dyn AuditSink>) -> Self {
+        let ring = Arc::new(RingSink::new(capacity));
+        let composite: Arc<dyn AuditSink> = Arc::new(CompositeSink::new(vec![ring.clone(), global]));
+        Self { sink: composite, ring }
+    }
+
+    /// Borrow the backing ring (Hub UI Plane-1 panel reads through this).
+    pub fn ring(&self) -> Arc<RingSink> {
+        self.ring.clone()
     }
 
     pub fn record_activation(
@@ -92,13 +69,21 @@ impl PolicyAudit {
         prior_fp: Option<&str>,
         warnings: &[String],
     ) {
-        self.push(AuditEvent::PolicyActivated {
+        // Policy-activation events have no per-request correlation — use the
+        // policy fingerprint as the grouping key in the Hub UI.
+        let correlation_id = format!("policy:{new_fp}");
+        let ev = AuditEvent::at(
             ts,
-            policy_name: policy_name.into(),
-            new_fingerprint: new_fp.into(),
-            prior_fingerprint: prior_fp.map(str::to_string),
-            warnings: warnings.to_vec(),
-        });
+            Plane::Agility,
+            correlation_id,
+            EventPayload::PolicyActivated {
+                policy_name: policy_name.into(),
+                new_fingerprint: new_fp.into(),
+                prior_fingerprint: prior_fp.map(str::to_string),
+                warnings: warnings.to_vec(),
+            },
+        );
+        self.sink.emit(ev);
     }
 
     pub fn record_decision(&self, req: &PolicyRequest, decision: &Decision, policy_fp: &str) {
@@ -106,7 +91,7 @@ impl PolicyAudit {
             Decision::Allow {
                 algorithm_override,
                 substituted_by_rule,
-            } => AuditDecision::Allow {
+            } => DecisionSummary::Allow {
                 algorithm_override: algorithm_override.clone(),
                 substituted_by_rule: *substituted_by_rule,
             },
@@ -114,7 +99,7 @@ impl PolicyAudit {
                 human,
                 fired_rule_index,
                 ..
-            } => AuditDecision::Deny {
+            } => DecisionSummary::Deny {
                 reason: human.clone(),
                 fired_rule_index: *fired_rule_index,
             },
@@ -122,19 +107,22 @@ impl PolicyAudit {
                 new_algorithm,
                 original_uid,
                 ..
-            } => AuditDecision::Rekey {
+            } => DecisionSummary::Rekey {
                 new_algorithm: new_algorithm.clone(),
                 original_uid: original_uid.clone(),
             },
         };
-        self.push(AuditEvent::Decision {
-            ts: req.ts,
-            op: req.op.into(),
-            algorithm: req.algorithm.map(str::to_string),
-            correlation_id: req.correlation_id.into(),
-            policy_fingerprint: policy_fp.into(),
-            outcome,
-        });
+        self.sink.emit(AuditEvent::at(
+            req.ts,
+            Plane::Agility,
+            req.correlation_id.to_string(),
+            EventPayload::PolicyDecided {
+                op: req.op.into(),
+                algorithm: req.algorithm.map(str::to_string),
+                outcome,
+                policy_fingerprint: policy_fp.into(),
+            },
+        ));
 
         if let Decision::RekeyAndProceed {
             original_uid,
@@ -144,34 +132,24 @@ impl PolicyAudit {
             ..
         } = decision
         {
-            self.push(AuditEvent::RekeyPlanned {
-                ts: req.ts,
-                correlation_id: req.correlation_id.into(),
-                original_uid: original_uid.clone(),
-                from_algorithm: from_algorithm.clone(),
-                new_algorithm: new_algorithm.clone(),
-                triggered_by_rule: *triggered_by_rule,
-                policy_fingerprint: policy_fp.into(),
-            });
+            self.sink.emit(AuditEvent::at(
+                req.ts,
+                Plane::Agility,
+                req.correlation_id.to_string(),
+                EventPayload::RekeyPlanned {
+                    original_uid: original_uid.clone(),
+                    from_algorithm: from_algorithm.clone(),
+                    new_algorithm: new_algorithm.clone(),
+                    triggered_by_rule: *triggered_by_rule,
+                    policy_fingerprint: policy_fp.into(),
+                },
+            ));
         }
     }
 
-    /// Snapshot the current event ring. Cheap-ish — clones the deque.
+    /// Snapshot the backing ring — Plane-1 events only.
     pub fn snapshot(&self) -> Vec<AuditEvent> {
-        self.inner
-            .lock()
-            .expect("audit ring poisoned")
-            .iter()
-            .cloned()
-            .collect()
-    }
-
-    fn push(&self, ev: AuditEvent) {
-        let mut q = self.inner.lock().expect("audit ring poisoned");
-        if q.len() == self.capacity {
-            q.pop_front();
-        }
-        q.push_back(ev);
+        self.ring.snapshot()
     }
 }
 
@@ -184,7 +162,10 @@ mod tests {
     fn activation_logged() {
         let audit = PolicyAudit::new(8);
         audit.record_activation(OffsetDateTime::UNIX_EPOCH, "test", "sha256:abc", None, &[]);
-        assert_eq!(audit.snapshot().len(), 1);
+        let snap = audit.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert!(matches!(snap[0].event, EventPayload::PolicyActivated { .. }));
+        assert_eq!(snap[0].plane, Plane::Agility);
     }
 
     #[test]
@@ -209,11 +190,13 @@ mod tests {
             },
             "sha256:fp",
         );
-        // Two events: Decision + RekeyPlanned
         let snap = audit.snapshot();
         assert_eq!(snap.len(), 2);
-        assert!(matches!(snap[0], AuditEvent::Decision { .. }));
-        assert!(matches!(snap[1], AuditEvent::RekeyPlanned { .. }));
+        assert!(matches!(snap[0].event, EventPayload::PolicyDecided { .. }));
+        assert!(matches!(snap[1].event, EventPayload::RekeyPlanned { .. }));
+        // Both events share the request's correlation_id.
+        assert_eq!(snap[0].correlation_id, "corr-1");
+        assert_eq!(snap[1].correlation_id, "corr-1");
     }
 
     #[test]
@@ -229,5 +212,32 @@ mod tests {
             );
         }
         assert_eq!(audit.snapshot().len(), 2);
+    }
+
+    #[test]
+    fn with_global_sink_fans_out_to_both() {
+        let global = Arc::new(RingSink::new(8));
+        let audit = PolicyAudit::with_global_sink(8, global.clone());
+        let attrs = HashMap::new();
+        let req = PolicyRequest::minimal(
+            "Sign",
+            Some("ML-DSA-87"),
+            OffsetDateTime::UNIX_EPOCH,
+            "global-corr",
+            &attrs,
+        );
+        audit.record_decision(
+            &req,
+            &Decision::Allow {
+                algorithm_override: None,
+                substituted_by_rule: None,
+            },
+            "sha256:fp",
+        );
+        // Local ring saw it.
+        assert_eq!(audit.snapshot().len(), 1);
+        // Global ring also saw it.
+        assert_eq!(global.snapshot().len(), 1);
+        assert_eq!(global.snapshot()[0].correlation_id, "global-corr");
     }
 }

--- a/kmip/src/policy/engine.rs
+++ b/kmip/src/policy/engine.rs
@@ -83,10 +83,24 @@ impl Engine {
     /// Build a deny-all engine — the safe default when no policy file is
     /// supplied at startup. Sandbox / dev should call [`Self::permissive`]
     /// or load the `training-permissive.yaml` policy explicitly.
+    ///
+    /// Audit events land in a private 1024-slot ring. Use
+    /// [`Self::with_global_sink`] if the Plane-7 server needs to fan events
+    /// into a cross-plane sink that also captures KMIP + PKCS#11 events.
     pub fn deny_all() -> Self {
         Self {
             inner: Arc::new(RwLock::new(EngineInner { active: None })),
             audit: Arc::new(PolicyAudit::new(1024)),
+        }
+    }
+
+    /// Build a deny-all engine wired to a cross-plane audit sink. Plane-1
+    /// events ALSO land in a private 1024-slot ring for the Hub UI's
+    /// dedicated Plane-1 panel.
+    pub fn with_global_sink(sink: std::sync::Arc<dyn crate::auditlog::AuditSink>) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(EngineInner { active: None })),
+            audit: Arc::new(PolicyAudit::with_global_sink(1024, sink)),
         }
     }
 

--- a/kmip/src/policy/mod.rs
+++ b/kmip/src/policy/mod.rs
@@ -85,7 +85,7 @@ pub mod request;
 pub mod rule;
 pub mod store;
 
-pub use audit::{AuditDecision, AuditEvent, PolicyAudit};
+pub use audit::PolicyAudit;
 pub use decision::{Decision, DenyReason};
 pub use engine::{ActivePolicy, Engine};
 pub use loader::{load_from_file, load_from_str, validate, LoadedPolicy, LoaderError};

--- a/kmip/tests/audit_tri_plane.rs
+++ b/kmip/tests/audit_tri_plane.rs
@@ -1,0 +1,277 @@
+//! Tri-plane correlated audit trace — demonstrates the Hub-UI view of one
+//! request flowing through Plane 1 (agility engine) → Plane 2 (KMIP) →
+//! Plane 3 (PKCS#11). Plane 2 + Plane 3 emissions are STUBBED here; Phase 5
+//! (op handlers) and bridge instrumentation will replace the stubs with
+//! real emissions, but the wire format is committed in this test.
+//!
+//! Each plane writes to the same sink. The Hub UI reads from that sink
+//! (in production: via a Phase-7 HTTP `GET /audit/tail` endpoint; in this
+//! test: directly via `RingSink::filter_correlation_id`).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use time::OffsetDateTime;
+
+use pqctoday_kmip::auditlog::{
+    AuditEvent, AuditSink, CompositeSink, EventPayload, JsonlSink, KmipOpResult, Plane, RingSink,
+};
+use pqctoday_kmip::policy::{load_from_str, Decision, Engine, PolicyRequest};
+
+const PQC_POLICY: &str = r#"
+schema_version: 1
+metadata:
+  name: tri-plane-demo
+  description: PQC default + rekey on existing classical
+  authority: test
+  effective: "always"
+rules:
+  - type: algorithm_default
+    ops: ["CreateKeyPair:Sign"]
+    default_algorithm: ML-DSA-87
+    reason: "PQC signing default"
+  - type: algorithm_substitution
+    ops: [Sign]
+    from: ECDSA-P256
+    to: ML-DSA-87
+    reason: "Rekey classical signing key"
+"#;
+
+fn now() -> OffsetDateTime {
+    OffsetDateTime::from_unix_timestamp(1_780_000_000).unwrap()
+}
+
+/// Production wiring pattern: hold `Arc<RingSink>` for queries alongside
+/// `Arc<dyn AuditSink>` for emitter handoff — same allocation.
+fn build_sink_pair() -> (Arc<RingSink>, Arc<dyn AuditSink>) {
+    let ring = Arc::new(RingSink::new(64));
+    let as_sink: Arc<dyn AuditSink> = ring.clone();
+    (ring, as_sink)
+}
+
+// ── §1: all three planes fan into one sink, UI queries by correlation_id ────
+
+#[test]
+fn one_request_three_planes_one_correlation_id() {
+    let (ring, sink) = build_sink_pair();
+    let engine = Engine::with_global_sink(sink.clone());
+    engine
+        .activate(load_from_str(PQC_POLICY, std::path::Path::new("<test>")).unwrap())
+        .unwrap();
+
+    let correlation_id = "req-abc-123";
+    let attrs = HashMap::new();
+
+    // ── Plane 1 — agility engine ─────────────────────────────────────────
+    let mut req = PolicyRequest::minimal("Sign", Some("ECDSA-P256"), now(), correlation_id, &attrs);
+    req.current_object_algorithm = Some("ECDSA-P256");
+    req.target_uid = Some("urn:pqctoday:obj:legacy-ecdsa");
+    let decision = engine.evaluate(&req);
+    assert!(matches!(decision, Decision::RekeyAndProceed { .. }));
+
+    // ── Plane 2 — KMIP dispatcher (STUBBED — Phase 5 emits) ─────────────
+    sink.emit(AuditEvent::at(
+        now(),
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipRequestReceived {
+            op: "Sign".into(),
+            request_summary: "Sign { uid: urn:pqctoday:obj:legacy-ecdsa }".into(),
+            client_cn: Some("CN=demo-client".into()),
+        },
+    ));
+    sink.emit(AuditEvent::at(
+        now(),
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipObjectStateChanged {
+            uid: "urn:pqctoday:obj:legacy-ecdsa".into(),
+            from_state: "Active".into(),
+            to_state: "Deprecated".into(),
+            reason: "rekey to ML-DSA-87 per Plane-1 policy".into(),
+        },
+    ));
+
+    // ── Plane 3 — PKCS#11 bridge (STUBBED — Phase 5 emits) ──────────────
+    sink.emit(AuditEvent::at(
+        now(),
+        Plane::Pkcs11,
+        correlation_id,
+        EventPayload::Pkcs11Call {
+            function: "C_GenerateKeyPair".into(),
+            mechanism: Some("CKM_PQCTODAY_ML_DSA_KEY_PAIR_GEN".into()),
+            slot: Some(0),
+            session: Some(42),
+            rv: 0,
+            rv_name: "CKR_OK".into(),
+            latency_ms: 12,
+        },
+    ));
+    sink.emit(AuditEvent::at(
+        now(),
+        Plane::Pkcs11,
+        correlation_id,
+        EventPayload::Pkcs11Call {
+            function: "C_Sign".into(),
+            mechanism: Some("CKM_PQCTODAY_ML_DSA_SIGN_VERIFY".into()),
+            slot: Some(0),
+            session: Some(42),
+            rv: 0,
+            rv_name: "CKR_OK".into(),
+            latency_ms: 8,
+        },
+    ));
+
+    // ── Plane 2 — KMIP response (STUBBED) ───────────────────────────────
+    sink.emit(AuditEvent::at(
+        now(),
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipResponseSent {
+            op: "Sign".into(),
+            result: KmipOpResult::Success,
+            latency_ms: 24,
+        },
+    ));
+
+    // ── Hub UI query: give me everything for this correlation_id ────────
+    let trace = ring.filter_correlation_id(correlation_id);
+
+    // Expected: 2 P1 (Decided + RekeyPlanned) + 3 P2 (Req + StateChange + Resp)
+    //         + 2 P3 (two Pkcs11Call) = 7
+    assert_eq!(trace.len(), 7, "should have 7 correlated events");
+
+    let planes: Vec<Plane> = trace.iter().map(|e| e.plane).collect();
+    assert!(planes.contains(&Plane::Agility));
+    assert!(planes.contains(&Plane::Kmip));
+    assert!(planes.contains(&Plane::Pkcs11));
+
+    let p1: Vec<&AuditEvent> = trace.iter().filter(|e| e.plane == Plane::Agility).collect();
+    assert_eq!(p1.len(), 2);
+    assert!(matches!(p1[0].event, EventPayload::PolicyDecided { .. }));
+    assert!(matches!(p1[1].event, EventPayload::RekeyPlanned { .. }));
+}
+
+// ── §2: composite sink fans to ring + JSONL (durable forensic record) ──────
+
+#[test]
+fn composite_sink_writes_ring_plus_jsonl() {
+    let ring = Arc::new(RingSink::new(64));
+    let path = std::env::temp_dir().join(format!(
+        "pqctoday-tri-plane-{}.jsonl",
+        uuid::Uuid::new_v4()
+    ));
+    let jsonl = Arc::new(JsonlSink::open(&path).unwrap());
+    let composite: Arc<dyn AuditSink> = Arc::new(CompositeSink::new(vec![
+        ring.clone(),
+        jsonl.clone(),
+    ]));
+
+    let engine = Engine::with_global_sink(composite);
+    engine
+        .activate(load_from_str(PQC_POLICY, std::path::Path::new("<test>")).unwrap())
+        .unwrap();
+
+    let attrs = HashMap::new();
+    let req = PolicyRequest::minimal("CreateKeyPair:Sign", None, now(), "corr-2", &attrs);
+    assert!(engine.evaluate(&req).is_allow());
+
+    drop(jsonl); // release file handle
+    let ring_events = ring.snapshot();
+    assert!(ring_events.len() >= 2); // activation + decision
+    let jsonl_text = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(jsonl_text.lines().count(), ring_events.len());
+    for line in jsonl_text.lines() {
+        let _back: AuditEvent = serde_json::from_str(line).expect("each line valid JSON");
+    }
+    let _ = std::fs::remove_file(&path);
+}
+
+// ── §3: per-plane filtering for the Hub UI's per-plane panels ──────────────
+
+#[test]
+fn hub_ui_can_filter_per_plane() {
+    let (ring, sink) = build_sink_pair();
+    let engine = Engine::with_global_sink(sink.clone());
+    engine
+        .activate(load_from_str(PQC_POLICY, std::path::Path::new("<test>")).unwrap())
+        .unwrap();
+
+    let attrs = HashMap::new();
+    for i in 0..3 {
+        let corr = format!("corr-{i}");
+        let req = PolicyRequest::minimal(
+            "CreateKeyPair:Sign",
+            None,
+            now(),
+            &corr,
+            &attrs,
+        );
+        let _ = engine.evaluate(&req);
+        sink.emit(AuditEvent::at(
+            now(),
+            Plane::Pkcs11,
+            format!("corr-{i}"),
+            EventPayload::Pkcs11Call {
+                function: "C_GenerateKeyPair".into(),
+                mechanism: Some("CKM_PQCTODAY_ML_DSA_KEY_PAIR_GEN".into()),
+                slot: Some(0),
+                session: Some(1),
+                rv: 0,
+                rv_name: "CKR_OK".into(),
+                latency_ms: 10,
+            },
+        ));
+    }
+
+    // Plane-1: 1 activation + 3 decisions = 4 events.
+    assert_eq!(ring.filter_plane(Plane::Agility).len(), 4);
+    // Plane-3: 3 events.
+    assert_eq!(ring.filter_plane(Plane::Pkcs11).len(), 3);
+    // Plane-2: nothing emitted in this test.
+    assert_eq!(ring.filter_plane(Plane::Kmip).len(), 0);
+}
+
+// ── §4: events serialise to stable JSON (wire format committed) ────────────
+
+#[test]
+fn event_payloads_serialise_to_committed_wire_format() {
+    // Plane-1 PolicyDecided
+    let p1 = AuditEvent::at(
+        now(),
+        Plane::Agility,
+        "corr",
+        EventPayload::PolicyDecided {
+            op: "Sign".into(),
+            algorithm: Some("ML-DSA-87".into()),
+            outcome: pqctoday_kmip::auditlog::DecisionSummary::Allow {
+                algorithm_override: Some("ML-DSA-87".into()),
+                substituted_by_rule: Some(2),
+            },
+            policy_fingerprint: "sha256:abc".into(),
+        },
+    );
+    let json = serde_json::to_string(&p1).unwrap();
+    assert!(json.contains("\"plane\":\"p1\""));
+    assert!(json.contains("\"type\":\"PolicyDecided\""));
+    assert!(json.contains("\"type\":\"Allow\""));
+
+    // Plane-3 Pkcs11Call
+    let p3 = AuditEvent::at(
+        now(),
+        Plane::Pkcs11,
+        "corr",
+        EventPayload::Pkcs11Call {
+            function: "C_Sign".into(),
+            mechanism: Some("CKM_PQCTODAY_ML_DSA_SIGN_VERIFY".into()),
+            slot: Some(0),
+            session: Some(42),
+            rv: 0,
+            rv_name: "CKR_OK".into(),
+            latency_ms: 8,
+        },
+    );
+    let json = serde_json::to_string(&p3).unwrap();
+    assert!(json.contains("\"plane\":\"p3\""));
+    assert!(json.contains("\"type\":\"Pkcs11Call\""));
+    assert!(json.contains("\"function\":\"C_Sign\""));
+}


### PR DESCRIPTION
## Summary

Layered audit log surface so the Hub UI can passively render the correlated
trace of one request flowing through all three planes:

\`\`\`
   Plane 1 — agility engine ─emit()─┐
   Plane 2 — KMIP dispatcher ─emit()─┼─► Arc<dyn AuditSink>
   Plane 3 — PKCS#11 bridge ─emit()─┘
                                     │
                                     ▼
                            Hub UI tails / renders
\`\`\`

Each plane stamps its own \`correlation_id\` per request; the UI groups rows
by that field — **no joiner, no enrichment, no correlation logic on the UI
side.** The UI is a pure passive viewer of structured layer-emitted logs.

## What's in the diff

**\`src/auditlog/\` (new module):**
- \`event.rs\` — unified \`AuditEvent\` envelope, \`Plane\` enum, \`EventPayload\`
  variants for all three planes (committed wire format)
- \`sink.rs\` — \`AuditSink\` trait + \`NullSink\`
- \`ring.rs\` — bounded in-memory ring with \`filter_correlation_id\` /
  \`filter_plane\` queries the Hub UI wraps
- \`jsonl.rs\` — append-only JSONL file writer for durable forensic records
- \`composite.rs\` — fan-out sink (typical wiring: ring + jsonl)
- \`mod.rs\` — design docs + re-exports

**Plane 1 retrofit:**
- \`PolicyAudit\` now wraps a backing \`RingSink\` + optional global sink via
  \`CompositeSink\`. Existing \`record_*\` / \`snapshot\` API preserved.
- \`Engine::with_global_sink(sink)\` — new constructor for the Phase-7
  server to wire the tri-plane sink.
- Policy-local \`AuditEvent\`/\`AuditDecision\` enums removed; events now use
  the global type so the Hub UI sees one schema across all three planes.

**Plane 2 + Plane 3 event variants** — defined here as committed wire
format. Phase 5 (op handlers) and bridge instrumentation will fill in the
emission sites; the JSON shape is locked.

## Tests

- 102 lib tests (up from 93 — added 9 new across the auditlog module)
- 4 new integration tests in \`tests/audit_tri_plane.rs\`:
  - **one_request_three_planes_one_correlation_id** — full headline demo:
    7 correlated events across all three planes for one Sign request that
    triggers a rekey, queried back by correlation_id from the UI side
  - **composite_sink_writes_ring_plus_jsonl** — production wiring pattern
  - **hub_ui_can_filter_per_plane** — per-plane filter for dedicated panels
  - **event_payloads_serialise_to_committed_wire_format** — pins JSON shape

**131 tests total pass, 0 fail.** No regressions to Phase 4.5 or prior.

## What this unblocks

- **Hub UI work** can start now against a stable wire format. The UI can
  bind to the JSON shape committed in \`event.rs\` even before Phase 5
  emissions land.
- **Phase 5** (op handlers) wires Plane-2 + Plane-3 emissions into the
  existing sink — no schema work needed at that point.
- **Phase 7** (TLS server) instantiates the \`CompositeSink\` at startup
  and hands the \`Arc<dyn AuditSink>\` to the engine + dispatcher + bridge.

## Test plan

- [x] \`cargo test --lib --tests\` — 131 / 0
- [x] Clean build (only pre-existing softhsmrustv3 warnings)
- [ ] Phase 5 will wire real Plane-2 + Plane-3 emissions against this surface
- [ ] Phase 7 server will expose \`GET /audit/tail\` SSE endpoint wrapping
      the RingSink

🤖 Generated with [Claude Code](https://claude.com/claude-code)