### PR TITLE
feat(kmip): Phase 5 session 1 — foundation + 3 demo-critical op handlers

### DIFF
--- a/kmip/docs/IMPLEMENTATION_PLAN.md
+++ b/kmip/docs/IMPLEMENTATION_PLAN.md
@@ -600,9 +600,64 @@ at startup. Sandbox must explicitly load `training-permissive.yaml`.
 
 **Commit**: `feat/kmip-phase-4.5-policy-engine` branch; PR pending.
 
-### Phase 5 — Op handlers (Plane 2) (2.0 PD) — 🟡 **PARTIAL 2026-06-07** (3 of 12 ops + shared infra)
+### Phase 5 — Op handlers (Plane 2) (2.0 PD) — ✅ **COMPLETE 2026-06-07** (12 of 12 ops + shared infra + active-policy persistence)
 
-**Session 1 (this) — foundation + 3 demo-critical ops shipped on `feat/kmip-phase-5-op-handlers`:**
+**Session 2 (this) — remaining 9 ops + shared helpers + Plane-1 active-policy persistence shipped:**
+
+- [x] `src/ops/helpers.rs` — extracted before writing the new ops so all 12
+      handlers share one surface for emit_request / emit_pkcs11 /
+      emit_state_change / emit_success / fail_err / canonical_name /
+      state_name. Each op file stays focused on its KMIP semantics.
+- [x] `src/ops/activate.rs` — KMIP 3.0 §6.1.1 Activate (op 0x12).
+- [x] `src/ops/revoke.rs` — KMIP 3.0 §6.1.49 Revoke (op 0x13). Branches on
+      RevocationReason: KeyCompromise/CaCompromise → Compromised, else
+      → Deactivated.
+- [x] `src/ops/destroy.rs` — KMIP 3.0 §6.1.19 Destroy (op 0x14). PreActive
+      | Deactivated → Destroyed; Compromised → DestroyedCompromised;
+      Active rejected (must Revoke first per §3.4). C_DestroyObject.
+- [x] `src/ops/create.rs` — KMIP 3.0 §6.1.8 Create (op 0x01) symmetric +
+      secret data only; asymmetric rejected. C_GenerateKey.
+- [x] `src/ops/get.rs` — KMIP 3.0 §6.1.23 Get (op 0x0a). Private-key
+      material never extracted (CKA_SENSITIVE) — returns OpaqueObject
+      with empty value. C_GetAttributeValue.
+- [x] `src/ops/locate.rs` — KMIP 3.0 §6.1.32 Locate (op 0x08). Filters
+      by CryptographicAlgorithm / ObjectType / State. C_FindObjects*.
+- [x] `src/ops/signature_verify.rs` — KMIP 3.0 §6.1.61 (op 0x22). Failed
+      verify is NOT a KMIP error — returns success with validity=Invalid.
+      C_VerifyInit + C_Verify.
+- [x] `src/ops/encrypt.rs` — KMIP 3.0 §6.1.21 Encrypt (op 0x1f). Branches:
+      ML-KEM → C_EncapsulateKey (ciphertext + shared_secret); classical
+      → C_EncryptInit + C_Encrypt (ciphertext only).
+- [x] `src/ops/decrypt.rs` — KMIP 3.0 §6.1.15 Decrypt (op 0x20). Branches:
+      ML-KEM → C_DecapsulateKey (shared secret); classical →
+      C_DecryptInit + C_Decrypt (plaintext). Allowed in Active /
+      Deactivated / Compromised (need to decrypt old ciphertexts post-rotation).
+- [x] `src/policy/store.rs` — Plane-1 active-policy persistence (§12 user
+      decision 2026-06-07). New `.active` marker file in the policies/
+      directory, JSON shape `{ name, fingerprint, activated_at }`. API:
+      `read_active`, `write_active` (atomic-rename), `clear_active`,
+      `activate_with_engine` (load + activate + write marker as one),
+      `resume_active` (boot-time replay with **fingerprint-drift
+      protection** — refuses to silently re-activate a YAML edited
+      out-of-band; operator must re-activate via Hub). Mirrors how
+      softhsmv3 persists slot/token state so handles survive engine
+      restarts — same pattern, one level up the stack.
+
+**Test summary (Phase 5 cumulative):** 193 total pass (was 153 at start
+of session; +40 across the 8 ops, helpers, and active-marker persistence
++ engine + tests). 0 failed. 50 ops-module tests across all 12 handlers;
+13 store tests (4 prior + 9 new for active marker).
+
+**Phase-7 wiring remaining (deferred per §12.7.7 lock):** All Plane-3
+emissions today produce correct `Pkcs11Call` audit events (function
+name, mechanism, slot) but use deterministic SHA-256 placeholders for
+the actual cryptographic output. Phase 7 wires real
+`softhsmrustv3::C_*` calls behind the same audit emissions — the wire
+format committed in PR #72 + §12.7.5 doesn't change, only the bytes
+inside `ciphertext` / `signature` / `shared_secret` become real instead
+of placeholder.
+
+**Session 1 (prior) — foundation + 3 demo-critical ops shipped on `feat/kmip-phase-5-op-handlers`:**
 
 - [x] `src/error.rs` — `ResultReason` enum with codepoints cross-checked
       against `spec/oasis-kmip-3.0/kmip-spec-3.0-tags-enums.json` (`Result Reason`):

--- a/kmip/docs/IMPLEMENTATION_PLAN.md
+++ b/kmip/docs/IMPLEMENTATION_PLAN.md
@@ -600,7 +600,66 @@ at startup. Sandbox must explicitly load `training-permissive.yaml`.
 
 **Commit**: `feat/kmip-phase-4.5-policy-engine` branch; PR pending.
 
-### Phase 5 — Op handlers (Plane 2) (2.0 PD)
+### Phase 5 — Op handlers (Plane 2) (2.0 PD) — 🟡 **PARTIAL 2026-06-07** (3 of 12 ops + shared infra)
+
+**Session 1 (this) — foundation + 3 demo-critical ops shipped on `feat/kmip-phase-5-op-handlers`:**
+
+- [x] `src/error.rs` — `ResultReason` enum with codepoints cross-checked
+      against `spec/oasis-kmip-3.0/kmip-spec-3.0-tags-enums.json` (`Result Reason`):
+      ItemNotFound (0x01), OperationNotSupported (0x05), MissingData (0x06),
+      InvalidField (0x07), CryptographicFailure (0x0a), PermissionDenied
+      (0x0c), ObjectArchived (0x0d), ObjectAlreadyExists (0x18),
+      InvalidAttribute (0x2c), InvalidAttributeValue (0x2d). `KmipError`
+      enum with typed constructors + `From<BridgeError>`.
+- [x] `src/store/{traits,memory}.rs` — `KeyStore` trait (minimal surface
+      for ops) + `MemoryStore` in-memory impl for Phase-5 tests.
+      `ObjectRecord` carries uid + object_type + algorithm + usage_mask +
+      state + pkcs11_cka_id + pkcs11_slot + timestamps + supersedes link.
+      Phase 6 replaces `MemoryStore` with SQLite-backed durable store.
+- [x] `src/ops/deps.rs` — `Deps` shared bundle: `engine`, `store`, `sink`,
+      `config` (slot, pin, vendor identification, server version).
+- [x] `src/ops/query.rs` — **KMIP 3.0 §6.1.45 Query** (op `0x18`).
+      Returns supported operations / object types / server information.
+      Phase-3 capability list (12 ops). PKCS#11 v3.2 §C.5.3 `C_GetInfo`
+      not yet called — v0.1 uses static config.
+- [x] `src/ops/create_key_pair.rs` — **KMIP 3.0 §6.1.11 Create Key Pair**
+      (op `0x02`). Extracts `CryptographicAlgorithm` / `CryptographicLength`
+      / `CryptographicUsageMask` from template attributes. Plane-1 engine
+      gate; honours `algorithm_default` / `algorithm_substitution`. Maps
+      `(KmipAlgorithm, PkcsOp::KeyGen) → CKM_*` via Phase-3 enum. Audit
+      emits `KmipRequestReceived` → `Pkcs11Call(C_GenerateKeyPair)` →
+      `KmipResponseSent`. Persists `PreActive` records for both public +
+      private keys. PKCS#11 v3.2 §C.7.1 entry-point signature verified
+      against `rust/src/ffi.rs::C_GenerateKeyPair`.
+- [x] `src/ops/sign.rs` — **KMIP 3.0 §6.1.60 Sign** (op `0x21`). Store
+      lookup → lifecycle gate (only `Active` per §3.4) → Plane-1 engine.
+      Surfaces `Decision::RekeyAndProceed` as `PermissionDenied` with an
+      actionable hint (`"rekey required: policy substitutes X → Y for
+      UID Z"`); the actual multi-op rekey transaction belongs to Phase 6
+      / dispatcher work. PKCS#11 v3.2 §C.6.5 `C_SignInit` + §C.6.6
+      `C_Sign` signatures verified against `rust/src/ffi.rs`.
+
+**Test summary (this session):** 150 total pass (121 lib + 29 integration;
+0 failed). Added 16 ops tests + 4 store tests + 9 error tests = 29 new.
+
+**Session 2+ — remaining 9 ops:** Activate, Create (sym), Decrypt, Destroy,
+Encrypt (branches classical / ML-KEM encapsulate), Get, Locate, Revoke,
+SignatureVerify. Same template — each ≤ ~250 LOC with KMIP 3.0 + PKCS#11
+v3.2 spec citations in the file header.
+
+**Known limitations carried to Phase 6:**
+
+- `canonical_name(KmipAlgorithm)` returns bare names (`"ECDSA"`, `"RSA"`,
+  `"AES"`) — no curve/size suffix. The Phase-5 store doesn't yet carry
+  the `Cryptographic Parameters` attribute that would let the dispatcher
+  produce `"ECDSA-P256"` / `"AES-256"`. Phase 6 closes this so policies
+  can target sized algorithms.
+- Bridge calls into `softhsmrustv3::C_*` are placeholder-audited but not
+  actually executed (v0.1 produces deterministic SHA-256 signatures and
+  UUID-derived CKA_IDs). Phase 7 (TLS server) wires the real session +
+  bridge calls behind the audit emissions.
+
+### Phase 5 — Op handlers (Plane 2) — original plan (2.0 PD)
 
 11 ops, one module each, ≤ 100 LOC including tests. Note KMIP 3.0 reuses `Encrypt` for ML-KEM encapsulation and `Decrypt` for decapsulation — the handler branches on key algorithm:
 

--- a/kmip/docs/IMPLEMENTATION_PLAN.md
+++ b/kmip/docs/IMPLEMENTATION_PLAN.md
@@ -851,7 +851,129 @@ Phase 1 (the entire subsystem, standalone) is NOT complete until ALL of these ar
 | 100-LOC-per-op-handler gate forces helper proliferation | Hard CI gate; prefer extracting helpers into `src/ops/_common.rs` over relaxing the gate |
 | Policy YAML schema drift over time | `policies/SCHEMA.md` documents the v0.1 schema; loader validates against it; bump schema version + provide migration |
 
-## 12. Status log
+## 12. Phase 10 — Dev sandbox integration (scoped 2026-06-07)
+
+### 12.1 What the existing dev sandbox is (findings)
+
+`pqctoday-sandbox` is **already a Docker dev workbench** where users run and modify crypto code in five languages against `libsofthsmv3.so`. Inventory verified by reading the actual code:
+
+| Component | Path | What it does |
+|---|---|---|
+| **Multi-language samples** | [`samples/{py,c,cpp,rust,java}/`](../../pqctoday-sandbox/samples/) | 13 Python + 12 C + Rust + C++ + Java sample programs, each exercising one PKCS#11 v3.2 primitive (ML-DSA / ML-KEM / SLH-DSA / classical). Coverage matrix in [`samples/SAMPLES.md`](../../pqctoday-sandbox/samples/SAMPLES.md). |
+| **HTTP API** | [`api/server.py`](../../pqctoday-sandbox/api/server.py), [`api/kms_router.py`](../../pqctoday-sandbox/api/kms_router.py) | Flask app exposing `/api/run/*` scenario endpoints + a PKCS#11-fronted REST surface. |
+| **WebSocket terminal** | [`pyterm.py`](../../pqctoday-sandbox/pyterm.py) | ttyd-protocol-compatible PTY/tmux WebSocket server; users get an interactive shell inside the container via xterm.js. |
+| **PKCS#11 spy log parser** | [`api/spy_parser.py`](../../pqctoday-sandbox/api/spy_parser.py) | Parses live `C_*` call traces into the Hub UI's telemetry stream. |
+| **Hub embedding** | [`SandboxScenarioEmbed.tsx`](../../pqctoday-hub/src/components/Playground/SandboxScenarioEmbed.tsx) | Iframes the sandbox container (localhost:4000 or orchestrator-issued session); postMessage for theme/userId/scenarioId. |
+
+**Plane coverage today vs needed:**
+
+| Plane | Dev sandbox today | Phase 10 adds |
+|---|---|---|
+| **P3 — PKCS#11 HSM** (softhsmv3) | ✅ full — 5-language samples + spy logs visible | (unchanged) |
+| **P2 — KMIP 3.0** | ❌ no KMIP server in the container | ✅ ship Rust `pqctoday-kmip` binary alongside softhsmv3 |
+| **P1 — Crypto agility engine** | ❌ no policy layer | ✅ engine + dropdown-editable YAML policies, audit ring exposed via API |
+
+**The pivot is therefore not "build a dev sandbox" — it's "extend the existing dev sandbox with the P1/P2 layers Phases 0–9 have been building."**
+
+### 12.2 Deliverables (MVP, Python first)
+
+| # | Deliverable | Path | Effort |
+|---|---|---|---|
+| 12.2.1 | Finish remaining 9 Rust ops (Phase 5b) + wire real softhsmrustv3 calls (short Phase 7) so the binary actually runs end-to-end | `pqctoday-hsm/kmip/src/ops/`, `src/pkcs11bridge/`, `src/server/` | 2.5 PD |
+| 12.2.2 | Ship the Rust binary inside the sandbox Docker image | `pqctoday-sandbox/docker/Dockerfile.network`, `entrypoint.sh` | 0.25 PD |
+| 12.2.3 | Add 10 `/api/kmip/*` proxy endpoints to the Flask API (§12.3) | `pqctoday-sandbox/api/server.py` | 0.5 PD |
+| 12.2.4 | `kmip_client.py` Python helper (thin TTLV codec) + 4 sample programs (§12.4) | `pqctoday-sandbox/samples/py/kmip/` | 0.5 PD |
+| 12.2.5 | Hub-side `AgilityScenarioPanel.tsx` — policy dropdown + Monaco YAML editor + tri-plane log viewer | `pqctoday-hub/src/components/Playground/` | 1.0 PD |
+| 12.2.6 | End-to-end demo recording + lab-guide doc | `docs/labs/agility-scenario.md` | 0.25 PD |
+| **MVP total** | | | **~5.0 PD** |
+
+**Cross-language sample extension** (C / C++ / Rust / Java) parked at ~0.5 PD per language — pick up after the Python MVP demos cleanly.
+
+### 12.3 New API endpoints in `api/server.py`
+
+All under `/api/kmip/` prefix; thin proxy in front of the Rust binary's `PolicyStore` + audit surface.
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/kmip/health` | KMIP server up? policy loaded? sink size? |
+| GET | `/api/kmip/policy/list` | Names of YAML files in `policies/` dir (Hub dropdown source) |
+| GET | `/api/kmip/policy/active` | `{ name, fingerprint, loaded_at }` |
+| GET | `/api/kmip/policy/yaml?name=X` | Raw YAML body for editor display |
+| PUT | `/api/kmip/policy/yaml?name=X` | Save edited YAML (`PolicyStore::save` — validate-then-atomic-rename) |
+| POST | `/api/kmip/policy/activate` | Body `{ name }` → `Engine::activate` (atomic swap) |
+| POST | `/api/kmip/policy/dry_run` | Body `{ yaml, sample_request }` → `Decision` JSON (editor "test" button) |
+| GET | `/api/kmip/audit/tail` (SSE) | Stream of tri-plane `AuditEvent`s — one JSON per SSE event |
+| GET | `/api/kmip/audit?correlation_id=X` | Full historical trace for one request |
+| POST | `/api/kmip/audit/clear` | Reset in-memory ring for clean demo runs |
+
+### 12.4 Sample subset (`samples/py/kmip/`)
+
+Parallel to existing `samples/py/` PKCS#11-direct samples. Each ≤ 60 LOC + a shared `kmip_client.py` helper.
+
+| # | File | Demonstrates | KMIP ops exercised |
+|---|---|---|---|
+| 1 | `kmip-01-create-keypair-sign.py` | Generate sig keypair via KMIP, sign a message, verify | CreateKeyPair, Sign, SignatureVerify |
+| 2 | `kmip-02-create-keypair-kem.py` | Generate KEM keypair, encapsulate, decapsulate | CreateKeyPair, Encrypt (encap), Decrypt (decap) |
+| 3 | `kmip-03-create-key-encrypt.py` | Generate AES key, encrypt + decrypt a blob | Create, Encrypt, Decrypt |
+| 4 | `kmip-04-rekey-on-policy-flip.py` | Create classical key → flip policy → next Sign auto-rekeys to PQC | CreateKeyPair, Sign (twice, with policy edit between) |
+
+Sample #4 is the headline demo: user runs script, flips policy dropdown in Hub, runs script again, observes engine emitting `RekeyAndProceed` and the second Sign producing an ML-DSA signature under the same Python code.
+
+### 12.5 Hub-side panel (`AgilityScenarioPanel.tsx`)
+
+New component **in the same tab as** the existing `SandboxScenarioEmbed`
+(per locked decision §12.7.6). The two panels share one viewport — the
+existing iframe + terminal occupy the upper / left region, the agility
+panel occupies the lower / right region; exact split is responsive.
+Layout of the agility panel itself:
+
+```text
+┌────────────────────────────────────────────────────────────────────┐
+│  Policy: [classical ▼]  [Edit YAML]  [Activate]   • active:pqc     │
+├────────────────────────────────┬───────────────────────────────────┤
+│   ╔══════════════════════════╗ │  Plane 1 — Agility engine          │
+│   ║  Monaco YAML editor      ║ ├───────────────────────────────────┤
+│   ║  (GET /api/kmip/yaml)    ║ │  Plane 2 — KMIP dispatcher         │
+│   ╚══════════════════════════╝ ├───────────────────────────────────┤
+│                                │  Plane 3 — PKCS#11 HSM             │
+└────────────────────────────────┴───────────────────────────────────┘
+```
+
+Behavioural pieces (each ≤ ~150 LOC):
+- **Policy dropdown** — `useEffect` on mount → `GET /api/kmip/policy/list`; on change → `POST /api/kmip/policy/activate`
+- **YAML editor** — Monaco wired to `GET/PUT /api/kmip/policy/yaml?name=X`; Activate button → `POST /activate`
+- **Tri-plane log panes** — three stacked panels; each `EventSource('/api/kmip/audit/tail')` filtered by `plane: "p1"|"p2"|"p3"`; rows render with timestamp + summary + click-to-expand JSON
+- **Correlation highlight** — clicking any row dims everything except matching `correlation_id` across all three panes (the "see one request flow through all three layers" moment)
+
+### 12.6 Sandbox container changes
+
+`Dockerfile.network` additions:
+
+1. Multi-stage build the Rust KMIP binary (`cargo build --release --bin pqctoday-kmip`).
+2. Copy binary + `policies/*.yaml` into the runtime image.
+3. Start KMIP server in `entrypoint.sh` alongside softhsmv3 init — listens on `127.0.0.1:5696` (standard KMIP port), reads policies from `/etc/pqctoday/policies/` (host-mounted volume), writes audit JSONL to `/var/log/pqctoday/audit.jsonl` via `CompositeSink(RingSink, JsonlSink)`.
+
+### 12.7 Locked decisions
+
+| # | Decision | Choice | Reason |
+|---|---|---|---|
+| 12.7.1 | KMIP wire transport for samples | Raw TTLV over local TCP via a thin `kmip_client.py` helper | No third-party dep; honest about being a KMIP client; portable to a real KMS later. |
+| 12.7.2 | Server bind | TCP `localhost:5696` (KMIP IANA port) | Standard; samples port to a real KMS unchanged. |
+| 12.7.3 | Container topology | Single container — KMIP server + softhsmv3 + Flask API + ttyd in the same image | Simpler MVP; sidecar split later if needed. |
+| 12.7.4 | Policy YAML location | Host-mounted volume at `/etc/pqctoday/policies/` | Users edit + persist without rebuild. |
+| 12.7.5 | Audit storage | `CompositeSink(RingSink(16_384), JsonlSink("/var/log/pqctoday/audit.jsonl"))` | Hub UI tails the ring; JSONL accumulates durable forensics. Both supported by PR #72. |
+| 12.7.6 | Hub UX | **Single-tab split panel** — the existing `SandboxScenarioEmbed` (iframe + terminal) shares one tab with the new `AgilityScenarioPanel` (policy editor + tri-plane log viewer). The two panels sit side-by-side (or stacked vertically depending on viewport). | User decision 2026-06-07: agility view is part of the same scenario, not a parallel one. One tab, one mental model. |
+| 12.7.7 | Real softhsmrustv3 wiring | Required before MVP ships — placeholder Plane-3 events lie to the user | Forces completion of Phase 5b + a short Phase 7 binding the bridge. |
+
+### 12.8 Sequencing constraint
+
+§12.2.1 blocks §12.2.4 (samples need real ops). Everything else can parallelise. Three PRs:
+
+1. **PR A** (this repo) — Phase 5b + short Phase 7 (the binary actually runs).
+2. **PR B** (`pqctoday-sandbox`) — Dockerfile + API endpoints + Python samples.
+3. **PR C** (`pqctoday-hub`) — `AgilityScenarioPanel.tsx`.
+
+## 13. Status log
 
 | Date | Note |
 |---|---|
@@ -863,3 +985,4 @@ Phase 1 (the entire subsystem, standalone) is NOT complete until ALL of these ar
 | 2026-06-07 | **Phase 3 (KMIP 3.0 extension layer) ✅ complete on branch `feat/kmip-phase-3-extension`.** 1,108 LOC across `src/kmip30/{mod,algos,attrs,ops}.rs`. **algos.rs** (432 LOC): `KmipAlgorithm` enum with 25 variants (7 classical AES/RSA/ECDSA/HMAC + 18 FIPS PQC ML-KEM/ML-DSA/SLH-DSA-{SHA2,SHAKE} per the FIPS-only workflow decision); `to_wire_value`/`from_wire_value` map to OASIS-extracted §10.2.6 codepoints (ML-KEM-768=`0x3a`, ML-DSA-65=`0x3d`, etc.); `to_pkcs11_mech(self, PkcsOp)` returns the right vendor or standard mech based on the `(algorithm, op)` pair; `manifest_consistency_test` pins the six `0x4032`–`0x4037` vendor codepoints to `pkcs11-mech-manifest.json` `active.*` block (so any drift between the consumer table and the authoritative manifest is caught at test time). **attrs.rs** (301 LOC): `Attribute` enum (8 variants for v0.1), `UsageMask` bitflags (21 KMIP 3.0 §4 flags), `ObjectType` (5 variants), `State` lifecycle enum with `can_transition_to(next)` FSM enforcement, `RevocationReason` for the Revoke op. **ops.rs** (340 LOC): `Operation` enum + 12 request/response struct pairs covering the v0.1 op set (Query, Create, CreateKeyPair, Get, Locate, Activate, Revoke, Destroy, Encrypt, Decrypt, Sign, SignatureVerify). `EncryptRequest`/`EncryptResponse` carry `shared_secret: Option<Vec<u8>>` so ML-KEM encapsulation reuses the same struct (KMIP 3.0 design — no separate Encapsulate/Decapsulate ops; handler branches on key algorithm). Test summary: 50 lib tests pass (30 from Phase 2 + 20 new) — includes wire round-trips for every algorithm variant, FIPS-PQC classifier, ML-KEM encap/decap mech equality, ML-DSA rejecting Encrypt + ML-KEM rejecting Sign, lifecycle FSM transition table, OASIS Operation codepoint sanity checks. KAT replay still green. `bitflags = "2"` added as a regular dep. Phase 4 (trivial PKCS#11 bridge — `use softhsmrustv3` + session wrappers) can begin against this typed surface. |
 
 | 2026-06-07 | **Phase 4 (PKCS#11 bridge) ✅ complete on branch `feat/kmip-phase-4-pkcs11bridge`.** 435 LOC across `src/pkcs11bridge/{mod,error,mechs,session}.rs`. Plan called it "trivial — no FFI"; in practice softhsmrustv3 exposes the raw PKCS#11 v3.2 C ABI (`u32` handles, `*mut u8` buffers, `CK_RV` return codes — no `unsafe fn` annotations because the engine self-validates pointers). Phase 4 puts a safe Rust face on the session lifecycle. **error.rs** (152 LOC): `BridgeError` enum mapping named `CKR_*` classes Phase 5 cares about (GeneralError, MechanismInvalid, ObjectHandleInvalid, TemplateError, SignatureInvalid, BufferTooSmall, SessionInvalid range `0x00B0..=0x00BC`, ArgumentsBad, HostMemory, FunctionFailed, MechanismParamInvalid, UnclassifiedCkr catch-all). **session.rs** (199 LOC): `Session` struct with RAII Drop calling `C_CloseSession`. `open(slot, pin)` initialises the engine on first call (`Once`-guarded `C_Initialize` to avoid `CKR_CRYPTOKI_ALREADY_INITIALIZED`), opens an R/W user session, logs in as `CKU_USER`. `Session: !Send` deliberately via `*const ()` PhantomData — the engine has thread-local state. Op-method bodies (sign/encapsulate/etc.) intentionally NOT in this phase — Phase 5 wires them up alongside their handlers. **mechs.rs** (55 LOC): re-exports the FIPS-only mech constants from `crate::kmip30::algos` so the bridge has one mech table for the whole subsystem; second drift detector against the manifest. **Smoke test**: `initialize_engine_round_trip` calls `softhsmrustv3::C_Initialize(null_mut)` and accepts `CKR_OK` or `CKR_CRYPTOKI_ALREADY_INITIALIZED`. The plan's broader smoke test (open session, ML-KEM-768 keygen, encap/decap, destroy) requires a fully-initialised softhsmv3 token; end-to-end smoke belongs in Phase 7 when the TLS server can drive the whole stack. Test summary: 58 lib tests pass (50 prior + 8 new) — error mapping per CKR class, raw round-trip through classify, Session is !Send, engine initialise round-trip, flag constants match PKCS#11 v3.2 §11.6, vendor codepoints match the manifest. KAT replay still green. Phase 4.5 (Plane 1 policy engine) can begin against this bridge. |
+| 2026-06-07 | **Phase 10 (Dev sandbox integration) scoped — see §12.** Initially confused this with "build a dev sandbox from scratch"; corrected after reading the actual `pqctoday-sandbox` code. **Finding:** the dev sandbox is already a substantial multi-language Docker workbench (5-language samples + ttyd PTY shell + Flask API + Hub iframe embed) — what's missing is only the Plane 1 (agility engine) + Plane 2 (KMIP) layers Phases 0–9 have been building. Phase 10 wires those in: ship the Rust `pqctoday-kmip` binary inside the sandbox container, add 10 `/api/kmip/*` proxy endpoints, ship 4 Python samples + a tiny `kmip_client.py` TTLV helper, and add a Hub-side `AgilityScenarioPanel.tsx`. **MVP effort: ~5.0 PD across three PRs** (Phase 5b+short Phase 7 in this repo; container + API + samples in `pqctoday-sandbox`; agility panel in `pqctoday-hub`). **Locked decisions:** (13.7.1) raw TTLV over local TCP, no pykmip dep; (13.7.2) bind on standard KMIP IANA port 5696; (13.7.3) single container; (13.7.4) policies host-mounted; (13.7.5) `CompositeSink(RingSink, JsonlSink)`; (13.7.6) **single-tab split panel** alongside the existing `SandboxScenarioEmbed` (user override of my recommendation — agility is part of the same scenario, not a parallel one); (13.7.7) real softhsmrustv3 wiring required before MVP ships (no placeholder Plane-3 events in production). Cross-language sample extension (C / C++ / Rust / Java) parked at ~0.5 PD per language after the Python MVP demos cleanly. |

--- a/kmip/src/error.rs
+++ b/kmip/src/error.rs
@@ -1,14 +1,134 @@
-//! KMIP error type; maps to KMIP `ResultReason` enumeration on the wire.
+//! KMIP error type — maps to KMIP 3.0 `Result Reason` enumeration on the wire.
 //!
-//! Phase 0 (bootstrap): minimal stub. Full variant set per
-//! `docs/IMPLEMENTATION_PLAN.md` §6 Phase 3 (KMIP ResultReason codes).
+//! Codepoints verified against
+//! `spec/oasis-kmip-3.0/kmip-spec-3.0-tags-enums.json` (`Result Reason` enum)
+//! which itself was extracted from the OASIS KMIP 3.0 HTML spec
+//! (sha256-pinned). KMIP 3.0 §9.2.x defines the enumeration.
 
 use thiserror::Error;
 
+/// KMIP 3.0 `Result Reason` codepoint subset used by Phase 5 op handlers.
+/// The wire encoding is `Enumeration` (item type `0x05`) with the `u32`
+/// value below.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ResultReason {
+    ItemNotFound          = 0x0000_0001,
+    OperationNotSupported = 0x0000_0005,
+    MissingData           = 0x0000_0006,
+    InvalidField          = 0x0000_0007,
+    CryptographicFailure  = 0x0000_000a,
+    PermissionDenied      = 0x0000_000c,
+    ObjectArchived        = 0x0000_000d,
+    ObjectAlreadyExists   = 0x0000_0018,
+    InvalidAttribute      = 0x0000_002c,
+    InvalidAttributeValue = 0x0000_002d,
+    GeneralFailure        = 0x0000_0100,
+}
+
+impl ResultReason {
+    pub const fn to_wire_value(self) -> u32 {
+        self as u32
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum KmipError {
+    #[error("KMIP {reason:?} (0x{code:08x}): {msg}")]
+    Failed {
+        reason: ResultReason,
+        code: u32,
+        msg: String,
+    },
+
     #[error("not yet implemented: {0}")]
     NotImplemented(&'static str),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+
+    #[error("PKCS#11 bridge: {0}")]
+    Bridge(#[from] crate::pkcs11bridge::BridgeError),
+}
+
+impl KmipError {
+    pub fn failed(reason: ResultReason, msg: impl Into<String>) -> Self {
+        let code = reason.to_wire_value();
+        Self::Failed {
+            reason,
+            code,
+            msg: msg.into(),
+        }
+    }
+
+    pub fn permission_denied(msg: impl Into<String>) -> Self {
+        Self::failed(ResultReason::PermissionDenied, msg)
+    }
+    pub fn not_found(uid: &str) -> Self {
+        Self::failed(ResultReason::ItemNotFound, format!("UID {uid:?} not found"))
+    }
+    pub fn invalid_field(msg: impl Into<String>) -> Self {
+        Self::failed(ResultReason::InvalidField, msg)
+    }
+    pub fn invalid_attribute(msg: impl Into<String>) -> Self {
+        Self::failed(ResultReason::InvalidAttribute, msg)
+    }
+    pub fn invalid_attribute_value(msg: impl Into<String>) -> Self {
+        Self::failed(ResultReason::InvalidAttributeValue, msg)
+    }
+    pub fn missing_data(msg: impl Into<String>) -> Self {
+        Self::failed(ResultReason::MissingData, msg)
+    }
+    pub fn object_archived(uid: &str) -> Self {
+        Self::failed(
+            ResultReason::ObjectArchived,
+            format!("UID {uid:?} not in usable lifecycle state"),
+        )
+    }
+    pub fn cryptographic_failure(msg: impl Into<String>) -> Self {
+        Self::failed(ResultReason::CryptographicFailure, msg)
+    }
+    pub fn internal(msg: impl Into<String>) -> Self {
+        Self::Internal(msg.into())
+    }
+
+    /// `ResultReason` for response builders; `None`-equivalent reasons
+    /// (`NotImplemented`, `Internal`, `Bridge`) surface as `GeneralFailure`.
+    pub fn result_reason(&self) -> ResultReason {
+        match self {
+            Self::Failed { reason, .. } => *reason,
+            Self::Bridge(_) | Self::Internal(_) | Self::NotImplemented(_) => {
+                ResultReason::GeneralFailure
+            }
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, KmipError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn result_reason_codepoints_match_oasis_spec() {
+        // Cross-check against kmip-spec-3.0-tags-enums.json (`Result Reason`).
+        assert_eq!(ResultReason::ItemNotFound.to_wire_value(),          0x0000_0001);
+        assert_eq!(ResultReason::OperationNotSupported.to_wire_value(), 0x0000_0005);
+        assert_eq!(ResultReason::MissingData.to_wire_value(),           0x0000_0006);
+        assert_eq!(ResultReason::InvalidField.to_wire_value(),          0x0000_0007);
+        assert_eq!(ResultReason::CryptographicFailure.to_wire_value(),  0x0000_000a);
+        assert_eq!(ResultReason::PermissionDenied.to_wire_value(),      0x0000_000c);
+        assert_eq!(ResultReason::ObjectArchived.to_wire_value(),        0x0000_000d);
+        assert_eq!(ResultReason::ObjectAlreadyExists.to_wire_value(),   0x0000_0018);
+        assert_eq!(ResultReason::InvalidAttribute.to_wire_value(),      0x0000_002c);
+        assert_eq!(ResultReason::InvalidAttributeValue.to_wire_value(), 0x0000_002d);
+    }
+
+    #[test]
+    fn helpers_carry_correct_reason() {
+        assert_eq!(KmipError::not_found("u1").result_reason(), ResultReason::ItemNotFound);
+        assert_eq!(KmipError::permission_denied("x").result_reason(), ResultReason::PermissionDenied);
+        assert_eq!(KmipError::object_archived("u1").result_reason(), ResultReason::ObjectArchived);
+    }
+}

--- a/kmip/src/ops/activate.rs
+++ b/kmip/src/ops/activate.rs
@@ -1,0 +1,172 @@
+//! KMIP 3.0 §6.1.1 **Activate** operation.
+//!
+//! > "This operation requests the server to activate a Managed
+//! > Cryptographic Object."
+//!
+//! Op codepoint `0x12` (verified — `Activate = 0x00000012` in
+//! `kmip-spec-3.0-tags-enums.json`).
+//!
+//! ## Plane mapping
+//!
+//! - **Plane 1** — engine.evaluate with op=`"Activate"`. Policies typically
+//!   do not gate Activate (no algorithm choice is being made), but the
+//!   rule surface is available if needed.
+//! - **Plane 2** — lifecycle FSM transition `PreActive → Active`
+//!   (`docs/IMPLEMENTATION_PLAN.md` §3.4). Any other source state is
+//!   rejected with `PermissionDenied`.
+//! - **Plane 3** — none. Activation is a KMIP-only concept; PKCS#11
+//!   has no equivalent op.
+
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+use crate::error::{KmipError, Result};
+use crate::kmip30::{ActivateRequest, ActivateResponse, State};
+use crate::policy::{Decision, PolicyRequest};
+
+use super::deps::Deps;
+use super::helpers::{
+    canonical_name, emit_request, emit_state_change, emit_success, fail_err, state_name,
+};
+
+pub fn activate(deps: &Deps, req: ActivateRequest, correlation_id: &str) -> Result<ActivateResponse> {
+    let started = OffsetDateTime::now_utc();
+    emit_request(deps, correlation_id, "Activate", format!("uid={}", req.uid));
+
+    let mut obj = deps
+        .store
+        .get(&req.uid)?
+        .ok_or_else(|| fail_err(deps, correlation_id, "Activate", KmipError::not_found(&req.uid)))?;
+
+    // KMIP 3.0 §3.x — Activate is only valid from PreActive.
+    if obj.state != State::PreActive {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "Activate",
+            KmipError::permission_denied(format!(
+                "Activate requires PreActive; UID {} is in {:?}",
+                req.uid, obj.state
+            )),
+        ));
+    }
+
+    // Plane-1 policy gate.
+    let empty: HashMap<String, String> = HashMap::new();
+    let algo = canonical_name(obj.algorithm);
+    let mut p_req = PolicyRequest::minimal(
+        "Activate",
+        Some(&algo),
+        started,
+        correlation_id,
+        &empty,
+    );
+    p_req.state = Some(state_name(obj.state));
+    p_req.target_uid = Some(&req.uid);
+    if let Decision::Deny { human, .. } = deps.engine.evaluate(&p_req) {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "Activate",
+            KmipError::permission_denied(human),
+        ));
+    }
+
+    // Lifecycle transition.
+    obj.state = State::Active;
+    obj.activation_date = Some(OffsetDateTime::now_utc());
+    deps.store.update(obj.clone())?;
+    emit_state_change(
+        deps,
+        correlation_id,
+        &req.uid,
+        "PreActive",
+        "Active",
+        "KMIP Activate op",
+    );
+    emit_success(deps, correlation_id, "Activate");
+
+    Ok(ActivateResponse {
+        uid: req.uid,
+        state: State::Active,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::{AuditSink, Plane, RingSink};
+    use crate::kmip30::{KmipAlgorithm, ObjectType, UsageMask};
+    use crate::policy::{load_from_str, Engine};
+    use crate::store::{MemoryStore, ObjectRecord};
+    use std::sync::Arc;
+
+    fn deps_with(yaml: &str) -> (Arc<RingSink>, Deps) {
+        let ring = Arc::new(RingSink::new(64));
+        let sink: Arc<dyn AuditSink> = ring.clone();
+        let engine = Engine::with_global_sink(sink.clone());
+        engine.activate(load_from_str(yaml, std::path::Path::new("<t>")).unwrap()).unwrap();
+        (
+            ring,
+            Deps::new(engine, Arc::new(MemoryStore::new()), sink, super::super::deps::DepsConfig::default()),
+        )
+    }
+
+    fn pre_active(deps: &Deps, uid: &str) {
+        deps.store.put(ObjectRecord {
+            uid: uid.into(),
+            object_type: ObjectType::PrivateKey,
+            algorithm: KmipAlgorithm::MlDsa87,
+            cryptographic_length: 0,
+            usage_mask: UsageMask::SIGN | UsageMask::VERIFY,
+            state: State::PreActive,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: None,
+            supersedes: None,
+        }).unwrap();
+    }
+
+    const ALLOW_ALL: &str = "schema_version: 1\nmetadata: {name: t, description: t, authority: t, effective: always}\nrules: []\n";
+
+    #[test]
+    fn activates_pre_active_to_active() {
+        let (ring, d) = deps_with(ALLOW_ALL);
+        pre_active(&d, "urn:u");
+        let resp = activate(&d, ActivateRequest { uid: "urn:u".into() }, "c").unwrap();
+        assert_eq!(resp.state, State::Active);
+        assert_eq!(d.store.get("urn:u").unwrap().unwrap().state, State::Active);
+        // Audit: 1 ObjectStateChanged event recorded.
+        let p2 = ring.filter_plane(Plane::Kmip);
+        assert!(p2.iter().any(|e| matches!(e.event, crate::auditlog::EventPayload::KmipObjectStateChanged { .. })));
+    }
+
+    #[test]
+    fn rejects_non_pre_active() {
+        let (_ring, d) = deps_with(ALLOW_ALL);
+        // Insert an already-Active record.
+        d.store.put(ObjectRecord {
+            uid: "urn:a".into(),
+            object_type: ObjectType::PrivateKey,
+            algorithm: KmipAlgorithm::MlDsa87,
+            cryptographic_length: 0,
+            usage_mask: UsageMask::SIGN,
+            state: State::Active,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: Some(OffsetDateTime::UNIX_EPOCH),
+            supersedes: None,
+        }).unwrap();
+        let err = activate(&d, ActivateRequest { uid: "urn:a".into() }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), crate::error::ResultReason::PermissionDenied);
+    }
+
+    #[test]
+    fn missing_uid_returns_item_not_found() {
+        let (_ring, d) = deps_with(ALLOW_ALL);
+        let err = activate(&d, ActivateRequest { uid: "ghost".into() }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), crate::error::ResultReason::ItemNotFound);
+    }
+}

--- a/kmip/src/ops/create.rs
+++ b/kmip/src/ops/create.rs
@@ -1,0 +1,253 @@
+//! KMIP 3.0 §6.1.8 **Create** operation (symmetric keys only).
+//!
+//! > "This operation requests the server to generate a new symmetric key
+//! > or generate Secret Data as a Managed Cryptographic Object."
+//!
+//! Op codepoint `0x01` (verified — `Create = 0x00000001`).
+//!
+//! Asymmetric key generation goes through KMIP `Create Key Pair`
+//! (KMIP 3.0 §6.1.11) — see [`super::create_key_pair`].
+//!
+//! ## Plane mapping
+//!
+//! - **Plane 1** — engine.evaluate with op=`"Create"` so `algorithm_default`
+//!   rules can supply `AES-256` when the application omits the algorithm.
+//! - **Plane 2** — allocate a fresh KMIP UID, persist a `PreActive`
+//!   symmetric key record.
+//! - **Plane 3** — calls `C_GenerateKey` (PKCS#11 v3.2 §C.7.1).
+//!   Signature verified at `rust/src/ffi.rs::C_GenerateKey`.
+
+use std::collections::HashMap;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::error::{KmipError, Result, ResultReason};
+use crate::kmip30::{
+    Attribute, CreateRequest, CreateResponse, KmipAlgorithm, ObjectType, PkcsOp, State, UsageMask,
+};
+use crate::policy::{Decision, PolicyRequest};
+use crate::store::ObjectRecord;
+
+use super::deps::Deps;
+use super::helpers::{emit_pkcs11, emit_request, emit_success, fail_err};
+
+pub fn create(deps: &Deps, req: CreateRequest, correlation_id: &str) -> Result<CreateResponse> {
+    let started = OffsetDateTime::now_utc();
+    emit_request(
+        deps,
+        correlation_id,
+        "Create",
+        format!(
+            "object_type={:?} attrs={}",
+            req.object_type,
+            req.template_attribute.len()
+        ),
+    );
+
+    // KMIP 3.0 §6.1.8 — Create is for symmetric keys + secret data.
+    // Asymmetric requests must use CreateKeyPair.
+    if req.object_type != ObjectType::SymmetricKey && req.object_type != ObjectType::SecretData {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "Create",
+            KmipError::invalid_attribute_value(format!(
+                "Create supports SymmetricKey | SecretData only; got {:?}",
+                req.object_type
+            )),
+        ));
+    }
+
+    let (algorithm_in, key_length, usage_mask) = extract_template(&req.template_attribute);
+
+    // Plane-1 policy gate.
+    let empty: HashMap<String, String> = HashMap::new();
+    let mut p_req =
+        PolicyRequest::minimal("Create", algorithm_in.as_deref(), started, correlation_id, &empty);
+    p_req.key_length = key_length;
+    p_req.usage_mask = usage_mask;
+
+    let resolved = match deps.engine.evaluate(&p_req) {
+        Decision::Allow { algorithm_override, .. } => match algorithm_override.or(algorithm_in) {
+            Some(a) => a,
+            None => {
+                return Err(fail_err(
+                    deps,
+                    correlation_id,
+                    "Create",
+                    KmipError::missing_data(
+                        "no CryptographicAlgorithm in template and policy supplied no default",
+                    ),
+                ));
+            }
+        },
+        Decision::Deny { human, .. } => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Create",
+                KmipError::permission_denied(human),
+            ));
+        }
+        Decision::RekeyAndProceed { .. } => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Create",
+                KmipError::internal("RekeyAndProceed returned for Create"),
+            ));
+        }
+    };
+
+    let algo = parse_sym_algorithm(&resolved)?;
+
+    // Plane-3: emit (Phase 7 wires the real C_GenerateKey call).
+    let mech = algo.to_pkcs11_mech(PkcsOp::KeyGen).ok_or_else(|| {
+        KmipError::failed(
+            ResultReason::OperationNotSupported,
+            format!("symmetric algorithm {resolved} has no KeyGen mechanism"),
+        )
+    })?;
+    emit_pkcs11(
+        deps,
+        correlation_id,
+        "C_GenerateKey",
+        Some(mech),
+        0,
+        "CKR_OK",
+    );
+
+    // Plane-2: persist.
+    let uid = format!("urn:pqctoday:obj:{}", Uuid::new_v4());
+    let now = OffsetDateTime::now_utc();
+    deps.store.put(ObjectRecord {
+        uid: uid.clone(),
+        object_type: req.object_type,
+        algorithm: algo,
+        cryptographic_length: key_length.unwrap_or(0),
+        usage_mask: usage_mask.unwrap_or_else(UsageMask::empty),
+        state: State::PreActive,
+        pkcs11_cka_id: Uuid::new_v4().as_bytes().to_vec(),
+        pkcs11_slot: deps.config.pkcs11_slot,
+        initial_date: now,
+        activation_date: None,
+        supersedes: None,
+    })?;
+
+    emit_success(deps, correlation_id, "Create");
+
+    Ok(CreateResponse {
+        object_type: req.object_type,
+        uid,
+    })
+}
+
+fn extract_template(attrs: &[Attribute]) -> (Option<String>, Option<u32>, Option<UsageMask>) {
+    let mut algorithm: Option<String> = None;
+    let mut length: Option<u32> = None;
+    let mut usage: Option<UsageMask> = None;
+    for a in attrs {
+        match a {
+            Attribute::CryptographicAlgorithm(alg) => {
+                algorithm = Some(super::helpers::canonical_name(*alg));
+            }
+            Attribute::CryptographicLength(n) => length = Some(*n as u32),
+            Attribute::CryptographicUsageMask(m) => usage = Some(*m),
+            _ => {}
+        }
+    }
+    (algorithm, length, usage)
+}
+
+/// Symmetric-only algorithm parse. AES + HMAC variants accepted; asymmetric
+/// names are rejected (caller must use CreateKeyPair).
+fn parse_sym_algorithm(s: &str) -> Result<KmipAlgorithm> {
+    use KmipAlgorithm::*;
+    let base = s.split('-').next().unwrap_or(s);
+    Ok(match s {
+        "HMAC-SHA-256" => HmacSha256,
+        "HMAC-SHA-384" => HmacSha384,
+        "HMAC-SHA-512" => HmacSha512,
+        _ => match base {
+            "AES" => Aes,
+            _ => {
+                return Err(KmipError::invalid_attribute_value(format!(
+                    "Create: {s:?} is not a symmetric algorithm (use CreateKeyPair for asymmetric)"
+                )))
+            }
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::{AuditSink, RingSink};
+    use crate::policy::{load_from_str, Engine};
+    use crate::store::MemoryStore;
+    use std::sync::Arc;
+
+    fn deps_with(yaml: &str) -> Deps {
+        let ring = Arc::new(RingSink::new(64));
+        let sink: Arc<dyn AuditSink> = ring.clone();
+        let engine = Engine::with_global_sink(sink.clone());
+        engine.activate(load_from_str(yaml, std::path::Path::new("<t>")).unwrap()).unwrap();
+        Deps::new(engine, Arc::new(MemoryStore::new()), sink, super::super::deps::DepsConfig::default())
+    }
+
+    const AES_DEFAULT: &str = r#"
+schema_version: 1
+metadata: { name: t, description: t, authority: t, effective: always }
+rules:
+  - type: algorithm_default
+    ops: [Create]
+    default_algorithm: AES-256
+    reason: "AES-256 default"
+"#;
+
+    #[test]
+    fn create_symmetric_with_policy_default() {
+        let d = deps_with(AES_DEFAULT);
+        let resp = create(&d, CreateRequest {
+            object_type: ObjectType::SymmetricKey,
+            template_attribute: vec![],
+        }, "c").unwrap();
+        let rec = d.store.get(&resp.uid).unwrap().unwrap();
+        assert_eq!(rec.algorithm, KmipAlgorithm::Aes);
+        assert_eq!(rec.object_type, ObjectType::SymmetricKey);
+        assert_eq!(rec.state, State::PreActive);
+    }
+
+    #[test]
+    fn create_rejects_asymmetric_object_type() {
+        let d = deps_with(AES_DEFAULT);
+        let err = create(&d, CreateRequest {
+            object_type: ObjectType::PrivateKey,
+            template_attribute: vec![],
+        }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::InvalidAttributeValue);
+    }
+
+    #[test]
+    fn create_rejects_asymmetric_algorithm() {
+        let d = deps_with(AES_DEFAULT);
+        let err = create(&d, CreateRequest {
+            object_type: ObjectType::SymmetricKey,
+            template_attribute: vec![Attribute::CryptographicAlgorithm(KmipAlgorithm::MlDsa87)],
+        }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::InvalidAttributeValue);
+    }
+
+    #[test]
+    fn create_hmac_explicit() {
+        let d = deps_with("schema_version: 1\nmetadata: {name: t, description: t, authority: t, effective: always}\nrules: []\n");
+        let resp = create(&d, CreateRequest {
+            object_type: ObjectType::SymmetricKey,
+            template_attribute: vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::HmacSha256),
+            ],
+        }, "c").unwrap();
+        let rec = d.store.get(&resp.uid).unwrap().unwrap();
+        assert_eq!(rec.algorithm, KmipAlgorithm::HmacSha256);
+    }
+}

--- a/kmip/src/ops/create_key_pair.rs
+++ b/kmip/src/ops/create_key_pair.rs
@@ -1,0 +1,424 @@
+//! KMIP 3.0 §6.1.11 **Create Key Pair** operation.
+//!
+//! > "This operation requests the server to generate a new public/private
+//! > key pair and register the two corresponding new Managed Cryptographic
+//! > Object instances."
+//!
+//! Op codepoint `0x02` (verified against KMIP 3.0 `Operation` enum
+//! extract — `Create Key Pair = 0x00000002`).
+//!
+//! ## Plane mapping
+//!
+//! - **Plane 1** — engine.evaluate with op canonicalised by the caller
+//!   (e.g. `"CreateKeyPair:Sign"`) so policy `algorithm_default` /
+//!   `algorithm_substitution` rules can fire per-purpose. The engine's
+//!   [`Decision::Allow { algorithm_override }`] tells us what algorithm
+//!   to actually use; [`Decision::RekeyAndProceed`] is rejected here
+//!   because there is no pre-existing object to rekey at create-time.
+//! - **Plane 2** — allocate a fresh KMIP `Unique Identifier`, store the
+//!   record with `State = PreActive` (KMIP 3.0 §3.x lifecycle FSM).
+//! - **Plane 3** — would call `C_GenerateKeyPair`
+//!   (PKCS#11 v3.2 §C.7.1; signature verified against
+//!   `rust/src/ffi.rs::C_GenerateKeyPair`) with the mechanism returned by
+//!   [`KmipAlgorithm::to_pkcs11_mech`]. v0.1 produces deterministic
+//!   placeholder `CKA_ID`s — Phase 7 will wire the real session call.
+
+use std::collections::HashMap;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::auditlog::{AuditEvent, EventPayload, KmipOpResult, Plane};
+use crate::error::{KmipError, Result, ResultReason};
+use crate::kmip30::{
+    Attribute, CreateKeyPairRequest, CreateKeyPairResponse, KmipAlgorithm, ObjectType, PkcsOp,
+    State, UsageMask,
+};
+use crate::policy::{Decision, PolicyRequest};
+use crate::store::ObjectRecord;
+
+use super::deps::Deps;
+
+/// Handle a `CreateKeyPair` request. `op_canonical` is the dispatcher-
+/// supplied op string (`"CreateKeyPair:Sign"` / `"CreateKeyPair:Encrypt"`
+/// / `"CreateKeyPair:KeyAgreement"`) — see `policies/README.md` for the
+/// canonicalisation convention.
+pub fn create_key_pair(
+    deps: &Deps,
+    req: CreateKeyPairRequest,
+    op_canonical: &str,
+    correlation_id: &str,
+) -> Result<CreateKeyPairResponse> {
+    let started = OffsetDateTime::now_utc();
+    deps.sink.emit(AuditEvent::at(
+        started,
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipRequestReceived {
+            op: op_canonical.into(),
+            request_summary: format!(
+                "common={} priv={} pub={}",
+                req.common_attributes.len(),
+                req.private_key_attributes.len(),
+                req.public_key_attributes.len(),
+            ),
+            client_cn: None,
+        },
+    ));
+
+    // Extract algorithm + usage_mask from the merged template attributes
+    // (KMIP 3.0 §4.x — `Common Attributes` precede the per-key ones).
+    let (algorithm_in, key_length, usage_mask) = extract_template(&req);
+
+    // ── Plane 1: policy gate ────────────────────────────────────────────
+    let empty_attrs: HashMap<String, String> = HashMap::new();
+    let mut p_req = PolicyRequest::minimal(
+        op_canonical,
+        algorithm_in.as_deref(),
+        started,
+        correlation_id,
+        &empty_attrs,
+    );
+    p_req.key_length = key_length;
+    p_req.usage_mask = usage_mask;
+
+    let resolved_algorithm = match deps.engine.evaluate(&p_req) {
+        Decision::Allow { algorithm_override, .. } => match algorithm_override.or(algorithm_in) {
+            Some(a) => a,
+            None => {
+                return fail(
+                    deps,
+                    correlation_id,
+                    op_canonical,
+                    KmipError::missing_data(
+                        "no CryptographicAlgorithm in template and policy supplied no default",
+                    ),
+                );
+            }
+        },
+        Decision::Deny { human, .. } => {
+            return fail(
+                deps,
+                correlation_id,
+                op_canonical,
+                KmipError::permission_denied(human),
+            );
+        }
+        Decision::RekeyAndProceed { .. } => {
+            // RekeyAndProceed only makes sense for ops that target an
+            // existing object. CreateKeyPair allocates a fresh handle —
+            // we should never reach this branch.
+            return fail(
+                deps,
+                correlation_id,
+                op_canonical,
+                KmipError::internal("RekeyAndProceed returned for CreateKeyPair"),
+            );
+        }
+    };
+
+    let kmip_algo = parse_algorithm(&resolved_algorithm)?;
+
+    // ── Plane 3: would call C_GenerateKeyPair ───────────────────────────
+    // PKCS#11 v3.2 §C.7.1 — signature in pkcs11f.h:
+    //   C_GenerateKeyPair(hSession, pMechanism,
+    //                     pPublicKeyTemplate, ulPublicKeyAttributeCount,
+    //                     pPrivateKeyTemplate, ulPrivateKeyAttributeCount,
+    //                     phPublicKey, phPrivateKey)
+    // softhsmrustv3 export verified at rust/src/ffi.rs::C_GenerateKeyPair.
+    let mech = kmip_algo.to_pkcs11_mech(PkcsOp::KeyGen).ok_or_else(|| {
+        KmipError::failed(
+            ResultReason::OperationNotSupported,
+            format!("algorithm {resolved_algorithm} has no KeyGen mechanism"),
+        )
+    })?;
+
+    // v0.1 deterministic placeholder: Phase 7 wires the real bridge call
+    // and records the actual u32 handles. The audit event below pins the
+    // mechanism name so the trace remains spec-accurate.
+    let pkcs11_cka_id_priv = Uuid::new_v4().as_bytes().to_vec();
+    let pkcs11_cka_id_pub = Uuid::new_v4().as_bytes().to_vec();
+    let mech_name = format!("CKM_0x{mech:04X}");
+
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Pkcs11,
+        correlation_id,
+        EventPayload::Pkcs11Call {
+            function: "C_GenerateKeyPair".into(),
+            mechanism: Some(mech_name),
+            slot: Some(deps.config.pkcs11_slot),
+            session: None,
+            rv: 0, // placeholder until Phase 7 wires the real call
+            rv_name: "CKR_OK".into(),
+            latency_ms: 0,
+        },
+    ));
+
+    // ── Plane 2: allocate UIDs + store records ──────────────────────────
+    let priv_uid = format!("urn:pqctoday:obj:{}", Uuid::new_v4());
+    let pub_uid = format!("urn:pqctoday:obj:{}", Uuid::new_v4());
+
+    let now = OffsetDateTime::now_utc();
+    let usage = usage_mask.unwrap_or_else(UsageMask::empty);
+    deps.store.put(ObjectRecord {
+        uid: priv_uid.clone(),
+        object_type: ObjectType::PrivateKey,
+        algorithm: kmip_algo,
+        cryptographic_length: key_length.unwrap_or(0),
+        usage_mask: usage,
+        state: State::PreActive,
+        pkcs11_cka_id: pkcs11_cka_id_priv,
+        pkcs11_slot: deps.config.pkcs11_slot,
+        initial_date: now,
+        activation_date: None,
+        supersedes: None,
+    })?;
+    deps.store.put(ObjectRecord {
+        uid: pub_uid.clone(),
+        object_type: ObjectType::PublicKey,
+        algorithm: kmip_algo,
+        cryptographic_length: key_length.unwrap_or(0),
+        usage_mask: usage,
+        state: State::PreActive,
+        pkcs11_cka_id: pkcs11_cka_id_pub,
+        pkcs11_slot: deps.config.pkcs11_slot,
+        initial_date: now,
+        activation_date: None,
+        supersedes: None,
+    })?;
+
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipResponseSent {
+            op: op_canonical.into(),
+            result: KmipOpResult::Success,
+            latency_ms: 0,
+        },
+    ));
+
+    Ok(CreateKeyPairResponse {
+        private_key_uid: priv_uid,
+        public_key_uid: pub_uid,
+    })
+}
+
+/// Pull (algorithm, length, usage) out of the merged template attributes.
+/// KMIP 3.0 §4.x — `CryptographicAlgorithm`, `CryptographicLength`, and
+/// `CryptographicUsageMask` are the three attributes the dispatcher
+/// canonicalises for the engine.
+fn extract_template(req: &CreateKeyPairRequest) -> (Option<String>, Option<u32>, Option<UsageMask>) {
+    let mut algorithm: Option<String> = None;
+    let mut length: Option<u32> = None;
+    let mut usage: Option<UsageMask> = None;
+    for a in req
+        .common_attributes
+        .iter()
+        .chain(req.private_key_attributes.iter())
+        .chain(req.public_key_attributes.iter())
+    {
+        match a {
+            Attribute::CryptographicAlgorithm(alg) => {
+                algorithm = Some(canonical_name(*alg));
+            }
+            Attribute::CryptographicLength(n) => {
+                length = Some(*n as u32);
+            }
+            Attribute::CryptographicUsageMask(m) => {
+                usage = Some(*m);
+            }
+            _ => {}
+        }
+    }
+    (algorithm, length, usage)
+}
+
+/// Canonical algorithm string used by the policy engine. Mirrors the
+/// `KmipAlgorithm` enum variant names in `policies/*.yaml`.
+fn canonical_name(a: KmipAlgorithm) -> String {
+    use KmipAlgorithm::*;
+    match a {
+        Aes        => "AES",
+        Rsa        => "RSA",
+        Ecdsa      => "ECDSA",
+        HmacSha256 => "HMAC-SHA-256",
+        HmacSha384 => "HMAC-SHA-384",
+        HmacSha512 => "HMAC-SHA-512",
+        Ecdh       => "ECDH",
+        MlKem512   => "ML-KEM-512",
+        MlKem768   => "ML-KEM-768",
+        MlKem1024  => "ML-KEM-1024",
+        MlDsa44    => "ML-DSA-44",
+        MlDsa65    => "ML-DSA-65",
+        MlDsa87    => "ML-DSA-87",
+        SlhDsaSha2_128s => "SLH-DSA-SHA2-128s",
+        SlhDsaSha2_128f => "SLH-DSA-SHA2-128f",
+        SlhDsaSha2_192s => "SLH-DSA-SHA2-192s",
+        SlhDsaSha2_192f => "SLH-DSA-SHA2-192f",
+        SlhDsaSha2_256s => "SLH-DSA-SHA2-256s",
+        SlhDsaSha2_256f => "SLH-DSA-SHA2-256f",
+        SlhDsaShake128s => "SLH-DSA-SHAKE-128s",
+        SlhDsaShake128f => "SLH-DSA-SHAKE-128f",
+        SlhDsaShake192s => "SLH-DSA-SHAKE-192s",
+        SlhDsaShake192f => "SLH-DSA-SHAKE-192f",
+        SlhDsaShake256s => "SLH-DSA-SHAKE-256s",
+        SlhDsaShake256f => "SLH-DSA-SHAKE-256f",
+    }
+    .into()
+}
+
+/// Reverse mapping. Accepts the size-suffixed canonical names policies use
+/// (e.g. `"AES-256"`, `"ECDSA-P256"`) by stripping the suffix when needed.
+fn parse_algorithm(s: &str) -> Result<KmipAlgorithm> {
+    use KmipAlgorithm::*;
+    let base = s
+        .split('-')
+        .next()
+        .ok_or_else(|| KmipError::invalid_attribute_value(format!("algorithm {s:?}")))?;
+    Ok(match s {
+        "ML-KEM-512" => MlKem512,
+        "ML-KEM-768" => MlKem768,
+        "ML-KEM-1024" => MlKem1024,
+        "ML-DSA-44" => MlDsa44,
+        "ML-DSA-65" => MlDsa65,
+        "ML-DSA-87" => MlDsa87,
+        "SLH-DSA-SHA2-128s" => SlhDsaSha2_128s,
+        "SLH-DSA-SHA2-128f" => SlhDsaSha2_128f,
+        "SLH-DSA-SHA2-192s" => SlhDsaSha2_192s,
+        "SLH-DSA-SHA2-192f" => SlhDsaSha2_192f,
+        "SLH-DSA-SHA2-256s" => SlhDsaSha2_256s,
+        "SLH-DSA-SHA2-256f" => SlhDsaSha2_256f,
+        "SLH-DSA-SHAKE-128s" => SlhDsaShake128s,
+        "SLH-DSA-SHAKE-128f" => SlhDsaShake128f,
+        "SLH-DSA-SHAKE-192s" => SlhDsaShake192s,
+        "SLH-DSA-SHAKE-192f" => SlhDsaShake192f,
+        "SLH-DSA-SHAKE-256s" => SlhDsaShake256s,
+        "SLH-DSA-SHAKE-256f" => SlhDsaShake256f,
+        // Size-suffixed classical algos collapse to their base enum.
+        _ => match base {
+            "AES" => Aes,
+            "RSA" => Rsa,
+            "ECDSA" => Ecdsa,
+            "ECDH" => Ecdh,
+            _ => {
+                return Err(KmipError::invalid_attribute_value(format!(
+                    "unrecognised CryptographicAlgorithm {s:?}"
+                )))
+            }
+        },
+    })
+}
+
+fn fail<T>(deps: &Deps, correlation_id: &str, op: &str, err: KmipError) -> Result<T> {
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipResponseSent {
+            op: op.into(),
+            result: KmipOpResult::OperationFailed {
+                reason: format!("{:?}", err.result_reason()),
+            },
+            latency_ms: 0,
+        },
+    ));
+    Err(err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::RingSink;
+    use crate::policy::{load_from_str, Engine};
+    use crate::store::MemoryStore;
+    use std::sync::Arc;
+
+    const PQC_DEFAULTS: &str = r#"
+schema_version: 1
+metadata:
+  name: pqc
+  description: PQC defaults
+  authority: test
+  effective: "always"
+rules:
+  - type: algorithm_default
+    ops: ["CreateKeyPair:Sign"]
+    default_algorithm: ML-DSA-87
+    reason: "PQC sig default"
+  - type: algorithm_default
+    ops: ["CreateKeyPair:KeyAgreement"]
+    default_algorithm: ML-KEM-1024
+    reason: "PQC KEM default"
+"#;
+
+    fn deps_with(yaml: &str) -> (Arc<RingSink>, Deps) {
+        let ring = Arc::new(RingSink::new(64));
+        let sink: Arc<dyn crate::auditlog::AuditSink> = ring.clone();
+        let engine = Engine::with_global_sink(sink.clone());
+        engine
+            .activate(load_from_str(yaml, std::path::Path::new("<test>")).unwrap())
+            .unwrap();
+        (
+            ring,
+            Deps::new(
+                engine,
+                Arc::new(MemoryStore::new()),
+                sink,
+                super::super::deps::DepsConfig::default(),
+            ),
+        )
+    }
+
+    fn empty_req() -> CreateKeyPairRequest {
+        CreateKeyPairRequest {
+            common_attributes: vec![],
+            private_key_attributes: vec![],
+            public_key_attributes: vec![],
+        }
+    }
+
+    #[test]
+    fn defaults_pqc_signing_under_pqc_policy() {
+        let (ring, d) = deps_with(PQC_DEFAULTS);
+        let resp = create_key_pair(&d, empty_req(), "CreateKeyPair:Sign", "corr-1").unwrap();
+        let priv_record = d.store.get(&resp.private_key_uid).unwrap().unwrap();
+        assert_eq!(priv_record.algorithm, KmipAlgorithm::MlDsa87);
+        // Audit: 1 RequestReceived (p2) + 1 PolicyDecided (p1) + 1 Pkcs11Call (p3)
+        //      + 1 ResponseSent (p2)  +  the activation event (p1)
+        assert!(ring.filter_plane(Plane::Pkcs11).len() >= 1);
+        assert!(ring.filter_plane(Plane::Kmip).len() >= 2);
+    }
+
+    #[test]
+    fn defaults_pqc_kem_under_pqc_policy() {
+        let (_ring, d) = deps_with(PQC_DEFAULTS);
+        let resp =
+            create_key_pair(&d, empty_req(), "CreateKeyPair:KeyAgreement", "corr-2").unwrap();
+        let priv_record = d.store.get(&resp.private_key_uid).unwrap().unwrap();
+        assert_eq!(priv_record.algorithm, KmipAlgorithm::MlKem1024);
+    }
+
+    #[test]
+    fn fails_when_no_algo_and_no_default() {
+        let (_ring, d) = deps_with(
+            r#"
+schema_version: 1
+metadata: { name: empty, description: empty, authority: t, effective: "always" }
+rules: []
+"#,
+        );
+        let err = create_key_pair(&d, empty_req(), "CreateKeyPair:Sign", "corr-3").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::MissingData);
+    }
+
+    #[test]
+    fn parse_algorithm_round_trip() {
+        // PQC names round-trip exact.
+        assert_eq!(parse_algorithm("ML-DSA-87").unwrap(), KmipAlgorithm::MlDsa87);
+        assert_eq!(parse_algorithm("ML-KEM-1024").unwrap(), KmipAlgorithm::MlKem1024);
+        // Classical sized names collapse to base.
+        assert_eq!(parse_algorithm("AES-256").unwrap(), KmipAlgorithm::Aes);
+        assert_eq!(parse_algorithm("ECDSA-P256").unwrap(), KmipAlgorithm::Ecdsa);
+    }
+}

--- a/kmip/src/ops/decrypt.rs
+++ b/kmip/src/ops/decrypt.rs
@@ -1,0 +1,232 @@
+//! KMIP 3.0 §6.1.15 **Decrypt** operation.
+//!
+//! > "This operation requests the server to perform a decryption operation
+//! > on the provided data using the specified key."
+//!
+//! Op codepoint `0x20` (verified — `Decrypt = 0x00000020`).
+//!
+//! ## ML-KEM design point
+//!
+//! KMIP 3.0 has no separate `Decapsulate` op — ML-KEM decapsulation reuses
+//! `Decrypt` when the target key is an ML-KEM private key. Handler
+//! branches on `key.algorithm`:
+//!
+//! - **Classical (RSA / AES)** — `C_DecryptInit` (PKCS#11 v3.2 §C.6.3) +
+//!   `C_Decrypt` (§C.6.4). `DecryptResponse.data` carries plaintext.
+//! - **ML-KEM** — `C_DecapsulateKey` (§C.6.6 / v3.2). Signature verified
+//!   at `rust/src/ffi.rs::C_DecapsulateKey`. `DecryptResponse.data`
+//!   carries the recovered shared secret.
+//!
+//! ## Lifecycle gate (KMIP 3.0 §3.4)
+//!
+//! Decrypt is allowed in `Active` (default) and `Deactivated` (need to
+//! decrypt old ciphertexts after key rotation). `Compromised` is
+//! permitted by the spec but operationally risky; v0.1 allows it with a
+//! deny in policy if the operator wants stricter. `PreActive` and
+//! `Destroyed` are rejected.
+
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+use crate::error::{KmipError, Result, ResultReason};
+use crate::kmip30::{DecryptRequest, DecryptResponse, KmipAlgorithm, PkcsOp, State};
+use crate::policy::{Decision, PolicyRequest};
+
+use super::deps::Deps;
+use super::helpers::{canonical_name, emit_pkcs11, emit_request, emit_success, fail_err, state_name};
+
+pub fn decrypt(deps: &Deps, req: DecryptRequest, correlation_id: &str) -> Result<DecryptResponse> {
+    let started = OffsetDateTime::now_utc();
+    emit_request(
+        deps,
+        correlation_id,
+        "Decrypt",
+        format!("uid={} data_len={}", req.uid, req.data.len()),
+    );
+
+    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
+        fail_err(deps, correlation_id, "Decrypt", KmipError::not_found(&req.uid))
+    })?;
+
+    // Lifecycle gate per §3.4 — Decrypt allowed in Active / Deactivated /
+    // Compromised; PreActive and Destroyed rejected.
+    match obj.state {
+        State::Active | State::Deactivated | State::Compromised => {}
+        _ => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Decrypt",
+                KmipError::object_archived(&req.uid),
+            ));
+        }
+    }
+
+    // Plane-1 policy gate.
+    let empty: HashMap<String, String> = HashMap::new();
+    let algo = canonical_name(obj.algorithm);
+    let mut p_req = PolicyRequest::minimal("Decrypt", Some(&algo), started, correlation_id, &empty);
+    p_req.usage_mask = Some(obj.usage_mask);
+    p_req.state = Some(state_name(obj.state));
+    p_req.current_object_algorithm = Some(&algo);
+    p_req.target_uid = Some(&req.uid);
+    if let Decision::Deny { human, .. } = deps.engine.evaluate(&p_req) {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "Decrypt",
+            KmipError::permission_denied(human),
+        ));
+    }
+
+    // Plane-3: branch on algorithm.
+    let resp = if is_ml_kem(obj.algorithm) {
+        decrypt_ml_kem(deps, &req, obj.algorithm, correlation_id)
+    } else {
+        decrypt_classical(deps, &req, obj.algorithm, correlation_id)
+    }?;
+
+    emit_success(deps, correlation_id, "Decrypt");
+    Ok(resp)
+}
+
+fn is_ml_kem(a: KmipAlgorithm) -> bool {
+    matches!(a, KmipAlgorithm::MlKem512 | KmipAlgorithm::MlKem768 | KmipAlgorithm::MlKem1024)
+}
+
+/// ML-KEM decapsulation — `C_DecapsulateKey`. `req.data` is the
+/// encapsulation; response `data` carries the recovered shared secret.
+fn decrypt_ml_kem(
+    deps: &Deps,
+    req: &DecryptRequest,
+    algo: KmipAlgorithm,
+    correlation_id: &str,
+) -> Result<DecryptResponse> {
+    let mech = algo.to_pkcs11_mech(PkcsOp::Decrypt).ok_or_else(|| {
+        KmipError::failed(
+            ResultReason::OperationNotSupported,
+            format!("ML-KEM {algo:?} has no Decrypt mechanism"),
+        )
+    })?;
+    emit_pkcs11(deps, correlation_id, "C_DecapsulateKey", Some(mech), 0, "CKR_OK");
+
+    // v0.1 placeholder: deterministic SS derived from uid + encapsulation.
+    // Phase 7 wires real softhsmrustv3::C_DecapsulateKey.
+    let shared_secret = placeholder_bytes(&req.uid, &req.data, b"ss", 32);
+    Ok(DecryptResponse { uid: req.uid.clone(), data: shared_secret })
+}
+
+/// Classical decrypt — C_DecryptInit + C_Decrypt.
+fn decrypt_classical(
+    deps: &Deps,
+    req: &DecryptRequest,
+    algo: KmipAlgorithm,
+    correlation_id: &str,
+) -> Result<DecryptResponse> {
+    let mech = algo.to_pkcs11_mech(PkcsOp::Decrypt).ok_or_else(|| {
+        KmipError::failed(
+            ResultReason::OperationNotSupported,
+            format!("{algo:?} has no Decrypt mechanism"),
+        )
+    })?;
+    emit_pkcs11(deps, correlation_id, "C_DecryptInit", Some(mech), 0, "CKR_OK");
+    emit_pkcs11(deps, correlation_id, "C_Decrypt", Some(mech), 0, "CKR_OK");
+
+    // v0.1 placeholder: deterministic stamp from uid + iv + ciphertext.
+    let mut input = req.iv.clone().unwrap_or_default();
+    input.extend_from_slice(&req.data);
+    let plaintext = placeholder_bytes(&req.uid, &input, b"dec", input.len().max(16));
+    Ok(DecryptResponse { uid: req.uid.clone(), data: plaintext })
+}
+
+fn placeholder_bytes(uid: &str, input: &[u8], domain: &[u8], len: usize) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+    let mut out = Vec::with_capacity(len);
+    let mut counter: u32 = 0;
+    while out.len() < len {
+        let mut h = Sha256::new();
+        h.update(domain);
+        h.update(uid.as_bytes());
+        h.update(input);
+        h.update(counter.to_be_bytes());
+        out.extend_from_slice(&h.finalize());
+        counter += 1;
+    }
+    out.truncate(len);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::{AuditSink, EventPayload, Plane, RingSink};
+    use crate::kmip30::{ObjectType, UsageMask};
+    use crate::policy::{load_from_str, Engine};
+    use crate::store::{MemoryStore, ObjectRecord};
+    use std::sync::Arc;
+
+    fn deps_and_ring() -> (Arc<RingSink>, Deps) {
+        let ring = Arc::new(RingSink::new(64));
+        let sink: Arc<dyn AuditSink> = ring.clone();
+        let engine = Engine::with_global_sink(sink.clone());
+        engine
+            .activate(load_from_str(
+                "schema_version: 1\nmetadata: {name: t, description: t, authority: t, effective: always}\nrules: []\n",
+                std::path::Path::new("<t>"),
+            ).unwrap())
+            .unwrap();
+        (ring.clone(), Deps::new(engine, Arc::new(MemoryStore::new()), sink, super::super::deps::DepsConfig::default()))
+    }
+
+    fn put(deps: &Deps, uid: &str, algo: KmipAlgorithm, obj_type: ObjectType, state: State, mask: UsageMask) {
+        deps.store.put(ObjectRecord {
+            uid: uid.into(),
+            object_type: obj_type,
+            algorithm: algo,
+            cryptographic_length: 0,
+            usage_mask: mask,
+            state,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: Some(OffsetDateTime::UNIX_EPOCH),
+            supersedes: None,
+        }).unwrap();
+    }
+
+    #[test]
+    fn ml_kem_branch_calls_decapsulate() {
+        let (ring, d) = deps_and_ring();
+        put(&d, "k", KmipAlgorithm::MlKem1024, ObjectType::PrivateKey, State::Active, UsageMask::KEY_AGREEMENT);
+        let r = decrypt(&d, DecryptRequest { uid: "k".into(), data: vec![0u8; 1568], iv: None }, "c").unwrap();
+        assert_eq!(r.data.len(), 32, "shared secret length");
+        let p3: Vec<_> = ring.filter_plane(Plane::Pkcs11);
+        assert!(p3.iter().any(|e| matches!(&e.event, EventPayload::Pkcs11Call { function, .. } if function == "C_DecapsulateKey")));
+        assert!(!p3.iter().any(|e| matches!(&e.event, EventPayload::Pkcs11Call { function, .. } if function == "C_DecryptInit")));
+    }
+
+    #[test]
+    fn classical_branch_calls_decrypt_init_then_decrypt() {
+        let (ring, d) = deps_and_ring();
+        put(&d, "a", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Active, UsageMask::DECRYPT);
+        let _r = decrypt(&d, DecryptRequest { uid: "a".into(), data: vec![0; 32], iv: Some(vec![0; 12]) }, "c").unwrap();
+        let p3: Vec<_> = ring.filter_plane(Plane::Pkcs11);
+        assert!(p3.iter().any(|e| matches!(&e.event, EventPayload::Pkcs11Call { function, .. } if function == "C_DecryptInit")));
+        assert!(p3.iter().any(|e| matches!(&e.event, EventPayload::Pkcs11Call { function, .. } if function == "C_Decrypt")));
+    }
+
+    #[test]
+    fn decrypt_allowed_in_deactivated_state() {
+        let (_ring, d) = deps_and_ring();
+        put(&d, "a", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Deactivated, UsageMask::DECRYPT);
+        let _ = decrypt(&d, DecryptRequest { uid: "a".into(), data: vec![0; 32], iv: None }, "c").unwrap();
+    }
+
+    #[test]
+    fn decrypt_pre_active_rejected() {
+        let (_ring, d) = deps_and_ring();
+        put(&d, "a", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::PreActive, UsageMask::DECRYPT);
+        let err = decrypt(&d, DecryptRequest { uid: "a".into(), data: vec![0; 32], iv: None }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::ObjectArchived);
+    }
+}

--- a/kmip/src/ops/deps.rs
+++ b/kmip/src/ops/deps.rs
@@ -1,0 +1,94 @@
+//! [`Deps`] — shared dependency bundle every op handler takes.
+//!
+//! The dispatcher constructs one `Deps` at startup; each op handler
+//! borrows it. Components:
+//!
+//! - **`engine`** — Plane-1 [`Engine`] for the policy gate.
+//! - **`store`** — Plane-2 [`KeyStore`] for KMIP object metadata.
+//! - **`sink`** — Plane-1/2/3 audit fan-out target.
+//! - **`config`** — runtime config (slot ID, PIN, vendor identification).
+//!
+//! Phase 5 (this) wires this together for the foundational ops + tests.
+//! Phase 7 (TLS server) constructs `Deps` once at process start and
+//! shares it across all per-connection tasks.
+
+use std::sync::Arc;
+
+use crate::auditlog::AuditSink;
+use crate::policy::Engine;
+use crate::store::KeyStore;
+
+/// Runtime configuration the op handlers need.
+#[derive(Clone, Debug)]
+pub struct DepsConfig {
+    /// PKCS#11 slot the engine writes into. Single-slot in v0.1.
+    pub pkcs11_slot: u32,
+    /// User PIN passed to `C_Login`. Held in memory only; future phases
+    /// will switch to a secret-store abstraction.
+    pub pkcs11_pin: String,
+    /// KMIP `Vendor Identification` for `Query → ServerInformation`.
+    /// KMIP 3.0 §6.1.45 — free-form string identifying the implementation.
+    pub vendor_identification: String,
+    /// KMIP `Server Version` for `Query → ServerInformation`.
+    pub server_version: String,
+}
+
+impl Default for DepsConfig {
+    fn default() -> Self {
+        Self {
+            pkcs11_slot: 0,
+            pkcs11_pin: "1234".into(), // sandbox default; production overrides
+            vendor_identification: "pqctoday-hsm".into(),
+            server_version: env!("CARGO_PKG_VERSION").into(),
+        }
+    }
+}
+
+/// Shared dependencies passed to every op handler.
+pub struct Deps {
+    pub engine: Engine,
+    pub store: Arc<dyn KeyStore>,
+    pub sink: Arc<dyn AuditSink>,
+    pub config: DepsConfig,
+}
+
+impl Deps {
+    pub fn new(
+        engine: Engine,
+        store: Arc<dyn KeyStore>,
+        sink: Arc<dyn AuditSink>,
+        config: DepsConfig,
+    ) -> Self {
+        Self {
+            engine,
+            store,
+            sink,
+            config,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::RingSink;
+    use crate::store::MemoryStore;
+
+    #[test]
+    fn deps_constructs_with_default_config() {
+        let sink: Arc<dyn AuditSink> = Arc::new(RingSink::new(64));
+        let _deps = Deps::new(
+            Engine::permissive(),
+            Arc::new(MemoryStore::new()),
+            sink,
+            DepsConfig::default(),
+        );
+    }
+
+    #[test]
+    fn default_config_carries_vendor_strings() {
+        let c = DepsConfig::default();
+        assert!(!c.vendor_identification.is_empty());
+        assert!(!c.server_version.is_empty());
+    }
+}

--- a/kmip/src/ops/destroy.rs
+++ b/kmip/src/ops/destroy.rs
@@ -1,0 +1,184 @@
+//! KMIP 3.0 §6.1.19 **Destroy** operation.
+//!
+//! > "This operation is used to indicate to the server that the key
+//! > material for the specified Managed Object SHALL be destroyed."
+//!
+//! Op codepoint `0x14` (verified — `Destroy = 0x00000014`).
+//!
+//! ## Plane mapping
+//!
+//! - **Plane 1** — engine.evaluate; rare to gate Destroy via policy but
+//!   the surface is available.
+//! - **Plane 2** — lifecycle FSM per `docs/IMPLEMENTATION_PLAN.md` §3.4:
+//!   `PreActive → Destroyed`, `Deactivated → Destroyed`,
+//!   `Compromised → DestroyedCompromised`. Active and already-Destroyed
+//!   are rejected.
+//! - **Plane 3** — calls `C_DestroyObject` (PKCS#11 v3.2 §C.5.10).
+//!   Signature verified at `rust/src/ffi.rs::C_DestroyObject`:
+//!   `C_DestroyObject(hSession: u32, hObject: u32) -> u32`.
+
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+use crate::error::{KmipError, Result};
+use crate::kmip30::{DestroyRequest, DestroyResponse, State};
+use crate::policy::{Decision, PolicyRequest};
+
+use super::deps::Deps;
+use super::helpers::{
+    canonical_name, emit_pkcs11, emit_request, emit_state_change, emit_success, fail_err,
+    state_name,
+};
+
+pub fn destroy(deps: &Deps, req: DestroyRequest, correlation_id: &str) -> Result<DestroyResponse> {
+    let started = OffsetDateTime::now_utc();
+    emit_request(deps, correlation_id, "Destroy", format!("uid={}", req.uid));
+
+    let mut obj = deps.store.get(&req.uid)?.ok_or_else(|| {
+        fail_err(deps, correlation_id, "Destroy", KmipError::not_found(&req.uid))
+    })?;
+
+    // KMIP 3.0 §3.x lifecycle — Active cannot transition directly to Destroyed;
+    // already-Destroyed is terminal.
+    let target_state = match obj.state {
+        State::PreActive | State::Deactivated => State::Destroyed,
+        State::Compromised => State::DestroyedCompromised,
+        State::Active => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Destroy",
+                KmipError::permission_denied(
+                    "Active keys must be Revoked before Destroy (KMIP §3.x FSM)",
+                ),
+            ));
+        }
+        State::Destroyed | State::DestroyedCompromised => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Destroy",
+                KmipError::object_archived(&req.uid),
+            ));
+        }
+    };
+
+    // Plane-1 policy gate.
+    let empty: HashMap<String, String> = HashMap::new();
+    let algo = canonical_name(obj.algorithm);
+    let mut p_req = PolicyRequest::minimal("Destroy", Some(&algo), started, correlation_id, &empty);
+    p_req.state = Some(state_name(obj.state));
+    p_req.target_uid = Some(&req.uid);
+    if let Decision::Deny { human, .. } = deps.engine.evaluate(&p_req) {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "Destroy",
+            KmipError::permission_denied(human),
+        ));
+    }
+
+    // Plane-3: emit (Phase 7 wires the real bridge call to
+    // softhsmrustv3::C_DestroyObject(session, h_object)).
+    emit_pkcs11(deps, correlation_id, "C_DestroyObject", None, 0, "CKR_OK");
+
+    // Plane-2: lifecycle update.
+    let from_label = state_name(obj.state).to_string();
+    let to_label = state_name(target_state).to_string();
+    obj.state = target_state;
+    deps.store.update(obj)?;
+
+    emit_state_change(
+        deps,
+        correlation_id,
+        &req.uid,
+        &from_label,
+        &to_label,
+        "KMIP Destroy op",
+    );
+    emit_success(deps, correlation_id, "Destroy");
+
+    Ok(DestroyResponse {
+        uid: req.uid,
+        state: target_state,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::{AuditSink, RingSink};
+    use crate::kmip30::{KmipAlgorithm, ObjectType, UsageMask};
+    use crate::policy::{load_from_str, Engine};
+    use crate::store::{MemoryStore, ObjectRecord};
+    use std::sync::Arc;
+
+    fn deps_with() -> Deps {
+        let ring = Arc::new(RingSink::new(64));
+        let sink: Arc<dyn AuditSink> = ring.clone();
+        let engine = Engine::with_global_sink(sink.clone());
+        engine
+            .activate(load_from_str(
+                "schema_version: 1\nmetadata: {name: t, description: t, authority: t, effective: always}\nrules: []\n",
+                std::path::Path::new("<t>"),
+            ).unwrap())
+            .unwrap();
+        Deps::new(engine, Arc::new(MemoryStore::new()), sink, super::super::deps::DepsConfig::default())
+    }
+
+    fn put(deps: &Deps, uid: &str, state: State) {
+        deps.store.put(ObjectRecord {
+            uid: uid.into(),
+            object_type: ObjectType::PrivateKey,
+            algorithm: KmipAlgorithm::MlDsa87,
+            cryptographic_length: 0,
+            usage_mask: UsageMask::SIGN,
+            state,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: None,
+            supersedes: None,
+        }).unwrap();
+    }
+
+    #[test]
+    fn pre_active_to_destroyed() {
+        let d = deps_with();
+        put(&d, "u", State::PreActive);
+        let r = destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap();
+        assert_eq!(r.state, State::Destroyed);
+    }
+
+    #[test]
+    fn deactivated_to_destroyed() {
+        let d = deps_with();
+        put(&d, "u", State::Deactivated);
+        let r = destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap();
+        assert_eq!(r.state, State::Destroyed);
+    }
+
+    #[test]
+    fn compromised_to_destroyed_compromised() {
+        let d = deps_with();
+        put(&d, "u", State::Compromised);
+        let r = destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap();
+        assert_eq!(r.state, State::DestroyedCompromised);
+    }
+
+    #[test]
+    fn active_rejected_must_revoke_first() {
+        let d = deps_with();
+        put(&d, "u", State::Active);
+        let err = destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), crate::error::ResultReason::PermissionDenied);
+    }
+
+    #[test]
+    fn already_destroyed_rejected() {
+        let d = deps_with();
+        put(&d, "u", State::Destroyed);
+        let err = destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), crate::error::ResultReason::ObjectArchived);
+    }
+}

--- a/kmip/src/ops/encrypt.rs
+++ b/kmip/src/ops/encrypt.rs
@@ -1,0 +1,254 @@
+//! KMIP 3.0 §6.1.21 **Encrypt** operation.
+//!
+//! > "This operation requests the server to perform an encryption
+//! > operation on the provided data using the specified key."
+//!
+//! Op codepoint `0x1f` (verified — `Encrypt = 0x0000001f`).
+//!
+//! ## ML-KEM design point (verified 2026-06-04)
+//!
+//! KMIP 3.0 has **no** separate `Encapsulate` op — ML-KEM encapsulation
+//! reuses `Encrypt` when the target key is an ML-KEM public key. This
+//! handler branches on `key.algorithm`:
+//!
+//! - **Classical (RSA / AES)** — `C_EncryptInit` (PKCS#11 v3.2 §C.6.1) +
+//!   `C_Encrypt` (§C.6.2). `EncryptResponse.ciphertext` carries the
+//!   ciphertext; `shared_secret` is `None`.
+//! - **ML-KEM** — `C_EncapsulateKey` (§C.6.5 introduced in v3.2).
+//!   Signature verified at `rust/src/ffi.rs::C_EncapsulateKey`:
+//!   `(hSession, pMechanism, hPublicKey, pTemplate, ulAttributeCount,
+//!    pCiphertext, pulCiphertextLen, phKey)`. Response carries
+//!   `ciphertext = encapsulation` AND `shared_secret = Some(K)`.
+//!
+//! ## Lifecycle gate (KMIP 3.0 §3.4)
+//!
+//! Encrypt requires `Active`. Other states rejected with `ObjectArchived`.
+
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+use crate::error::{KmipError, Result, ResultReason};
+use crate::kmip30::{EncryptRequest, EncryptResponse, KmipAlgorithm, PkcsOp, State};
+use crate::policy::{Decision, PolicyRequest};
+
+use super::deps::Deps;
+use super::helpers::{canonical_name, emit_pkcs11, emit_request, emit_success, fail_err, state_name};
+
+pub fn encrypt(deps: &Deps, req: EncryptRequest, correlation_id: &str) -> Result<EncryptResponse> {
+    let started = OffsetDateTime::now_utc();
+    emit_request(
+        deps,
+        correlation_id,
+        "Encrypt",
+        format!("uid={} data_len={}", req.uid, req.data.len()),
+    );
+
+    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
+        fail_err(deps, correlation_id, "Encrypt", KmipError::not_found(&req.uid))
+    })?;
+
+    if obj.state != State::Active {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "Encrypt",
+            KmipError::object_archived(&req.uid),
+        ));
+    }
+
+    // Plane-1 policy gate. The dispatcher would canonicalise the op to
+    // "Encapsulate" for ML-KEM in a future revision so policies can
+    // differentiate; v0.1 passes plain "Encrypt".
+    let empty: HashMap<String, String> = HashMap::new();
+    let algo = canonical_name(obj.algorithm);
+    let mut p_req = PolicyRequest::minimal("Encrypt", Some(&algo), started, correlation_id, &empty);
+    p_req.usage_mask = Some(obj.usage_mask);
+    p_req.state = Some(state_name(obj.state));
+    p_req.current_object_algorithm = Some(&algo);
+    p_req.target_uid = Some(&req.uid);
+    match deps.engine.evaluate(&p_req) {
+        Decision::Allow { .. } => {}
+        Decision::Deny { human, .. } => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Encrypt",
+                KmipError::permission_denied(human),
+            ));
+        }
+        Decision::RekeyAndProceed { new_algorithm, original_uid, .. } => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Encrypt",
+                KmipError::failed(
+                    ResultReason::PermissionDenied,
+                    format!(
+                        "rekey required: policy substitutes {algo} → {new_algorithm} for UID {original_uid}"
+                    ),
+                ),
+            ));
+        }
+    }
+
+    // Plane-3: branch on algorithm.
+    let resp = if is_ml_kem(obj.algorithm) {
+        encrypt_ml_kem(deps, &req, obj.algorithm, correlation_id)
+    } else {
+        encrypt_classical(deps, &req, obj.algorithm, correlation_id)
+    }?;
+
+    emit_success(deps, correlation_id, "Encrypt");
+    Ok(resp)
+}
+
+fn is_ml_kem(a: KmipAlgorithm) -> bool {
+    matches!(a, KmipAlgorithm::MlKem512 | KmipAlgorithm::MlKem768 | KmipAlgorithm::MlKem1024)
+}
+
+/// ML-KEM encapsulation — calls `C_EncapsulateKey`. Response carries
+/// ciphertext (the encapsulation) AND the derived shared secret.
+fn encrypt_ml_kem(
+    deps: &Deps,
+    req: &EncryptRequest,
+    algo: KmipAlgorithm,
+    correlation_id: &str,
+) -> Result<EncryptResponse> {
+    let mech = algo.to_pkcs11_mech(PkcsOp::Encrypt).ok_or_else(|| {
+        KmipError::failed(
+            ResultReason::OperationNotSupported,
+            format!("ML-KEM {algo:?} has no Encrypt mechanism"),
+        )
+    })?;
+    emit_pkcs11(deps, correlation_id, "C_EncapsulateKey", Some(mech), 0, "CKR_OK");
+
+    // v0.1 placeholder: deterministic encapsulation + shared secret.
+    // Phase 7 wires real softhsmrustv3::C_EncapsulateKey call.
+    let encapsulation = placeholder_bytes(&req.uid, &req.data, b"encap", 32);
+    let shared_secret = placeholder_bytes(&req.uid, &req.data, b"ss", 32);
+    Ok(EncryptResponse {
+        uid: req.uid.clone(),
+        ciphertext: encapsulation,
+        shared_secret: Some(shared_secret),
+    })
+}
+
+/// Classical encrypt — calls C_EncryptInit + C_Encrypt.
+fn encrypt_classical(
+    deps: &Deps,
+    req: &EncryptRequest,
+    algo: KmipAlgorithm,
+    correlation_id: &str,
+) -> Result<EncryptResponse> {
+    let mech = algo.to_pkcs11_mech(PkcsOp::Encrypt).ok_or_else(|| {
+        KmipError::failed(
+            ResultReason::OperationNotSupported,
+            format!("{algo:?} has no Encrypt mechanism"),
+        )
+    })?;
+    emit_pkcs11(deps, correlation_id, "C_EncryptInit", Some(mech), 0, "CKR_OK");
+    emit_pkcs11(deps, correlation_id, "C_Encrypt", Some(mech), 0, "CKR_OK");
+
+    // v0.1 placeholder: deterministic stamp from uid + iv + data.
+    let mut input = req.iv.clone().unwrap_or_default();
+    input.extend_from_slice(&req.data);
+    let ciphertext = placeholder_bytes(&req.uid, &input, b"enc", input.len().max(16));
+    Ok(EncryptResponse {
+        uid: req.uid.clone(),
+        ciphertext,
+        shared_secret: None,
+    })
+}
+
+fn placeholder_bytes(uid: &str, input: &[u8], domain: &[u8], len: usize) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+    let mut out = Vec::with_capacity(len);
+    let mut counter: u32 = 0;
+    while out.len() < len {
+        let mut h = Sha256::new();
+        h.update(domain);
+        h.update(uid.as_bytes());
+        h.update(input);
+        h.update(counter.to_be_bytes());
+        out.extend_from_slice(&h.finalize());
+        counter += 1;
+    }
+    out.truncate(len);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::{AuditSink, EventPayload, Plane, RingSink};
+    use crate::kmip30::{ObjectType, UsageMask};
+    use crate::policy::{load_from_str, Engine};
+    use crate::store::{MemoryStore, ObjectRecord};
+    use std::sync::Arc;
+
+    fn deps_and_ring() -> (Arc<RingSink>, Deps) {
+        let ring = Arc::new(RingSink::new(64));
+        let sink: Arc<dyn AuditSink> = ring.clone();
+        let engine = Engine::with_global_sink(sink.clone());
+        engine
+            .activate(load_from_str(
+                "schema_version: 1\nmetadata: {name: t, description: t, authority: t, effective: always}\nrules: []\n",
+                std::path::Path::new("<t>"),
+            ).unwrap())
+            .unwrap();
+        (ring.clone(), Deps::new(engine, Arc::new(MemoryStore::new()), sink, super::super::deps::DepsConfig::default()))
+    }
+
+    fn put(deps: &Deps, uid: &str, algo: KmipAlgorithm, obj_type: ObjectType, state: State, mask: UsageMask) {
+        deps.store.put(ObjectRecord {
+            uid: uid.into(),
+            object_type: obj_type,
+            algorithm: algo,
+            cryptographic_length: 0,
+            usage_mask: mask,
+            state,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: Some(OffsetDateTime::UNIX_EPOCH),
+            supersedes: None,
+        }).unwrap();
+    }
+
+    #[test]
+    fn ml_kem_branch_returns_encapsulation_and_shared_secret() {
+        let (ring, d) = deps_and_ring();
+        put(&d, "k", KmipAlgorithm::MlKem1024, ObjectType::PublicKey, State::Active, UsageMask::KEY_AGREEMENT);
+        let r = encrypt(&d, EncryptRequest { uid: "k".into(), data: vec![], iv: None }, "c").unwrap();
+        assert!(r.shared_secret.is_some(), "ML-KEM must return shared secret");
+        assert_eq!(r.ciphertext.len(), 32);
+        // Plane-3 emit should be C_EncapsulateKey, not C_EncryptInit.
+        let p3: Vec<_> = ring.filter_plane(Plane::Pkcs11);
+        assert!(p3.iter().any(|e| matches!(&e.event, EventPayload::Pkcs11Call { function, .. } if function == "C_EncapsulateKey")));
+        assert!(!p3.iter().any(|e| matches!(&e.event, EventPayload::Pkcs11Call { function, .. } if function == "C_EncryptInit")));
+    }
+
+    #[test]
+    fn classical_aes_branch_returns_ciphertext_no_shared_secret() {
+        let (ring, d) = deps_and_ring();
+        put(&d, "a", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Active, UsageMask::ENCRYPT);
+        let r = encrypt(&d, EncryptRequest {
+            uid: "a".into(),
+            data: b"plaintext".to_vec(),
+            iv: Some(vec![0u8; 12]),
+        }, "c").unwrap();
+        assert!(r.shared_secret.is_none(), "classical encrypt has no shared secret");
+        // Plane-3 emit should be C_EncryptInit + C_Encrypt.
+        let p3: Vec<_> = ring.filter_plane(Plane::Pkcs11);
+        assert!(p3.iter().any(|e| matches!(&e.event, EventPayload::Pkcs11Call { function, .. } if function == "C_EncryptInit")));
+        assert!(p3.iter().any(|e| matches!(&e.event, EventPayload::Pkcs11Call { function, .. } if function == "C_Encrypt")));
+    }
+
+    #[test]
+    fn encrypt_on_destroyed_returns_object_archived() {
+        let (_ring, d) = deps_and_ring();
+        put(&d, "a", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Destroyed, UsageMask::ENCRYPT);
+        let err = encrypt(&d, EncryptRequest { uid: "a".into(), data: vec![], iv: None }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::ObjectArchived);
+    }
+}

--- a/kmip/src/ops/get.rs
+++ b/kmip/src/ops/get.rs
@@ -1,0 +1,164 @@
+//! KMIP 3.0 §6.1.23 **Get** operation.
+//!
+//! > "This operation requests that the server returns the Managed Object
+//! > specified by its Unique Identifier."
+//!
+//! Op codepoint `0x0a` (verified — `Get = 0x0000000a`).
+//!
+//! ## Plane mapping
+//!
+//! - **Plane 1** — engine.evaluate; policies typically allow Get in any
+//!   lifecycle state (Get is read-only against KMIP metadata).
+//! - **Plane 2** — store lookup; build `KeyBlock` response from the
+//!   stored record's algorithm + length.
+//! - **Plane 3** — calls `C_GetAttributeValue` (PKCS#11 v3.2 §C.5.9) to
+//!   read `CKA_VALUE` for symmetric / `CKA_PUBLIC_KEY_INFO` for public
+//!   keys; private-key material is sensitive (`CKA_SENSITIVE = true`)
+//!   and never extracted. Phase 7 wires the real call; v0.1 returns a
+//!   deterministic placeholder so the response builder is exercised.
+
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+use crate::error::{KmipError, Result};
+use crate::kmip30::{GetRequest, GetResponse, KeyBlock, KeyFormatType, ObjectType, State};
+use crate::policy::{Decision, PolicyRequest};
+
+use super::deps::Deps;
+use super::helpers::{canonical_name, emit_pkcs11, emit_request, emit_success, fail_err, state_name};
+
+pub fn get(deps: &Deps, req: GetRequest, correlation_id: &str) -> Result<GetResponse> {
+    let started = OffsetDateTime::now_utc();
+    emit_request(deps, correlation_id, "Get", format!("uid={}", req.uid));
+
+    let obj = deps
+        .store
+        .get(&req.uid)?
+        .ok_or_else(|| fail_err(deps, correlation_id, "Get", KmipError::not_found(&req.uid)))?;
+
+    // Per the lifecycle table in docs/IMPLEMENTATION_PLAN.md §3.4, Get is
+    // allowed in every state including Deactivated / Compromised
+    // (key material is needed to verify legacy signatures); only Destroyed
+    // is blocked.
+    if matches!(obj.state, State::Destroyed | State::DestroyedCompromised) {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "Get",
+            KmipError::object_archived(&req.uid),
+        ));
+    }
+
+    // Plane-1 policy gate.
+    let empty: HashMap<String, String> = HashMap::new();
+    let algo = canonical_name(obj.algorithm);
+    let mut p_req = PolicyRequest::minimal("Get", Some(&algo), started, correlation_id, &empty);
+    p_req.state = Some(state_name(obj.state));
+    p_req.target_uid = Some(&req.uid);
+    if let Decision::Deny { human, .. } = deps.engine.evaluate(&p_req) {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "Get",
+            KmipError::permission_denied(human),
+        ));
+    }
+
+    // Plane-3: emit (Phase 7 wires the real C_GetAttributeValue call for
+    // CKA_VALUE on symmetric keys / CKA_PUBLIC_KEY_INFO on public keys).
+    emit_pkcs11(deps, correlation_id, "C_GetAttributeValue", None, 0, "CKR_OK");
+
+    // v0.1 placeholder key bytes — Phase 7 returns the real material.
+    // Private keys never expose CKA_VALUE (sensitive); return an empty
+    // value with format = OpaqueObject so KMIP-conformant clients see the
+    // object exists but contains no extractable material.
+    let (key_format, key_value) = match obj.object_type {
+        ObjectType::PrivateKey => (KeyFormatType::OpaqueObject, Vec::new()),
+        _ => (KeyFormatType::Raw, vec![0u8; (obj.cryptographic_length as usize).max(1)]),
+    };
+
+    emit_success(deps, correlation_id, "Get");
+
+    Ok(GetResponse {
+        object_type: obj.object_type,
+        uid: req.uid,
+        key_block: KeyBlock {
+            key_format_type: key_format,
+            cryptographic_algorithm: obj.algorithm,
+            cryptographic_length: obj.cryptographic_length,
+            key_value,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::{AuditSink, RingSink};
+    use crate::kmip30::{KmipAlgorithm, UsageMask};
+    use crate::policy::{load_from_str, Engine};
+    use crate::store::{MemoryStore, ObjectRecord};
+    use std::sync::Arc;
+
+    fn deps_with() -> Deps {
+        let ring = Arc::new(RingSink::new(64));
+        let sink: Arc<dyn AuditSink> = ring.clone();
+        let engine = Engine::with_global_sink(sink.clone());
+        engine
+            .activate(load_from_str(
+                "schema_version: 1\nmetadata: {name: t, description: t, authority: t, effective: always}\nrules: []\n",
+                std::path::Path::new("<t>"),
+            ).unwrap())
+            .unwrap();
+        Deps::new(engine, Arc::new(MemoryStore::new()), sink, super::super::deps::DepsConfig::default())
+    }
+
+    fn put(deps: &Deps, uid: &str, obj_type: ObjectType, state: State) {
+        deps.store.put(ObjectRecord {
+            uid: uid.into(),
+            object_type: obj_type,
+            algorithm: KmipAlgorithm::Aes,
+            cryptographic_length: 256,
+            usage_mask: UsageMask::ENCRYPT | UsageMask::DECRYPT,
+            state,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: None,
+            supersedes: None,
+        }).unwrap();
+    }
+
+    #[test]
+    fn get_symmetric_returns_raw_format() {
+        let d = deps_with();
+        put(&d, "u", ObjectType::SymmetricKey, State::Active);
+        let r = get(&d, GetRequest { uid: "u".into() }, "c").unwrap();
+        assert_eq!(r.key_block.key_format_type, KeyFormatType::Raw);
+        assert_eq!(r.key_block.cryptographic_length, 256);
+    }
+
+    #[test]
+    fn get_private_returns_opaque_format() {
+        let d = deps_with();
+        put(&d, "u", ObjectType::PrivateKey, State::Active);
+        let r = get(&d, GetRequest { uid: "u".into() }, "c").unwrap();
+        assert_eq!(r.key_block.key_format_type, KeyFormatType::OpaqueObject);
+        assert!(r.key_block.key_value.is_empty(), "private key material never returned");
+    }
+
+    #[test]
+    fn get_destroyed_returns_object_archived() {
+        let d = deps_with();
+        put(&d, "u", ObjectType::SymmetricKey, State::Destroyed);
+        let err = get(&d, GetRequest { uid: "u".into() }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), crate::error::ResultReason::ObjectArchived);
+    }
+
+    #[test]
+    fn get_missing_uid() {
+        let d = deps_with();
+        let err = get(&d, GetRequest { uid: "ghost".into() }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), crate::error::ResultReason::ItemNotFound);
+    }
+}

--- a/kmip/src/ops/helpers.rs
+++ b/kmip/src/ops/helpers.rs
@@ -1,0 +1,161 @@
+//! Shared helpers used by every Plane-2 op handler. Lives outside any
+//! one op file so all 12 handlers can share the audit-emission +
+//! algorithm-string boilerplate without duplication.
+
+use time::OffsetDateTime;
+
+use crate::auditlog::{AuditEvent, EventPayload, KmipOpResult, Plane};
+use crate::error::KmipError;
+use crate::kmip30::KmipAlgorithm;
+
+use super::deps::Deps;
+
+/// Emit a `KmipResponseSent { OperationFailed }` audit event and return
+/// the error unchanged. Every handler's error path goes through this so
+/// the Hub UI always sees a paired Request/Response pair per
+/// `correlation_id`.
+pub fn fail_err(deps: &Deps, correlation_id: &str, op: &str, err: KmipError) -> KmipError {
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipResponseSent {
+            op: op.into(),
+            result: KmipOpResult::OperationFailed {
+                reason: format!("{:?}", err.result_reason()),
+            },
+            latency_ms: 0,
+        },
+    ));
+    err
+}
+
+/// Emit a `KmipResponseSent { Success }` audit event.
+pub fn emit_success(deps: &Deps, correlation_id: &str, op: &str) {
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipResponseSent {
+            op: op.into(),
+            result: KmipOpResult::Success,
+            latency_ms: 0,
+        },
+    ));
+}
+
+/// Emit a `KmipRequestReceived` audit event.
+pub fn emit_request(deps: &Deps, correlation_id: &str, op: &str, summary: String) {
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipRequestReceived {
+            op: op.into(),
+            request_summary: summary,
+            client_cn: None,
+        },
+    ));
+}
+
+/// Emit a `Pkcs11Call` audit event. Phase 7 wires the actual softhsmrustv3
+/// call alongside this emission; v0.1 just records the intent.
+pub fn emit_pkcs11(
+    deps: &Deps,
+    correlation_id: &str,
+    function: &str,
+    mech: Option<u32>,
+    rv: u32,
+    rv_name: &str,
+) {
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Pkcs11,
+        correlation_id,
+        EventPayload::Pkcs11Call {
+            function: function.into(),
+            mechanism: mech.map(|m| format!("CKM_0x{m:04X}")),
+            slot: Some(deps.config.pkcs11_slot),
+            session: None,
+            rv,
+            rv_name: rv_name.into(),
+            latency_ms: 0,
+        },
+    ));
+}
+
+/// Emit a `KmipObjectStateChanged` audit event (KMIP 3.0 §3.x lifecycle).
+pub fn emit_state_change(
+    deps: &Deps,
+    correlation_id: &str,
+    uid: &str,
+    from: &str,
+    to: &str,
+    reason: &str,
+) {
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipObjectStateChanged {
+            uid: uid.into(),
+            from_state: from.into(),
+            to_state: to.into(),
+            reason: reason.into(),
+        },
+    ));
+}
+
+/// Canonical algorithm string used by the policy engine. Mirrors the
+/// `KmipAlgorithm` enum variant names that appear in `policies/*.yaml`.
+///
+/// **Known v0.1 limitation:** classical algos return bare names
+/// (`"ECDSA"`, `"RSA"`, `"AES"`) — no curve/size suffix. Phase 6's store
+/// will add the `Cryptographic Parameters` attribute so the dispatcher
+/// can produce `"ECDSA-P256"` / `"RSA-3072"` / `"AES-256"` from stored
+/// metadata.
+pub fn canonical_name(a: KmipAlgorithm) -> String {
+    use KmipAlgorithm::*;
+    match a {
+        Aes => "AES",
+        Rsa => "RSA",
+        Ecdsa => "ECDSA",
+        HmacSha256 => "HMAC-SHA-256",
+        HmacSha384 => "HMAC-SHA-384",
+        HmacSha512 => "HMAC-SHA-512",
+        Ecdh => "ECDH",
+        MlKem512 => "ML-KEM-512",
+        MlKem768 => "ML-KEM-768",
+        MlKem1024 => "ML-KEM-1024",
+        MlDsa44 => "ML-DSA-44",
+        MlDsa65 => "ML-DSA-65",
+        MlDsa87 => "ML-DSA-87",
+        SlhDsaSha2_128s => "SLH-DSA-SHA2-128s",
+        SlhDsaSha2_128f => "SLH-DSA-SHA2-128f",
+        SlhDsaSha2_192s => "SLH-DSA-SHA2-192s",
+        SlhDsaSha2_192f => "SLH-DSA-SHA2-192f",
+        SlhDsaSha2_256s => "SLH-DSA-SHA2-256s",
+        SlhDsaSha2_256f => "SLH-DSA-SHA2-256f",
+        SlhDsaShake128s => "SLH-DSA-SHAKE-128s",
+        SlhDsaShake128f => "SLH-DSA-SHAKE-128f",
+        SlhDsaShake192s => "SLH-DSA-SHAKE-192s",
+        SlhDsaShake192f => "SLH-DSA-SHAKE-192f",
+        SlhDsaShake256s => "SLH-DSA-SHAKE-256s",
+        SlhDsaShake256f => "SLH-DSA-SHAKE-256f",
+    }
+    .into()
+}
+
+/// State name string for the engine's `state` field — mirrors KMIP 3.0
+/// `State` enum names verbatim.
+pub fn state_name(s: crate::kmip30::State) -> &'static str {
+    use crate::kmip30::State::*;
+    match s {
+        PreActive => "PreActive",
+        Active => "Active",
+        Deactivated => "Deactivated",
+        Compromised => "Compromised",
+        Destroyed => "Destroyed",
+        DestroyedCompromised => "DestroyedCompromised",
+    }
+}

--- a/kmip/src/ops/locate.rs
+++ b/kmip/src/ops/locate.rs
@@ -1,0 +1,217 @@
+//! KMIP 3.0 §6.1.32 **Locate** operation.
+//!
+//! > "This operation requests that the server search for one or more
+//! > Managed Objects, depending on the attributes specified in the
+//! > request."
+//!
+//! Op codepoint `0x08` (verified — `Locate = 0x00000008`).
+//!
+//! ## Plane mapping
+//!
+//! - **Plane 1** — engine.evaluate (rare to gate Locate via policy).
+//! - **Plane 2** — `KeyStore::find` with a predicate built from the
+//!   request's attribute filters. Returns UIDs only — KMIP `Get` is a
+//!   separate op for fetching the full record.
+//! - **Plane 3** — would call `C_FindObjectsInit` + `C_FindObjects` +
+//!   `C_FindObjectsFinal` (PKCS#11 v3.2 §C.5.15-17) against the token to
+//!   confirm the KMIP-store metadata still has live object handles. v0.1
+//!   relies on the KMIP store; Phase 7 wires the PKCS#11 reconciliation.
+
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+use crate::error::Result;
+use crate::kmip30::{Attribute, KmipAlgorithm, LocateRequest, LocateResponse, ObjectType, State};
+use crate::policy::{Decision, PolicyRequest};
+use crate::store::ObjectRecord;
+
+use super::deps::Deps;
+use super::helpers::{emit_pkcs11, emit_request, emit_success, fail_err};
+use crate::error::KmipError;
+
+pub fn locate(deps: &Deps, req: LocateRequest, correlation_id: &str) -> Result<LocateResponse> {
+    let started = OffsetDateTime::now_utc();
+    emit_request(
+        deps,
+        correlation_id,
+        "Locate",
+        format!("filters={} max={:?}", req.attributes.len(), req.maximum_items),
+    );
+
+    // Plane-1 policy gate.
+    let empty: HashMap<String, String> = HashMap::new();
+    let p_req = PolicyRequest::minimal("Locate", None, started, correlation_id, &empty);
+    if let Decision::Deny { human, .. } = deps.engine.evaluate(&p_req) {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "Locate",
+            KmipError::permission_denied(human),
+        ));
+    }
+
+    // Build the predicate from the request's attribute filters.
+    let filters = build_filters(&req.attributes);
+
+    // Plane-3 emit (Phase 7 wires C_FindObjects* reconciliation).
+    emit_pkcs11(
+        deps,
+        correlation_id,
+        "C_FindObjectsInit",
+        None,
+        0,
+        "CKR_OK",
+    );
+
+    // Plane-2: store search.
+    let mut matches = deps.store.find(&|r| filters.matches(r))?;
+
+    // Apply MaximumItems cap.
+    if let Some(max) = req.maximum_items {
+        matches.truncate(max as usize);
+    }
+
+    emit_pkcs11(deps, correlation_id, "C_FindObjectsFinal", None, 0, "CKR_OK");
+    emit_success(deps, correlation_id, "Locate");
+
+    Ok(LocateResponse {
+        uids: matches.into_iter().map(|r| r.uid).collect(),
+    })
+}
+
+/// Attribute filters extracted from the LocateRequest template.
+struct LocateFilters {
+    algorithm: Option<KmipAlgorithm>,
+    object_type: Option<ObjectType>,
+    state: Option<State>,
+}
+
+impl LocateFilters {
+    fn matches(&self, r: &ObjectRecord) -> bool {
+        if let Some(a) = self.algorithm {
+            if r.algorithm != a {
+                return false;
+            }
+        }
+        if let Some(t) = self.object_type {
+            if r.object_type != t {
+                return false;
+            }
+        }
+        if let Some(s) = self.state {
+            if r.state != s {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+fn build_filters(attrs: &[Attribute]) -> LocateFilters {
+    let mut f = LocateFilters {
+        algorithm: None,
+        object_type: None,
+        state: None,
+    };
+    for a in attrs {
+        match a {
+            Attribute::CryptographicAlgorithm(alg) => f.algorithm = Some(*alg),
+            Attribute::ObjectType(t) => f.object_type = Some(*t),
+            Attribute::State(s) => f.state = Some(*s),
+            _ => {}
+        }
+    }
+    f
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::{AuditSink, RingSink};
+    use crate::kmip30::UsageMask;
+    use crate::policy::{load_from_str, Engine};
+    use crate::store::{MemoryStore, ObjectRecord};
+    use std::sync::Arc;
+
+    fn deps_with() -> Deps {
+        let ring = Arc::new(RingSink::new(64));
+        let sink: Arc<dyn AuditSink> = ring.clone();
+        let engine = Engine::with_global_sink(sink.clone());
+        engine
+            .activate(load_from_str(
+                "schema_version: 1\nmetadata: {name: t, description: t, authority: t, effective: always}\nrules: []\n",
+                std::path::Path::new("<t>"),
+            ).unwrap())
+            .unwrap();
+        Deps::new(engine, Arc::new(MemoryStore::new()), sink, super::super::deps::DepsConfig::default())
+    }
+
+    fn put(deps: &Deps, uid: &str, algo: KmipAlgorithm, obj_type: ObjectType, state: State) {
+        deps.store.put(ObjectRecord {
+            uid: uid.into(),
+            object_type: obj_type,
+            algorithm: algo,
+            cryptographic_length: 0,
+            usage_mask: UsageMask::empty(),
+            state,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: None,
+            supersedes: None,
+        }).unwrap();
+    }
+
+    #[test]
+    fn locate_filters_by_algorithm() {
+        let d = deps_with();
+        put(&d, "a", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Active);
+        put(&d, "b", KmipAlgorithm::MlDsa87, ObjectType::PrivateKey, State::Active);
+        let r = locate(&d, LocateRequest {
+            attributes: vec![Attribute::CryptographicAlgorithm(KmipAlgorithm::MlDsa87)],
+            maximum_items: None,
+        }, "c").unwrap();
+        assert_eq!(r.uids, vec!["b"]);
+    }
+
+    #[test]
+    fn locate_filters_by_state() {
+        let d = deps_with();
+        put(&d, "a", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Active);
+        put(&d, "b", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Deactivated);
+        let r = locate(&d, LocateRequest {
+            attributes: vec![Attribute::State(State::Active)],
+            maximum_items: None,
+        }, "c").unwrap();
+        assert_eq!(r.uids, vec!["a"]);
+    }
+
+    #[test]
+    fn locate_combines_filters_with_and() {
+        let d = deps_with();
+        put(&d, "a", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Active);
+        put(&d, "b", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Deactivated);
+        put(&d, "c", KmipAlgorithm::MlDsa87, ObjectType::PrivateKey, State::Active);
+        let r = locate(&d, LocateRequest {
+            attributes: vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
+                Attribute::State(State::Active),
+            ],
+            maximum_items: None,
+        }, "corr").unwrap();
+        assert_eq!(r.uids, vec!["a"]);
+    }
+
+    #[test]
+    fn locate_respects_maximum_items() {
+        let d = deps_with();
+        for i in 0..5 {
+            put(&d, &format!("k{i}"), KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Active);
+        }
+        let r = locate(&d, LocateRequest {
+            attributes: vec![],
+            maximum_items: Some(2),
+        }, "c").unwrap();
+        assert_eq!(r.uids.len(), 2);
+    }
+}

--- a/kmip/src/ops/mod.rs
+++ b/kmip/src/ops/mod.rs
@@ -5,9 +5,13 @@
 //!
 //! | File | KMIP 3.0 § | Op codepoint |
 //! |---|---|---|
+//! | [`activate`]        | 6.1.1  | 0x12 |
 //! | [`query`]           | 6.1.45 | 0x18 |
 //! | [`create_key_pair`] | 6.1.11 | 0x02 |
 //! | [`sign`]            | 6.1.60 | 0x21 |
+//!
+//! Shared helpers (audit emission, canonical algorithm names) live in
+//! [`helpers`] so every op file stays focused on its own KMIP semantics.
 //!
 //! Remaining 9 ops (Create, Get, Locate, Activate, Revoke, Destroy,
 //! Encrypt, Decrypt, SignatureVerify) follow the same template:
@@ -27,8 +31,10 @@
 //! ML-KEM encapsulation reuses `Encrypt`; ML-KEM decapsulation reuses
 //! `Decrypt`. The handler branches on key algorithm.
 
+pub mod activate;
 pub mod create_key_pair;
 pub mod deps;
+pub mod helpers;
 pub mod query;
 pub mod sign;
 

--- a/kmip/src/ops/mod.rs
+++ b/kmip/src/ops/mod.rs
@@ -5,13 +5,22 @@
 //!
 //! | File | KMIP 3.0 § | Op codepoint |
 //! |---|---|---|
-//! | [`activate`]        | 6.1.1  | 0x12 |
-//! | [`query`]           | 6.1.45 | 0x18 |
-//! | [`create_key_pair`] | 6.1.11 | 0x02 |
-//! | [`sign`]            | 6.1.60 | 0x21 |
+//! | [`activate`]          | 6.1.1  | 0x12 |
+//! | [`create`]            | 6.1.8  | 0x01 |
+//! | [`create_key_pair`]   | 6.1.11 | 0x02 |
+//! | [`decrypt`]           | 6.1.15 | 0x20 |
+//! | [`destroy`]           | 6.1.19 | 0x14 |
+//! | [`encrypt`]           | 6.1.21 | 0x1f |
+//! | [`get`]               | 6.1.23 | 0x0a |
+//! | [`locate`]            | 6.1.32 | 0x08 |
+//! | [`query`]             | 6.1.45 | 0x18 |
+//! | [`revoke`]            | 6.1.49 | 0x13 |
+//! | [`sign`]              | 6.1.60 | 0x21 |
+//! | [`signature_verify`]  | 6.1.61 | 0x22 |
 //!
-//! Shared helpers (audit emission, canonical algorithm names) live in
-//! [`helpers`] so every op file stays focused on its own KMIP semantics.
+//! All 12 v0.1 KMIP ops shipped. Shared helpers (audit emission, canonical
+//! algorithm names) live in [`helpers`] so every op file stays focused on
+//! its own KMIP semantics.
 //!
 //! Remaining 9 ops (Create, Get, Locate, Activate, Revoke, Destroy,
 //! Encrypt, Decrypt, SignatureVerify) follow the same template:
@@ -32,10 +41,18 @@
 //! `Decrypt`. The handler branches on key algorithm.
 
 pub mod activate;
+pub mod create;
 pub mod create_key_pair;
+pub mod decrypt;
 pub mod deps;
+pub mod destroy;
+pub mod encrypt;
+pub mod get;
 pub mod helpers;
+pub mod locate;
 pub mod query;
+pub mod revoke;
 pub mod sign;
+pub mod signature_verify;
 
 pub use deps::{Deps, DepsConfig};

--- a/kmip/src/ops/mod.rs
+++ b/kmip/src/ops/mod.rs
@@ -1,11 +1,35 @@
-//! Plane 2 — KMIP operation handlers (one file per op, ≤100 LOC each).
+//! Plane 2 — KMIP 3.0 operation handlers.
 //!
-//! v0.1 op set per `docs/IMPLEMENTATION_PLAN.md` §6 Phase 5:
-//! `query`, `create_sym`, `create_asym`, `get`, `locate`, `activate`, `revoke`,
-//! `destroy`, `encrypt`, `decrypt`, `sign`, `signature_verify`.
+//! Each handler is one file (≤ ~250 LOC including tests + spec citations).
+//! The set Phase 5 ships in this session:
 //!
-//! Note: KMIP 3.0 does NOT add separate `Encapsulate` / `Decapsulate` ops. ML-KEM
-//! encapsulation reuses `Encrypt`; ML-KEM decapsulation reuses `Decrypt`. The
-//! handler branches on key algorithm.
+//! | File | KMIP 3.0 § | Op codepoint |
+//! |---|---|---|
+//! | [`query`]           | 6.1.45 | 0x18 |
+//! | [`create_key_pair`] | 6.1.11 | 0x02 |
+//! | [`sign`]            | 6.1.60 | 0x21 |
 //!
-//! Phase 0 (bootstrap): module declared, no implementations. Lands in Phase 5.
+//! Remaining 9 ops (Create, Get, Locate, Activate, Revoke, Destroy,
+//! Encrypt, Decrypt, SignatureVerify) follow the same template:
+//!
+//! 1. Emit Plane-2 `KmipRequestReceived`.
+//! 2. Pre-flight store lookup + lifecycle gate (per `docs/IMPLEMENTATION_PLAN.md` §3.4).
+//! 3. Call `deps.engine.evaluate(&policy_request)`.
+//! 4. Map `(KmipAlgorithm, PkcsOp) → CKM_*` via
+//!    `KmipAlgorithm::to_pkcs11_mech` (Phase 3).
+//! 5. Emit Plane-3 `Pkcs11Call`s; call the bridge (Phase 7 wires real
+//!    softhsmrustv3 entries; v0.1 uses placeholders so tests run without
+//!    a token).
+//! 6. Persist any store mutations.
+//! 7. Emit Plane-2 `KmipResponseSent`.
+//!
+//! Note: KMIP 3.0 does NOT add separate `Encapsulate` / `Decapsulate` ops.
+//! ML-KEM encapsulation reuses `Encrypt`; ML-KEM decapsulation reuses
+//! `Decrypt`. The handler branches on key algorithm.
+
+pub mod create_key_pair;
+pub mod deps;
+pub mod query;
+pub mod sign;
+
+pub use deps::{Deps, DepsConfig};

--- a/kmip/src/ops/query.rs
+++ b/kmip/src/ops/query.rs
@@ -1,0 +1,167 @@
+//! KMIP 3.0 §6.1.45 **Query** operation.
+//!
+//! > "This operation is used by the client to interrogate the server to
+//! > determine its capabilities and/or protocol mechanisms."
+//!
+//! Wire-format op codepoint `0x18` (verified against
+//! `spec/oasis-kmip-3.0/kmip-spec-3.0-tags-enums.json`, `Operation` enum,
+//! `Query = 0x00000018`).
+//!
+//! ## Plane mapping
+//!
+//! - **Plane 1** — engine.evaluate gate. Query against an existing object
+//!   is rare; usually no algorithm is in the request.
+//! - **Plane 2** — assembles the response from the in-process config +
+//!   the static op/object-type capability list.
+//! - **Plane 3** — would call `C_GetInfo` (PKCS#11 v3.2 §C.5.3) and
+//!   `C_GetMechanismList` (§C.5.4) for capability discovery. v0.1 returns
+//!   the static capability set + the constant
+//!   [`DepsConfig::vendor_identification`] / `server_version`. A future
+//!   revision can call into the bridge for live mech-list reflection.
+
+use crate::auditlog::{AuditEvent, EventPayload, KmipOpResult, Plane};
+use crate::error::Result;
+use crate::kmip30::{
+    ObjectType, Operation, QueryFunction, QueryRequest, QueryResponse, ServerInformation,
+};
+use time::OffsetDateTime;
+
+use super::deps::Deps;
+
+/// Handle a `Query` request.
+///
+/// `correlation_id` is the per-request identifier stamped on every emitted
+/// audit event so the Hub UI can group rows.
+pub fn query(deps: &Deps, req: QueryRequest, correlation_id: &str) -> Result<QueryResponse> {
+    let started = OffsetDateTime::now_utc();
+
+    // Plane-2: emit RequestReceived
+    deps.sink.emit(AuditEvent::at(
+        started,
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipRequestReceived {
+            op: "Query".into(),
+            request_summary: format!("functions={:?}", req.functions),
+            client_cn: None,
+        },
+    ));
+
+    // Build the response per the requested QueryFunctions. KMIP 3.0
+    // §6.1.45 — each function maps to an optional response field.
+    let mut resp = QueryResponse {
+        operations: None,
+        object_types: None,
+        server_info: None,
+    };
+
+    for f in &req.functions {
+        match f {
+            QueryFunction::QueryOperations => {
+                resp.operations = Some(supported_operations());
+            }
+            QueryFunction::QueryObjects => {
+                resp.object_types = Some(supported_object_types());
+            }
+            QueryFunction::QueryServerInformation => {
+                resp.server_info = Some(ServerInformation {
+                    vendor_identification: deps.config.vendor_identification.clone(),
+                    server_version: deps.config.server_version.clone(),
+                });
+            }
+            QueryFunction::QueryApplicationNamespaces
+            | QueryFunction::QueryProfiles
+            | QueryFunction::QueryCapabilities => {
+                // v0.1 returns nothing for these — Phase 8 (compliance tool)
+                // fills in profile reporting.
+            }
+        }
+    }
+
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipResponseSent {
+            op: "Query".into(),
+            result: KmipOpResult::Success,
+            latency_ms: 0,
+        },
+    ));
+
+    Ok(resp)
+}
+
+/// v0.1 operation capability list — the 12 ops Phase 5 implements.
+fn supported_operations() -> Vec<Operation> {
+    vec![
+        Operation::Query,
+        Operation::Create,
+        Operation::CreateKeyPair,
+        Operation::Get,
+        Operation::Locate,
+        Operation::Activate,
+        Operation::Revoke,
+        Operation::Destroy,
+        Operation::Encrypt,
+        Operation::Decrypt,
+        Operation::Sign,
+        Operation::SignatureVerify,
+    ]
+}
+
+/// v0.1 object types the server understands.
+fn supported_object_types() -> Vec<ObjectType> {
+    vec![
+        ObjectType::SymmetricKey,
+        ObjectType::PublicKey,
+        ObjectType::PrivateKey,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::RingSink;
+    use crate::store::MemoryStore;
+    use std::sync::Arc;
+
+    fn deps() -> (Arc<RingSink>, Deps) {
+        let ring = Arc::new(RingSink::new(64));
+        let d = Deps::new(
+            crate::policy::Engine::permissive(),
+            Arc::new(MemoryStore::new()),
+            ring.clone(),
+            super::super::deps::DepsConfig::default(),
+        );
+        (ring, d)
+    }
+
+    #[test]
+    fn query_operations_returns_v01_op_set() {
+        let (_ring, d) = deps();
+        let resp = query(&d, QueryRequest { functions: vec![QueryFunction::QueryOperations] }, "corr-q").unwrap();
+        let ops = resp.operations.unwrap();
+        assert_eq!(ops.len(), 12);
+        assert!(ops.contains(&Operation::Sign));
+        assert!(ops.contains(&Operation::Encrypt));
+        assert!(ops.contains(&Operation::Decrypt));
+    }
+
+    #[test]
+    fn query_server_info_uses_deps_config() {
+        let (_ring, d) = deps();
+        let resp = query(&d, QueryRequest { functions: vec![QueryFunction::QueryServerInformation] }, "corr-s").unwrap();
+        let info = resp.server_info.unwrap();
+        assert_eq!(info.vendor_identification, "pqctoday-hsm");
+        assert_eq!(info.server_version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn query_emits_p2_audit_events() {
+        let (ring, d) = deps();
+        let _ = query(&d, QueryRequest { functions: vec![QueryFunction::QueryObjects] }, "corr-a").unwrap();
+        let p2 = ring.filter_plane(Plane::Kmip);
+        assert_eq!(p2.len(), 2); // RequestReceived + ResponseSent
+    }
+}

--- a/kmip/src/ops/revoke.rs
+++ b/kmip/src/ops/revoke.rs
@@ -1,0 +1,171 @@
+//! KMIP 3.0 §6.1.49 **Revoke** operation.
+//!
+//! > "This operation requests the server to revoke a Managed Cryptographic
+//! > Object or an Opaque Object."
+//!
+//! Op codepoint `0x13` (verified — `Revoke = 0x00000013` in
+//! `kmip-spec-3.0-tags-enums.json`).
+//!
+//! ## Plane mapping
+//!
+//! - **Plane 1** — engine.evaluate; policies can deny Revoke on certain
+//!   algorithm classes or require attribute predicates.
+//! - **Plane 2** — lifecycle FSM (per `docs/IMPLEMENTATION_PLAN.md` §3.4):
+//!   `Active → Deactivated` (default) or `Active → Compromised` (when
+//!   `revocation_reason ∈ { KeyCompromise, CaCompromise }`). Other source
+//!   states rejected with `PermissionDenied`.
+//! - **Plane 3** — none. Revoke is a KMIP-only concept; PKCS#11 has no
+//!   equivalent op.
+
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+use crate::error::{KmipError, Result};
+use crate::kmip30::{RevocationReason, RevokeRequest, RevokeResponse, State};
+use crate::policy::{Decision, PolicyRequest};
+
+use super::deps::Deps;
+use super::helpers::{
+    canonical_name, emit_request, emit_state_change, emit_success, fail_err, state_name,
+};
+
+pub fn revoke(deps: &Deps, req: RevokeRequest, correlation_id: &str) -> Result<RevokeResponse> {
+    let started = OffsetDateTime::now_utc();
+    emit_request(
+        deps,
+        correlation_id,
+        "Revoke",
+        format!("uid={} reason={:?}", req.uid, req.reason),
+    );
+
+    let mut obj = deps
+        .store
+        .get(&req.uid)?
+        .ok_or_else(|| fail_err(deps, correlation_id, "Revoke", KmipError::not_found(&req.uid)))?;
+
+    // KMIP 3.0 §3.x — Revoke is only valid from Active.
+    if obj.state != State::Active {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "Revoke",
+            KmipError::permission_denied(format!(
+                "Revoke requires Active; UID {} is in {:?}",
+                req.uid, obj.state
+            )),
+        ));
+    }
+
+    // Plane-1 policy gate.
+    let empty: HashMap<String, String> = HashMap::new();
+    let algo = canonical_name(obj.algorithm);
+    let mut p_req = PolicyRequest::minimal("Revoke", Some(&algo), started, correlation_id, &empty);
+    p_req.state = Some(state_name(obj.state));
+    p_req.target_uid = Some(&req.uid);
+    if let Decision::Deny { human, .. } = deps.engine.evaluate(&p_req) {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "Revoke",
+            KmipError::permission_denied(human),
+        ));
+    }
+
+    // Lifecycle transition. KeyCompromise / CaCompromise → Compromised;
+    // every other RevocationReason → Deactivated.
+    let target_state = match req.reason {
+        RevocationReason::KeyCompromise | RevocationReason::CaCompromise => State::Compromised,
+        _ => State::Deactivated,
+    };
+    let from_label = state_name(obj.state).to_string();
+    let to_label = state_name(target_state).to_string();
+    obj.state = target_state;
+    deps.store.update(obj)?;
+
+    emit_state_change(
+        deps,
+        correlation_id,
+        &req.uid,
+        &from_label,
+        &to_label,
+        &format!("KMIP Revoke op (reason {:?})", req.reason),
+    );
+    emit_success(deps, correlation_id, "Revoke");
+
+    Ok(RevokeResponse {
+        uid: req.uid,
+        state: target_state,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::{AuditSink, RingSink};
+    use crate::kmip30::{KmipAlgorithm, ObjectType, UsageMask};
+    use crate::policy::{load_from_str, Engine};
+    use crate::store::{MemoryStore, ObjectRecord};
+    use std::sync::Arc;
+
+    fn deps_with(yaml: &str) -> Deps {
+        let ring = Arc::new(RingSink::new(64));
+        let sink: Arc<dyn AuditSink> = ring.clone();
+        let engine = Engine::with_global_sink(sink.clone());
+        engine.activate(load_from_str(yaml, std::path::Path::new("<t>")).unwrap()).unwrap();
+        Deps::new(engine, Arc::new(MemoryStore::new()), sink, super::super::deps::DepsConfig::default())
+    }
+
+    fn active(deps: &Deps, uid: &str) {
+        deps.store.put(ObjectRecord {
+            uid: uid.into(),
+            object_type: ObjectType::PrivateKey,
+            algorithm: KmipAlgorithm::MlDsa87,
+            cryptographic_length: 0,
+            usage_mask: UsageMask::SIGN | UsageMask::VERIFY,
+            state: State::Active,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: Some(OffsetDateTime::UNIX_EPOCH),
+            supersedes: None,
+        }).unwrap();
+    }
+
+    const ALLOW: &str = "schema_version: 1\nmetadata: {name: t, description: t, authority: t, effective: always}\nrules: []\n";
+
+    #[test]
+    fn unspecified_reason_yields_deactivated() {
+        let d = deps_with(ALLOW);
+        active(&d, "u");
+        let resp = revoke(&d, RevokeRequest { uid: "u".into(), reason: RevocationReason::Unspecified }, "c").unwrap();
+        assert_eq!(resp.state, State::Deactivated);
+    }
+
+    #[test]
+    fn key_compromise_yields_compromised() {
+        let d = deps_with(ALLOW);
+        active(&d, "u2");
+        let resp = revoke(&d, RevokeRequest { uid: "u2".into(), reason: RevocationReason::KeyCompromise }, "c").unwrap();
+        assert_eq!(resp.state, State::Compromised);
+    }
+
+    #[test]
+    fn revoke_from_pre_active_rejected() {
+        let d = deps_with(ALLOW);
+        d.store.put(ObjectRecord {
+            uid: "p".into(),
+            object_type: ObjectType::PrivateKey,
+            algorithm: KmipAlgorithm::MlDsa87,
+            cryptographic_length: 0,
+            usage_mask: UsageMask::SIGN,
+            state: State::PreActive,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: None,
+            supersedes: None,
+        }).unwrap();
+        let err = revoke(&d, RevokeRequest { uid: "p".into(), reason: RevocationReason::Unspecified }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), crate::error::ResultReason::PermissionDenied);
+    }
+}

--- a/kmip/src/ops/sign.rs
+++ b/kmip/src/ops/sign.rs
@@ -1,0 +1,383 @@
+//! KMIP 3.0 §6.1.60 **Sign** operation.
+//!
+//! > "This operation requests the server to perform a signature operation
+//! > on the provided data using the specified signing key."
+//!
+//! Op codepoint `0x21` (verified — `Sign = 0x00000021` in the spec's
+//! `Operation` enum extract).
+//!
+//! ## Plane mapping
+//!
+//! - **Plane 1** — engine.evaluate with `op="Sign"`, `algorithm =
+//!   <stored key's algorithm>`, `current_object_algorithm = <same>`,
+//!   `target_uid = <KMIP UID>`. The engine may emit
+//!   [`Decision::RekeyAndProceed`] when policy substitutes the stored
+//!   algorithm to something else — Phase 5 handles this by returning a
+//!   typed error that the dispatcher / Phase 6 will translate into the
+//!   actual multi-op rekey transaction (out of scope for Phase 5 op
+//!   bodies; this handler just surfaces the rekey requirement).
+//! - **Plane 2** — store lookup + lifecycle gate (KMIP 3.0 §3.x: only
+//!   `Active` state may sign — see `docs/IMPLEMENTATION_PLAN.md` §3.4).
+//! - **Plane 3** — would call `C_SignInit` (PKCS#11 v3.2 §C.6.5) and
+//!   `C_Sign` (§C.6.6). Signatures verified against
+//!   `rust/src/ffi.rs::{C_SignInit, C_Sign}`. v0.1 produces a deterministic
+//!   placeholder signature so the response builder can be exercised;
+//!   Phase 7 wires the real bridge call.
+
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+use crate::auditlog::{AuditEvent, EventPayload, KmipOpResult, Plane};
+use crate::error::{KmipError, Result, ResultReason};
+use crate::kmip30::{PkcsOp, SignRequest, SignResponse, State};
+use crate::policy::{Decision, PolicyRequest};
+
+use super::deps::Deps;
+
+pub fn sign(deps: &Deps, req: SignRequest, correlation_id: &str) -> Result<SignResponse> {
+    let started = OffsetDateTime::now_utc();
+    deps.sink.emit(AuditEvent::at(
+        started,
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipRequestReceived {
+            op: "Sign".into(),
+            request_summary: format!("uid={} data_len={}", req.uid, req.data.len()),
+            client_cn: None,
+        },
+    ));
+
+    // ── Plane 2: store lookup ───────────────────────────────────────────
+    let obj = deps
+        .store
+        .get(&req.uid)?
+        .ok_or_else(|| fail_err(deps, correlation_id, "Sign", KmipError::not_found(&req.uid)))?;
+
+    // ── Lifecycle gate (KMIP 3.0 §3.x — Sign requires Active) ───────────
+    if obj.state != State::Active {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "Sign",
+            KmipError::object_archived(&req.uid),
+        ));
+    }
+
+    // ── Plane 1: policy gate ────────────────────────────────────────────
+    let empty: HashMap<String, String> = HashMap::new();
+    let stored_algo = canonical_name(obj.algorithm);
+    let mut p_req = PolicyRequest::minimal(
+        "Sign",
+        Some(&stored_algo),
+        started,
+        correlation_id,
+        &empty,
+    );
+    p_req.usage_mask = Some(obj.usage_mask);
+    p_req.state = Some("Active");
+    p_req.current_object_algorithm = Some(&stored_algo);
+    p_req.target_uid = Some(&req.uid);
+
+    let mech = match deps.engine.evaluate(&p_req) {
+        Decision::Allow { algorithm_override: None, .. } => {
+            // Pass-through — use stored algorithm.
+            obj.algorithm.to_pkcs11_mech(PkcsOp::SignVerify).ok_or_else(|| {
+                KmipError::failed(
+                    ResultReason::OperationNotSupported,
+                    format!("algorithm {:?} has no Sign mechanism", obj.algorithm),
+                )
+            })?
+        }
+        Decision::Allow { algorithm_override: Some(other), .. } => {
+            // Policy rewrote the algorithm but the stored key matches the
+            // rewrite — proceed. (If the rewrite differed from the stored
+            // algorithm, the engine would have emitted RekeyAndProceed.)
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Sign",
+                KmipError::internal(format!(
+                    "policy override {other:?} for Sign without rekey path"
+                )),
+            ));
+        }
+        Decision::Deny { human, .. } => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Sign",
+                KmipError::permission_denied(human),
+            ));
+        }
+        Decision::RekeyAndProceed { new_algorithm, original_uid, .. } => {
+            // Policy demands rekey before sign. Phase 5 op bodies do not
+            // execute the multi-op rekey transaction (that's a dispatcher
+            // concern in Phase 6/7). Surface a typed error so the caller
+            // knows to either run the rekey transaction or bail.
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Sign",
+                KmipError::failed(
+                    ResultReason::PermissionDenied,
+                    format!(
+                        "rekey required: policy substitutes {} → {} for UID {}",
+                        canonical_name(obj.algorithm),
+                        new_algorithm,
+                        original_uid,
+                    ),
+                ),
+            ));
+        }
+    };
+
+    // ── Plane 3: emit (would call C_SignInit + C_Sign) ──────────────────
+    let mech_name = format!("CKM_0x{mech:04X}");
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Pkcs11,
+        correlation_id,
+        EventPayload::Pkcs11Call {
+            function: "C_SignInit".into(),
+            mechanism: Some(mech_name.clone()),
+            slot: Some(deps.config.pkcs11_slot),
+            session: None,
+            rv: 0,
+            rv_name: "CKR_OK".into(),
+            latency_ms: 0,
+        },
+    ));
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Pkcs11,
+        correlation_id,
+        EventPayload::Pkcs11Call {
+            function: "C_Sign".into(),
+            mechanism: Some(mech_name),
+            slot: Some(deps.config.pkcs11_slot),
+            session: None,
+            rv: 0,
+            rv_name: "CKR_OK".into(),
+            latency_ms: 0,
+        },
+    ));
+
+    // v0.1 placeholder signature — Phase 7 wires the real call.
+    let signature = placeholder_signature(&req.uid, &req.data);
+
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipResponseSent {
+            op: "Sign".into(),
+            result: KmipOpResult::Success,
+            latency_ms: 0,
+        },
+    ));
+
+    Ok(SignResponse {
+        uid: req.uid,
+        signature,
+    })
+}
+
+fn placeholder_signature(uid: &str, data: &[u8]) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(uid.as_bytes());
+    h.update(data);
+    h.finalize().to_vec()
+}
+
+fn fail_err(deps: &Deps, correlation_id: &str, op: &str, err: KmipError) -> KmipError {
+    deps.sink.emit(AuditEvent::at(
+        OffsetDateTime::now_utc(),
+        Plane::Kmip,
+        correlation_id,
+        EventPayload::KmipResponseSent {
+            op: op.into(),
+            result: KmipOpResult::OperationFailed {
+                reason: format!("{:?}", err.result_reason()),
+            },
+            latency_ms: 0,
+        },
+    ));
+    err
+}
+
+/// Mirror of `create_key_pair::canonical_name` — duplicated here to keep
+/// the op file self-contained (each op is ≤ ~250 LOC per the plan).
+/// A future refactor can lift this into `kmip30::algos`.
+fn canonical_name(a: crate::kmip30::KmipAlgorithm) -> String {
+    use crate::kmip30::KmipAlgorithm::*;
+    match a {
+        Aes => "AES",
+        Rsa => "RSA",
+        Ecdsa => "ECDSA",
+        HmacSha256 => "HMAC-SHA-256",
+        HmacSha384 => "HMAC-SHA-384",
+        HmacSha512 => "HMAC-SHA-512",
+        Ecdh => "ECDH",
+        MlKem512 => "ML-KEM-512",
+        MlKem768 => "ML-KEM-768",
+        MlKem1024 => "ML-KEM-1024",
+        MlDsa44 => "ML-DSA-44",
+        MlDsa65 => "ML-DSA-65",
+        MlDsa87 => "ML-DSA-87",
+        SlhDsaSha2_128s => "SLH-DSA-SHA2-128s",
+        SlhDsaSha2_128f => "SLH-DSA-SHA2-128f",
+        SlhDsaSha2_192s => "SLH-DSA-SHA2-192s",
+        SlhDsaSha2_192f => "SLH-DSA-SHA2-192f",
+        SlhDsaSha2_256s => "SLH-DSA-SHA2-256s",
+        SlhDsaSha2_256f => "SLH-DSA-SHA2-256f",
+        SlhDsaShake128s => "SLH-DSA-SHAKE-128s",
+        SlhDsaShake128f => "SLH-DSA-SHAKE-128f",
+        SlhDsaShake192s => "SLH-DSA-SHAKE-192s",
+        SlhDsaShake192f => "SLH-DSA-SHAKE-192f",
+        SlhDsaShake256s => "SLH-DSA-SHAKE-256s",
+        SlhDsaShake256f => "SLH-DSA-SHAKE-256f",
+    }
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::RingSink;
+    use crate::kmip30::{KmipAlgorithm, ObjectType, UsageMask};
+    use crate::policy::{load_from_str, Engine};
+    use crate::store::{MemoryStore, ObjectRecord};
+    use std::sync::Arc;
+
+    fn deps_with(yaml: &str) -> (Arc<RingSink>, Deps) {
+        let ring = Arc::new(RingSink::new(64));
+        let sink: Arc<dyn crate::auditlog::AuditSink> = ring.clone();
+        let engine = Engine::with_global_sink(sink.clone());
+        engine
+            .activate(load_from_str(yaml, std::path::Path::new("<test>")).unwrap())
+            .unwrap();
+        (
+            ring,
+            Deps::new(
+                engine,
+                Arc::new(MemoryStore::new()),
+                sink,
+                super::super::deps::DepsConfig::default(),
+            ),
+        )
+    }
+
+    fn make_active_key(deps: &Deps, uid: &str, algo: KmipAlgorithm) {
+        let rec = ObjectRecord {
+            uid: uid.into(),
+            object_type: ObjectType::PrivateKey,
+            algorithm: algo,
+            cryptographic_length: 0,
+            usage_mask: UsageMask::SIGN | UsageMask::VERIFY,
+            state: State::Active,
+            pkcs11_cka_id: vec![1, 2, 3],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: Some(OffsetDateTime::UNIX_EPOCH),
+            supersedes: None,
+        };
+        deps.store.put(rec).unwrap();
+    }
+
+    const PERMISSIVE: &str = r#"
+schema_version: 1
+metadata: { name: p, description: p, authority: t, effective: "always" }
+rules: []
+"#;
+
+    // NOTE: canonical_name(KmipAlgorithm::Ecdsa) returns "ECDSA" (bare,
+    // no curve) because the Phase-5 store record doesn't carry curve
+    // metadata yet — Phase 6 adds the `Cryptographic Parameters` attribute
+    // surface so the dispatcher can canonicalise to "ECDSA-P256". Test
+    // policy uses the bare name until then.
+    const REKEY_POLICY: &str = r#"
+schema_version: 1
+metadata: { name: rk, description: rekey, authority: t, effective: "always" }
+rules:
+  - type: algorithm_substitution
+    ops: [Sign]
+    from: ECDSA
+    to: ML-DSA-87
+    reason: "Upgrade signing"
+"#;
+
+    #[test]
+    fn happy_path_returns_signature_and_emits_three_planes() {
+        let (ring, d) = deps_with(PERMISSIVE);
+        make_active_key(&d, "urn:uid:1", KmipAlgorithm::MlDsa87);
+        let resp = sign(
+            &d,
+            SignRequest {
+                uid: "urn:uid:1".into(),
+                data: b"hello".to_vec(),
+            },
+            "corr-sign",
+        )
+        .unwrap();
+        assert_eq!(resp.uid, "urn:uid:1");
+        assert_eq!(resp.signature.len(), 32); // sha256 placeholder
+        // p1 (policy activation + decision), p2 (req + resp), p3 (init + sign)
+        assert!(ring.filter_plane(Plane::Agility).len() >= 2);
+        assert_eq!(ring.filter_plane(Plane::Kmip).len(), 2);
+        assert_eq!(ring.filter_plane(Plane::Pkcs11).len(), 2);
+    }
+
+    #[test]
+    fn missing_uid_returns_item_not_found() {
+        let (_ring, d) = deps_with(PERMISSIVE);
+        let err = sign(
+            &d,
+            SignRequest { uid: "urn:nope".into(), data: vec![] },
+            "corr-404",
+        )
+        .unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::ItemNotFound);
+    }
+
+    #[test]
+    fn non_active_key_returns_object_archived() {
+        let (_ring, d) = deps_with(PERMISSIVE);
+        // Insert a PreActive key.
+        let rec = ObjectRecord {
+            uid: "urn:pre".into(),
+            object_type: ObjectType::PrivateKey,
+            algorithm: KmipAlgorithm::MlDsa87,
+            cryptographic_length: 0,
+            usage_mask: UsageMask::SIGN,
+            state: State::PreActive,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: None,
+            supersedes: None,
+        };
+        d.store.put(rec).unwrap();
+        let err = sign(&d, SignRequest { uid: "urn:pre".into(), data: vec![] }, "corr").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::ObjectArchived);
+    }
+
+    #[test]
+    fn rekey_required_surfaces_permission_denied_with_hint() {
+        let (_ring, d) = deps_with(REKEY_POLICY);
+        // Existing ECDSA key — policy says substitute to ML-DSA-87 → engine
+        // emits RekeyAndProceed → handler returns PermissionDenied with
+        // an actionable message.
+        make_active_key(&d, "urn:ecdsa", KmipAlgorithm::Ecdsa);
+        let err = sign(
+            &d,
+            SignRequest { uid: "urn:ecdsa".into(), data: b"x".to_vec() },
+            "corr-rk",
+        )
+        .unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::PermissionDenied);
+        let s = err.to_string();
+        assert!(s.contains("rekey required"));
+        assert!(s.contains("ML-DSA-87"));
+    }
+}

--- a/kmip/src/ops/signature_verify.rs
+++ b/kmip/src/ops/signature_verify.rs
@@ -1,0 +1,231 @@
+//! KMIP 3.0 §6.1.61 **Signature Verify** operation.
+//!
+//! > "This operation requests the server to perform a signature verify
+//! > operation on the provided data using the specified verification key."
+//!
+//! Op codepoint `0x22` (verified — `Signature Verify = 0x00000022`).
+//!
+//! ## KMIP design point
+//!
+//! A failed verification is **not** a KMIP error — it returns a successful
+//! `Signature Verify` response with `validity = Invalid`. KMIP errors are
+//! reserved for protocol-level failures (missing UID, archived key,
+//! policy denial, etc.).
+//!
+//! ## Plane mapping
+//!
+//! - **Plane 1** — engine.evaluate; policies may gate verify on certain
+//!   algorithms (e.g. denying MD5 / SHA-1 verification under a strict
+//!   compliance profile).
+//! - **Plane 2** — store lookup + lifecycle gate. Per §3.4 table:
+//!   `Active`, `Deactivated`, `Compromised` all permit verify (verifying
+//!   legacy signatures is required even after key rotation).
+//! - **Plane 3** — would call `C_VerifyInit` (PKCS#11 v3.2 §C.6.7) +
+//!   `C_Verify` (§C.6.8). Signatures verified against
+//!   `rust/src/ffi.rs::{C_VerifyInit, C_Verify}`. v0.1 placeholder
+//!   re-runs the SHA-256 stamp from `sign.rs` to determine validity.
+
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+use crate::error::{KmipError, Result, ResultReason};
+use crate::kmip30::{PkcsOp, SignatureValidity, SignatureVerifyRequest, SignatureVerifyResponse, State};
+use crate::policy::{Decision, PolicyRequest};
+
+use super::deps::Deps;
+use super::helpers::{canonical_name, emit_pkcs11, emit_request, emit_success, fail_err, state_name};
+
+pub fn signature_verify(
+    deps: &Deps,
+    req: SignatureVerifyRequest,
+    correlation_id: &str,
+) -> Result<SignatureVerifyResponse> {
+    let started = OffsetDateTime::now_utc();
+    emit_request(
+        deps,
+        correlation_id,
+        "SignatureVerify",
+        format!("uid={} data_len={} sig_len={}", req.uid, req.data.len(), req.signature.len()),
+    );
+
+    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
+        fail_err(deps, correlation_id, "SignatureVerify", KmipError::not_found(&req.uid))
+    })?;
+
+    // KMIP 3.0 §3.x lifecycle — Verify allowed in Active / Deactivated /
+    // Compromised (need to verify legacy artefacts). Blocked in PreActive
+    // (no key material yet) and Destroyed.
+    match obj.state {
+        State::Active | State::Deactivated | State::Compromised => {}
+        _ => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "SignatureVerify",
+                KmipError::object_archived(&req.uid),
+            ));
+        }
+    }
+
+    // Plane-1 policy gate.
+    let empty: HashMap<String, String> = HashMap::new();
+    let algo = canonical_name(obj.algorithm);
+    let mut p_req = PolicyRequest::minimal(
+        "SignatureVerify",
+        Some(&algo),
+        started,
+        correlation_id,
+        &empty,
+    );
+    p_req.usage_mask = Some(obj.usage_mask);
+    p_req.state = Some(state_name(obj.state));
+    p_req.target_uid = Some(&req.uid);
+    if let Decision::Deny { human, .. } = deps.engine.evaluate(&p_req) {
+        return Err(fail_err(
+            deps,
+            correlation_id,
+            "SignatureVerify",
+            KmipError::permission_denied(human),
+        ));
+    }
+
+    // Plane-3: emit (Phase 7 wires C_VerifyInit + C_Verify).
+    let mech = obj.algorithm.to_pkcs11_mech(PkcsOp::SignVerify).ok_or_else(|| {
+        KmipError::failed(
+            ResultReason::OperationNotSupported,
+            format!("algorithm {:?} has no Verify mechanism", obj.algorithm),
+        )
+    })?;
+    emit_pkcs11(deps, correlation_id, "C_VerifyInit", Some(mech), 0, "CKR_OK");
+
+    // v0.1 placeholder: re-compute the SHA-256 stamp sign.rs uses and
+    // compare. Phase 7 replaces with the real C_Verify call and returns
+    // Invalid on CKR_SIGNATURE_INVALID (and Unknown on other CKRs).
+    let expected = placeholder_signature(&req.uid, &req.data);
+    let validity = if req.signature == expected {
+        SignatureValidity::Valid
+    } else {
+        SignatureValidity::Invalid
+    };
+    emit_pkcs11(deps, correlation_id, "C_Verify", Some(mech), 0, "CKR_OK");
+    emit_success(deps, correlation_id, "SignatureVerify");
+
+    Ok(SignatureVerifyResponse { uid: req.uid, validity })
+}
+
+fn placeholder_signature(uid: &str, data: &[u8]) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(uid.as_bytes());
+    h.update(data);
+    h.finalize().to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::{AuditSink, RingSink};
+    use crate::kmip30::{KmipAlgorithm, ObjectType, UsageMask};
+    use crate::policy::{load_from_str, Engine};
+    use crate::store::{MemoryStore, ObjectRecord};
+    use std::sync::Arc;
+
+    fn deps_with() -> Deps {
+        let ring = Arc::new(RingSink::new(64));
+        let sink: Arc<dyn AuditSink> = ring.clone();
+        let engine = Engine::with_global_sink(sink.clone());
+        engine
+            .activate(load_from_str(
+                "schema_version: 1\nmetadata: {name: t, description: t, authority: t, effective: always}\nrules: []\n",
+                std::path::Path::new("<t>"),
+            ).unwrap())
+            .unwrap();
+        Deps::new(engine, Arc::new(MemoryStore::new()), sink, super::super::deps::DepsConfig::default())
+    }
+
+    fn active(deps: &Deps, uid: &str) {
+        deps.store.put(ObjectRecord {
+            uid: uid.into(),
+            object_type: ObjectType::PublicKey,
+            algorithm: KmipAlgorithm::MlDsa87,
+            cryptographic_length: 0,
+            usage_mask: UsageMask::SIGN | UsageMask::VERIFY,
+            state: State::Active,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: Some(OffsetDateTime::UNIX_EPOCH),
+            supersedes: None,
+        }).unwrap();
+    }
+
+    #[test]
+    fn verify_matching_signature_returns_valid() {
+        let d = deps_with();
+        active(&d, "u");
+        let data = b"hello world".to_vec();
+        let sig = placeholder_signature("u", &data);
+        let r = signature_verify(&d, SignatureVerifyRequest { uid: "u".into(), data, signature: sig }, "c").unwrap();
+        assert_eq!(r.validity, SignatureValidity::Valid);
+    }
+
+    #[test]
+    fn verify_wrong_signature_returns_invalid_not_error() {
+        let d = deps_with();
+        active(&d, "u");
+        let r = signature_verify(&d, SignatureVerifyRequest {
+            uid: "u".into(),
+            data: b"hello".to_vec(),
+            signature: vec![0xff; 32],
+        }, "c").unwrap();
+        assert_eq!(r.validity, SignatureValidity::Invalid);
+    }
+
+    #[test]
+    fn verify_allowed_in_deactivated_state() {
+        let d = deps_with();
+        d.store.put(ObjectRecord {
+            uid: "u".into(),
+            object_type: ObjectType::PublicKey,
+            algorithm: KmipAlgorithm::MlDsa87,
+            cryptographic_length: 0,
+            usage_mask: UsageMask::VERIFY,
+            state: State::Deactivated,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: None,
+            supersedes: None,
+        }).unwrap();
+        let _ = signature_verify(&d, SignatureVerifyRequest {
+            uid: "u".into(),
+            data: vec![],
+            signature: vec![],
+        }, "c").unwrap();
+        // success — Verify is permitted in Deactivated state per §3.4
+    }
+
+    #[test]
+    fn verify_destroyed_returns_object_archived() {
+        let d = deps_with();
+        d.store.put(ObjectRecord {
+            uid: "u".into(),
+            object_type: ObjectType::PublicKey,
+            algorithm: KmipAlgorithm::MlDsa87,
+            cryptographic_length: 0,
+            usage_mask: UsageMask::VERIFY,
+            state: State::Destroyed,
+            pkcs11_cka_id: vec![],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: None,
+            supersedes: None,
+        }).unwrap();
+        let err = signature_verify(&d, SignatureVerifyRequest {
+            uid: "u".into(),
+            data: vec![],
+            signature: vec![],
+        }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::ObjectArchived);
+    }
+}

--- a/kmip/src/policy/mod.rs
+++ b/kmip/src/policy/mod.rs
@@ -92,4 +92,4 @@ pub use loader::{load_from_file, load_from_str, validate, LoadedPolicy, LoaderEr
 pub use policy::{ComplianceMapping, Metadata, Policy};
 pub use request::PolicyRequest;
 pub use rule::{AttrPredicate, GatingDeny, Rule, Substitution, TimeBound};
-pub use store::{PolicyStore, StoreError};
+pub use store::{ActiveMarker, PolicyStore, StoreError, POLICY_STORE_ACTIVE_FILE};

--- a/kmip/src/policy/store.rs
+++ b/kmip/src/policy/store.rs
@@ -13,13 +13,60 @@
 //! flushed write never leaves the directory with broken YAML. The on-disk
 //! `policies/` directory is the source of truth — Phase 9 audit will
 //! commit + push these to git for change history.
+//!
+//! ## Active-policy persistence
+//!
+//! The `policies/` directory holds N candidate policies; exactly one is
+//! "active" at any moment. To survive container restart without an
+//! operator re-flipping the dropdown, the active selection is persisted
+//! in a small marker file [`POLICY_STORE_ACTIVE_FILE`] (= `.active`) in
+//! the same directory:
+//!
+//! ```json
+//! { "name": "pqc", "fingerprint": "sha256:...", "activated_at": "2026-..." }
+//! ```
+//!
+//! - [`Self::activate_with_engine`] activates a policy AND writes the
+//!   marker atomically (validate-then-rename).
+//! - [`Self::resume_active`] reads the marker on boot and re-activates
+//!   the same policy. No marker → caller decides the default (typically
+//!   load `training-permissive.yaml` for sandbox, or refuse to start in
+//!   production).
+//!
+//! This mirrors the way softhsmv3 persists slot/token state on disk so
+//! key handles survive engine restarts (PKCS#11 §A) — same pattern, one
+//! level up the stack.
 
 use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 use super::{
     engine::Engine,
     loader::{load_from_file, load_from_str, LoadedPolicy, LoaderError},
 };
+
+/// Filename for the active-policy marker. Conventionally a dotfile so the
+/// `*.yaml` filter in [`PolicyStore::list`] ignores it.
+pub const POLICY_STORE_ACTIVE_FILE: &str = ".active";
+
+/// On-disk record of which policy is currently active. Written by
+/// [`PolicyStore::write_active`] / [`PolicyStore::activate_with_engine`].
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActiveMarker {
+    /// Stem of the YAML file (no extension, no path) — same shape as the
+    /// names returned by [`PolicyStore::list`].
+    pub name: String,
+    /// SHA-256 fingerprint of the YAML body at activation time. Lets an
+    /// operator detect "policies/<name>.yaml was edited since this marker
+    /// was written" — the engine refuses to silently re-activate a
+    /// fingerprint-mismatched file (see [`PolicyStore::resume_active`]).
+    pub fingerprint: String,
+    /// UTC timestamp when the marker was written.
+    #[serde(with = "time::serde::rfc3339")]
+    pub activated_at: OffsetDateTime,
+}
 
 #[derive(Clone, Debug)]
 pub struct PolicyStore {
@@ -40,6 +87,12 @@ pub enum StoreError {
 
     #[error("policy store: policy name {0:?} is invalid (must be non-empty, no path separators)")]
     BadName(String),
+
+    #[error("policy store: active-marker JSON malformed: {0}")]
+    BadMarker(String),
+
+    #[error("policy store: active-marker fingerprint mismatch (marker={marker_fp}, on-disk={disk_fp}) — refusing to resume; operator must re-activate via Hub")]
+    FingerprintDrift { marker_fp: String, disk_fp: String },
 }
 
 impl PolicyStore {
@@ -109,6 +162,113 @@ impl PolicyStore {
         let engine = Engine::deny_all();
         engine.activate(loaded).expect("activation in dry_run must succeed");
         Ok(engine.evaluate(req))
+    }
+
+    // ── Active-policy persistence (.active marker) ──────────────────────
+
+    /// Path to the active-marker file inside the store root.
+    pub fn active_marker_path(&self) -> PathBuf {
+        self.root.join(POLICY_STORE_ACTIVE_FILE)
+    }
+
+    /// Read the on-disk active-policy marker, if present. `Ok(None)` for
+    /// "no marker on disk" (first boot, or after [`Self::clear_active`]).
+    pub fn read_active(&self) -> Result<Option<ActiveMarker>, StoreError> {
+        let path = self.active_marker_path();
+        let body = match std::fs::read_to_string(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(StoreError::Io { path, source }),
+        };
+        let marker: ActiveMarker = serde_json::from_str(&body)
+            .map_err(|e| StoreError::BadMarker(e.to_string()))?;
+        Ok(Some(marker))
+    }
+
+    /// Write the active-policy marker atomically (validate-then-rename
+    /// onto `.active`). Called automatically by
+    /// [`Self::activate_with_engine`]; the standalone form exists for
+    /// tools that need to drop a marker without running the engine
+    /// (e.g. ops bootstrap scripts).
+    pub fn write_active(&self, name: &str, fingerprint: &str) -> Result<(), StoreError> {
+        // Name must reference a real policy file — fail fast if not.
+        let _ = self.path_for(name)?;
+        let marker = ActiveMarker {
+            name: name.to_string(),
+            fingerprint: fingerprint.to_string(),
+            activated_at: OffsetDateTime::now_utc(),
+        };
+        let body = serde_json::to_string_pretty(&marker)
+            .map_err(|e| StoreError::BadMarker(e.to_string()))?;
+        let target = self.active_marker_path();
+        let tmp = self.root.join(format!("{POLICY_STORE_ACTIVE_FILE}.tmp"));
+        std::fs::write(&tmp, body).map_err(|source| StoreError::Io {
+            path: tmp.clone(),
+            source,
+        })?;
+        std::fs::rename(&tmp, &target).map_err(|source| StoreError::Io { path: target, source })?;
+        Ok(())
+    }
+
+    /// Delete the active marker. Idempotent (no-op if absent). Tests +
+    /// "go back to default" tooling use this.
+    pub fn clear_active(&self) -> Result<(), StoreError> {
+        let path = self.active_marker_path();
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(source) => Err(StoreError::Io { path, source }),
+        }
+    }
+
+    /// Combined: load + activate on the engine + write the marker.
+    /// Hub UI's policy-dropdown `Activate` button maps to this.
+    ///
+    /// Returns the prior marker (if any) so the caller can audit the
+    /// transition. The engine-internal `PolicyAudit` also records the
+    /// activation via its existing path.
+    pub fn activate_with_engine(
+        &self,
+        name: &str,
+        engine: &Engine,
+    ) -> Result<Option<ActiveMarker>, StoreError> {
+        let loaded = self.load(name)?;
+        let fingerprint = super::policy::Policy::fingerprint(&loaded.source);
+        let prior = self.read_active()?;
+        engine
+            .activate(loaded)
+            .map_err(|e| StoreError::BadMarker(format!("engine activate: {e}")))?;
+        self.write_active(name, &fingerprint)?;
+        Ok(prior)
+    }
+
+    /// Boot path: read `.active`, re-load the same YAML, re-activate on
+    /// the engine. Returns the resumed marker, or `Ok(None)` if there
+    /// was no marker on disk (caller picks a default).
+    ///
+    /// **Drift protection:** if the YAML file's current fingerprint
+    /// differs from the marker, returns
+    /// [`StoreError::FingerprintDrift`] rather than silently activating
+    /// an edited policy — operator must explicitly re-activate via the
+    /// Hub (this is exactly the "edited a policy file out-of-band" case
+    /// that should NOT auto-resume).
+    pub fn resume_active(&self, engine: &Engine) -> Result<Option<ActiveMarker>, StoreError> {
+        let marker = match self.read_active()? {
+            Some(m) => m,
+            None => return Ok(None),
+        };
+        let loaded = self.load(&marker.name)?;
+        let current_fp = super::policy::Policy::fingerprint(&loaded.source);
+        if current_fp != marker.fingerprint {
+            return Err(StoreError::FingerprintDrift {
+                marker_fp: marker.fingerprint,
+                disk_fp: current_fp,
+            });
+        }
+        engine
+            .activate(loaded)
+            .map_err(|e| StoreError::BadMarker(format!("engine activate: {e}")))?;
+        Ok(Some(marker))
     }
 
     fn path_for(&self, name: &str) -> Result<PathBuf, StoreError> {
@@ -222,5 +382,145 @@ rules:
         assert!(matches!(store.load(""), Err(StoreError::BadName(_))));
         assert!(matches!(store.load("../etc/passwd"), Err(StoreError::BadName(_))));
         assert!(matches!(store.load("foo/bar"), Err(StoreError::BadName(_))));
+    }
+
+    // ── Active-policy persistence ───────────────────────────────────────
+
+    fn write_yaml(dir: &Path, name: &str) {
+        std::fs::write(
+            dir.join(format!("{name}.yaml")),
+            format!(
+                "schema_version: 1\nmetadata: {{ name: {name}, description: {name}, authority: t, effective: always }}\nrules: []\n",
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn read_active_returns_none_when_no_marker() {
+        let dir = tmp_dir("active-none");
+        let store = PolicyStore::new(&dir);
+        assert!(store.read_active().unwrap().is_none());
+    }
+
+    #[test]
+    fn write_then_read_active_round_trip() {
+        let dir = tmp_dir("active-rw");
+        write_yaml(&dir, "classical");
+        let store = PolicyStore::new(&dir);
+        store.write_active("classical", "sha256:abc123").unwrap();
+        let marker = store.read_active().unwrap().expect("marker present");
+        assert_eq!(marker.name, "classical");
+        assert_eq!(marker.fingerprint, "sha256:abc123");
+        // Marker file is excluded from list (dotfile, no .yaml extension).
+        assert_eq!(store.list().unwrap(), vec!["classical"]);
+    }
+
+    #[test]
+    fn write_active_rejects_bad_name() {
+        let dir = tmp_dir("active-bad");
+        let store = PolicyStore::new(&dir);
+        assert!(matches!(
+            store.write_active("../etc/passwd", "sha256:x"),
+            Err(StoreError::BadName(_))
+        ));
+    }
+
+    #[test]
+    fn clear_active_is_idempotent() {
+        let dir = tmp_dir("active-clear");
+        let store = PolicyStore::new(&dir);
+        store.clear_active().unwrap(); // no-op when absent
+        write_yaml(&dir, "p");
+        store.write_active("p", "sha256:0").unwrap();
+        assert!(store.read_active().unwrap().is_some());
+        store.clear_active().unwrap();
+        assert!(store.read_active().unwrap().is_none());
+        // Second call still no-ops.
+        store.clear_active().unwrap();
+    }
+
+    #[test]
+    fn activate_with_engine_writes_marker_and_engine_observes_policy() {
+        let dir = tmp_dir("aw-engine");
+        write_yaml(&dir, "pqc");
+        let store = PolicyStore::new(&dir);
+        let engine = super::super::Engine::deny_all();
+
+        let prior = store.activate_with_engine("pqc", &engine).unwrap();
+        assert!(prior.is_none(), "no prior marker on first activate");
+
+        // Marker now present + engine has the policy active.
+        let m = store.read_active().unwrap().unwrap();
+        assert_eq!(m.name, "pqc");
+        assert!(m.fingerprint.starts_with("sha256:"));
+        assert_eq!(engine.active().unwrap().policy.metadata.name, "pqc");
+    }
+
+    #[test]
+    fn activate_with_engine_returns_prior_marker() {
+        let dir = tmp_dir("aw-prior");
+        write_yaml(&dir, "a");
+        write_yaml(&dir, "b");
+        let store = PolicyStore::new(&dir);
+        let engine = super::super::Engine::deny_all();
+
+        store.activate_with_engine("a", &engine).unwrap();
+        let prior = store.activate_with_engine("b", &engine).unwrap();
+        let prior = prior.expect("second activate should return prior");
+        assert_eq!(prior.name, "a");
+        assert_eq!(engine.active().unwrap().policy.metadata.name, "b");
+    }
+
+    #[test]
+    fn resume_active_replays_marker_on_boot() {
+        let dir = tmp_dir("resume-ok");
+        write_yaml(&dir, "pqc");
+        let store = PolicyStore::new(&dir);
+
+        // First boot: operator activates pqc.
+        let engine1 = super::super::Engine::deny_all();
+        store.activate_with_engine("pqc", &engine1).unwrap();
+        let original_fp = store.read_active().unwrap().unwrap().fingerprint;
+
+        // Restart simulation: fresh engine; resume reads marker + re-activates.
+        let engine2 = super::super::Engine::deny_all();
+        let resumed = store.resume_active(&engine2).unwrap().expect("must resume");
+        assert_eq!(resumed.name, "pqc");
+        assert_eq!(resumed.fingerprint, original_fp);
+        assert_eq!(engine2.active().unwrap().policy.metadata.name, "pqc");
+    }
+
+    #[test]
+    fn resume_active_returns_none_when_no_marker() {
+        let dir = tmp_dir("resume-empty");
+        let store = PolicyStore::new(&dir);
+        let engine = super::super::Engine::deny_all();
+        let resumed = store.resume_active(&engine).unwrap();
+        assert!(resumed.is_none());
+        // Engine still in its prior (no-policy) state.
+        assert!(engine.active().is_none());
+    }
+
+    #[test]
+    fn resume_active_rejects_drifted_yaml() {
+        let dir = tmp_dir("resume-drift");
+        write_yaml(&dir, "p");
+        let store = PolicyStore::new(&dir);
+        let engine1 = super::super::Engine::deny_all();
+        store.activate_with_engine("p", &engine1).unwrap();
+
+        // Operator edits the YAML out-of-band between sessions (e.g. via vim,
+        // not through the Hub). Fingerprint now mismatches.
+        std::fs::write(
+            dir.join("p.yaml"),
+            "schema_version: 1\nmetadata: { name: p, description: edited, authority: t, effective: always }\nrules: []\n",
+        ).unwrap();
+
+        let engine2 = super::super::Engine::deny_all();
+        let err = store.resume_active(&engine2).unwrap_err();
+        assert!(matches!(err, StoreError::FingerprintDrift { .. }));
+        // Engine NOT activated (refused to silently load drifted policy).
+        assert!(engine2.active().is_none());
     }
 }

--- a/kmip/src/store/memory.rs
+++ b/kmip/src/store/memory.rs
@@ -1,0 +1,150 @@
+//! [`MemoryStore`] — in-memory [`KeyStore`] implementation for Phase 5
+//! unit tests and dev sandbox runs. Phase 6 replaces this with the
+//! SQLite-backed durable store.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use super::traits::{KeyStore, ObjectRecord};
+use crate::error::{KmipError, Result};
+
+pub struct MemoryStore {
+    inner: RwLock<HashMap<String, ObjectRecord>>,
+}
+
+impl MemoryStore {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.read().expect("store poisoned").len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Default for MemoryStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl KeyStore for MemoryStore {
+    fn put(&self, record: ObjectRecord) -> Result<()> {
+        let mut map = self.inner.write().expect("store poisoned");
+        if map.contains_key(&record.uid) {
+            return Err(KmipError::failed(
+                crate::error::ResultReason::ObjectAlreadyExists,
+                format!("UID {:?} already exists", record.uid),
+            ));
+        }
+        map.insert(record.uid.clone(), record);
+        Ok(())
+    }
+
+    fn get(&self, uid: &str) -> Result<Option<ObjectRecord>> {
+        Ok(self
+            .inner
+            .read()
+            .expect("store poisoned")
+            .get(uid)
+            .cloned())
+    }
+
+    fn update(&self, record: ObjectRecord) -> Result<()> {
+        let mut map = self.inner.write().expect("store poisoned");
+        if !map.contains_key(&record.uid) {
+            return Err(KmipError::not_found(&record.uid));
+        }
+        map.insert(record.uid.clone(), record);
+        Ok(())
+    }
+
+    fn remove(&self, uid: &str) -> Result<()> {
+        self.inner
+            .write()
+            .expect("store poisoned")
+            .remove(uid);
+        Ok(())
+    }
+
+    fn find(&self, predicate: &dyn Fn(&ObjectRecord) -> bool) -> Result<Vec<ObjectRecord>> {
+        Ok(self
+            .inner
+            .read()
+            .expect("store poisoned")
+            .values()
+            .filter(|r| predicate(r))
+            .cloned()
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kmip30::{KmipAlgorithm, ObjectType, State, UsageMask};
+    use time::OffsetDateTime;
+
+    fn rec(uid: &str) -> ObjectRecord {
+        ObjectRecord {
+            uid: uid.into(),
+            object_type: ObjectType::PrivateKey,
+            algorithm: KmipAlgorithm::MlDsa87,
+            cryptographic_length: 0,
+            usage_mask: UsageMask::SIGN | UsageMask::VERIFY,
+            state: State::PreActive,
+            pkcs11_cka_id: vec![1, 2, 3],
+            pkcs11_slot: 0,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            activation_date: None,
+            supersedes: None,
+        }
+    }
+
+    #[test]
+    fn put_then_get() {
+        let s = MemoryStore::new();
+        s.put(rec("u1")).unwrap();
+        let r = s.get("u1").unwrap().unwrap();
+        assert_eq!(r.uid, "u1");
+        assert!(s.get("missing").unwrap().is_none());
+    }
+
+    #[test]
+    fn put_duplicate_fails() {
+        let s = MemoryStore::new();
+        s.put(rec("u1")).unwrap();
+        let err = s.put(rec("u1")).unwrap_err();
+        assert_eq!(
+            err.result_reason(),
+            crate::error::ResultReason::ObjectAlreadyExists
+        );
+    }
+
+    #[test]
+    fn update_requires_existing() {
+        let s = MemoryStore::new();
+        let err = s.update(rec("ghost")).unwrap_err();
+        assert_eq!(err.result_reason(), crate::error::ResultReason::ItemNotFound);
+    }
+
+    #[test]
+    fn find_filters() {
+        let s = MemoryStore::new();
+        let mut a = rec("a");
+        a.state = State::Active;
+        let mut b = rec("b");
+        b.state = State::Deactivated;
+        s.put(a).unwrap();
+        s.put(b).unwrap();
+        let active = s.find(&|r| r.state == State::Active).unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].uid, "a");
+    }
+}

--- a/kmip/src/store/mod.rs
+++ b/kmip/src/store/mod.rs
@@ -1,7 +1,12 @@
-//! Plane 2 — SQLite-backed KMIP object store + lifecycle FSM.
+//! Plane 2 — KMIP object store + lifecycle FSM.
 //!
-//! `rusqlite` wrapper, CRUD, lifecycle state transitions per
-//! `docs/IMPLEMENTATION_PLAN.md` §3.4, KMIP `Locate` query builder, `rusqlite_migration`
-//! schema versioning.
-//!
-//! Phase 0 (bootstrap): module declared, no implementation. Lands in Phase 6.
+//! Phase 5 (this) ships the [`KeyStore`] trait + [`MemoryStore`] impl —
+//! the minimum surface the op handlers need to compile + test. Phase 6
+//! ships the SQLite-backed durable store with full lifecycle FSM
+//! enforcement per `docs/IMPLEMENTATION_PLAN.md` §3.4.
+
+pub mod memory;
+pub mod traits;
+
+pub use memory::MemoryStore;
+pub use traits::{KeyStore, ObjectRecord, Uid};

--- a/kmip/src/store/traits.rs
+++ b/kmip/src/store/traits.rs
@@ -1,0 +1,61 @@
+//! [`KeyStore`] — minimal surface needed by Phase 5 op handlers.
+//!
+//! Phase 6 will implement the SQLite-backed concrete store with full
+//! lifecycle FSM enforcement (per `docs/IMPLEMENTATION_PLAN.md` §3.4).
+//! This trait defines just the operations the ops need to compile + test
+//! against; the in-memory implementation in [`super::MemoryStore`]
+//! satisfies it for Phase 5 unit tests.
+
+use crate::error::Result;
+use crate::kmip30::{KmipAlgorithm, ObjectType, State, UsageMask};
+use time::OffsetDateTime;
+
+/// KMIP `Unique Identifier` — KMIP 3.0 §4.x. We use a `urn:pqctoday:obj:<uuid>`
+/// shape; the dispatcher allocates one per Create / CreateKeyPair.
+pub type Uid = String;
+
+/// One managed object as the store sees it. Key material itself stays in
+/// `softhsmrustv3`; the store keeps the KMIP-level metadata + the stable
+/// PKCS#11 `CKA_ID` we use to find the object back inside the token.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObjectRecord {
+    pub uid: Uid,
+    pub object_type: ObjectType,
+    pub algorithm: KmipAlgorithm,
+    pub cryptographic_length: u32,
+    pub usage_mask: UsageMask,
+    pub state: State,
+    /// PKCS#11 `CKA_ID` (bytes). The bridge uses this with `C_FindObjects`
+    /// to recover the session-scoped `CK_OBJECT_HANDLE` for the object.
+    pub pkcs11_cka_id: Vec<u8>,
+    /// Slot the object lives in. v0.1 is single-slot but the field is
+    /// here so Phase 6 can grow into multi-slot without an API change.
+    pub pkcs11_slot: u32,
+    /// KMIP `Initial Date` (§4.x).
+    pub initial_date: OffsetDateTime,
+    /// KMIP `Activation Date` (§4.x) — set on `Activate`.
+    pub activation_date: Option<OffsetDateTime>,
+    /// Linked predecessor when this object was created by a Plane-1
+    /// `RekeyAndProceed`. KMIP `Link` attribute (§4.x); the dispatcher
+    /// also surfaces this via the `x-pqctoday-supersedes` custom attr.
+    pub supersedes: Option<Uid>,
+}
+
+/// Minimum surface the Phase-5 op handlers call.
+pub trait KeyStore: Send + Sync {
+    /// Insert a freshly-created object. Errors on duplicate UID.
+    fn put(&self, record: ObjectRecord) -> Result<()>;
+
+    /// Look up by UID. `Ok(None)` for "not present".
+    fn get(&self, uid: &str) -> Result<Option<ObjectRecord>>;
+
+    /// Replace an object (lifecycle transition, supersedes link, etc.).
+    /// Errors if the UID is unknown.
+    fn update(&self, record: ObjectRecord) -> Result<()>;
+
+    /// Delete by UID. Idempotent — succeeds even if the UID was absent.
+    fn remove(&self, uid: &str) -> Result<()>;
+
+    /// List all objects matching `predicate` (KMIP `Locate` op).
+    fn find(&self, predicate: &dyn Fn(&ObjectRecord) -> bool) -> Result<Vec<ObjectRecord>>;
+}


### PR DESCRIPTION
## Summary

First session of Phase 5 — ships the Plane-2 shared infrastructure plus
the three op handlers needed to drive the headline classical → PQC demo
end-to-end:

- **KMIP 3.0 §6.1.45 Query** (op 0x18)
- **KMIP 3.0 §6.1.11 Create Key Pair** (op 0x02)
- **KMIP 3.0 §6.1.60 Sign** (op 0x21)

Plus: \`ResultReason\` enum + \`KmipError\`, \`KeyStore\` trait + \`MemoryStore\`
impl, \`Deps\` shared bundle.

The remaining 9 ops (Activate, Create, Decrypt, Destroy, Encrypt, Get,
Locate, Revoke, SignatureVerify) follow the same template; queued for
session 2 per the 1-phase-per-session workflow lock.

## Spec correctness

**Every KMIP / PKCS#11 detail is cited from the local spec copies, not
guessed.** Section numbers verified against
\`kmip/spec/oasis-kmip-3.0/kmip-spec-v3.0.html\`; codepoints + ResultReason
values verified against \`kmip/spec/oasis-kmip-3.0/kmip-spec-3.0-tags-enums.json\`;
PKCS#11 entry-point signatures verified against \`rust/src/ffi.rs\` and
\`src/lib/pkcs11/pkcs11f.h\`. Each handler file's module doc carries the
explicit \`§\` reference.

| Op | KMIP 3.0 § | Op codepoint | PKCS#11 v3.2 entry |
|---|---|---|---|
| Query | 6.1.45 | 0x18 | C_GetInfo |
| Create Key Pair | 6.1.11 | 0x02 | C_GenerateKeyPair (§C.7.1) |
| Sign | 6.1.60 | 0x21 | C_SignInit (§C.6.5) + C_Sign (§C.6.6) |

ResultReason codepoints pinned in tests against the OASIS extract:
ItemNotFound (0x01), OperationNotSupported (0x05), MissingData (0x06),
InvalidField (0x07), CryptographicFailure (0x0a), PermissionDenied
(0x0c), ObjectArchived (0x0d), ObjectAlreadyExists (0x18),
InvalidAttribute (0x2c), InvalidAttributeValue (0x2d).

## Plane wiring

Every handler runs the full tri-plane audit trace defined in PR #72:

\`\`\`
[p2] KmipRequestReceived
[p1] PolicyDecided           ← engine.evaluate gate
[p1] RekeyPlanned (optional)  ← when policy substitutes against existing object
[p3] Pkcs11Call               ← per softhsmrustv3 entry point
[p2] KmipResponseSent
\`\`\`

The Hub UI sees the full path for one request via \`correlation_id\` —
**no joiner, no enrichment** on the UI side.

## What's NOT in this PR (deferred to later sessions / phases)

- **9 remaining ops** — same template; ≤ ~250 LOC each. Session 2.
- **Real softhsmrustv3 bridge calls** — v0.1 emits placeholder Plane-3
  audit events but doesn't actually call into the token (no init'd
  session in unit tests; deferred to Phase 7).
- **SQLite store** — Phase 5 ships \`MemoryStore\`; Phase 6 wires durable
  persistence + the full lifecycle FSM.
- **Multi-op rekey transaction** — when \`Sign\` hits \`RekeyAndProceed\`,
  this PR returns a typed \`PermissionDenied\` with an actionable hint.
  The actual "generate new PQC key + mark old Deprecated + link via
  \`x-pqctoday-supersedes\` + re-issue" transaction is Phase 6 work.
- **Algorithm canonicalisation with curve/size** — \`canonical_name\` today
  returns bare names (\"ECDSA\", \"AES\"). Phase 6 adds the
  \`Cryptographic Parameters\` attribute so policies can target
  \"ECDSA-P256\" / \"AES-256\".

All limitations are documented inline at the relevant call sites + in
the updated Phase-5 section of \`docs/IMPLEMENTATION_PLAN.md\`.

## Test plan

- [x] \`cargo test --lib ops::\` — 16 / 16
- [x] \`cargo test --lib store::\` — 4 / 4
- [x] \`cargo test --lib error::\` — 3 / 3
- [x] \`cargo test --lib --tests\` — **150 / 0** (was 131; no regressions)
- [x] Clean build (only pre-existing softhsmrustv3 warnings)
- [ ] Session 2 implements the remaining 9 ops against this template
- [ ] Phase 7 wires real softhsmrustv3 bridge calls behind the existing
      audit emissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)