### PR TITLE
docs(rust): scope softhsmrustv3::native — typed Rust API for native callers

### DIFF
--- a/rust/docs/NATIVE_API.md
+++ b/rust/docs/NATIVE_API.md
@@ -1,0 +1,311 @@
+# `softhsmrustv3::native` — typed Rust API for native callers
+
+> **Status**: scoping document (this commit) + module skeleton.
+> Implementations land in follow-up commits.
+> **Branch**: `feat/rust-native-api`.
+
+## 1. Why this module exists
+
+`softhsmrustv3` was originally written wasm32-first. The PKCS#11 C ABI it
+exposes via `pub mod ffi` was designed for the WebAssembly target:
+
+- `CK_ATTRIBUTE` template entries are **12 bytes** (`type:u32 + pValue:u32 +
+  ulValueLen:u32`).
+- `pValue` is a **32-bit pointer**, cast from / to `usize` and dereferenced
+  via `as usize as *const u8`.
+
+This works in wasm32 (pointers ARE 32 bits there). It **silently truncates**
+on native 64-bit hosts when callers construct attribute templates from
+ordinary Rust `Vec<u8>` / stack buffers whose addresses exceed the u32
+range.
+
+The `pqctoday-hsm/openmls-provider/wasm-smoke/` crate gates its
+`softhsmrustv3` path-dependency behind
+`cfg(target_arch = "wasm32")` for exactly this reason — its
+`Cargo.toml:13` reads:
+
+```toml
+# This crate is wasm32-only by design — every dep below is conditioned.
+# Building it for native targets is a no-op (empty rlib).
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+softhsmrustv3 = { path = "../../rust" }
+```
+
+**`pqctoday-hsm/kmip/` is a native target.** Phase 4's `Session` wrapper
+compiles (it only calls `C_Initialize` / `C_OpenSession` / `C_Login` /
+`C_CloseSession`, none of which take templates) but Phase 7b would need
+to construct attribute templates — which would silently break on native.
+
+## 2. Architectural principle
+
+**Typed Rust is the source of truth; the C ABI is a marshalling layer.**
+
+The engine already has typed Rust primitives in
+`src/crypto/handlers.rs`:
+
+```rust
+pub fn sign_ml_dsa(mech: u32, ps: u32, sk_bytes: &[u8], msg: &[u8])
+    -> Result<Vec<u8>, u32>;
+pub fn verify_ml_dsa(mech: u32, ps: u32, pk_bytes: &[u8], msg: &[u8], sig: &[u8])
+    -> Result<(), u32>;
+pub fn sign_slh_dsa(...) / verify_slh_dsa(...);
+pub fn sign_rsa(...) / verify_rsa(...) / verify_ecdsa(...) / etc.
+```
+
+And typed object storage in `src/state.rs`:
+
+```rust
+pub fn allocate_handle(attrs: Attributes) -> u32;
+pub fn get_object_value(handle: u32) -> Option<Vec<u8>>;
+pub fn get_object_attr_bytes(handle: u32, attr_type: u32) -> Option<Vec<u8>>;
+pub fn set_object_attr_bytes(handle: u32, attr_type: u32, value: Vec<u8>) -> bool;
+pub fn store_param_set / store_algo_family / store_bool / store_ulong;
+```
+
+The C ABI handlers (`ffi::C_GenerateKeyPair`, `ffi::C_Sign`,
+`ffi::C_EncapsulateKey`, …) **already call these typed primitives
+internally** — they're the marshalling layer.
+
+**What's missing** for a clean native API is a thin `pub mod native` that
+exposes the **composite operations** (keygen + storage + sign as one
+call) without the C ABI surface in between.
+
+## 3. Public surface — `pub mod native`
+
+### 3.1 Sessions
+
+```rust
+/// Initialise the engine. Idempotent (subsequent calls return
+/// `Ok(())` instead of `CKR_CRYPTOKI_ALREADY_INITIALIZED`).
+pub fn init() -> Result<(), CkRv>;
+
+/// Open an R/W user session against `slot`. Returns the session handle.
+/// `pin` is verified via the engine's PIN store.
+pub fn open_session(slot: u32, pin: &str) -> Result<u32, CkRv>;
+
+/// Close a session handle.
+pub fn close_session(session: u32) -> Result<(), CkRv>;
+```
+
+### 3.2 Key generation — PQC
+
+```rust
+/// Generate an ML-KEM keypair. `parameter_set` ∈ {ML_KEM_512, ML_KEM_768,
+/// ML_KEM_1024}. Returns `(public_handle, private_handle)`.
+pub fn generate_ml_kem_keypair(
+    session: u32,
+    parameter_set: u32,
+    cka_id: &[u8],
+    label: &str,
+) -> Result<(u32, u32), CkRv>;
+
+/// Generate an ML-DSA keypair. `parameter_set` ∈ {ML_DSA_44, ML_DSA_65,
+/// ML_DSA_87}.
+pub fn generate_ml_dsa_keypair(
+    session: u32,
+    parameter_set: u32,
+    cka_id: &[u8],
+    label: &str,
+) -> Result<(u32, u32), CkRv>;
+
+/// Generate an SLH-DSA keypair.
+pub fn generate_slh_dsa_keypair(
+    session: u32,
+    parameter_set: u32,
+    cka_id: &[u8],
+    label: &str,
+) -> Result<(u32, u32), CkRv>;
+```
+
+### 3.3 Key generation — classical
+
+```rust
+pub fn generate_rsa_keypair(session: u32, bits: u32, cka_id: &[u8], label: &str)
+    -> Result<(u32, u32), CkRv>;
+pub fn generate_ecdsa_keypair(session: u32, curve_oid: &[u8], cka_id: &[u8], label: &str)
+    -> Result<(u32, u32), CkRv>;
+pub fn generate_aes_key(session: u32, bits: u32, cka_id: &[u8], label: &str)
+    -> Result<u32, CkRv>;
+```
+
+### 3.4 Sign / Verify
+
+```rust
+pub fn sign(session: u32, key: u32, mechanism: u32, data: &[u8])
+    -> Result<Vec<u8>, CkRv>;
+pub fn verify(session: u32, key: u32, mechanism: u32, data: &[u8], signature: &[u8])
+    -> Result<bool, CkRv>;
+```
+
+### 3.5 Encrypt / Decrypt (classical + ML-KEM encap/decap)
+
+```rust
+pub fn encrypt(session: u32, key: u32, mechanism: u32, plaintext: &[u8], iv: Option<&[u8]>)
+    -> Result<Vec<u8>, CkRv>;
+pub fn decrypt(session: u32, key: u32, mechanism: u32, ciphertext: &[u8], iv: Option<&[u8]>)
+    -> Result<Vec<u8>, CkRv>;
+
+/// ML-KEM encapsulation. Returns `(ciphertext, shared_secret)`.
+pub fn encapsulate(session: u32, public_key: u32, mechanism: u32)
+    -> Result<(Vec<u8>, Vec<u8>), CkRv>;
+pub fn decapsulate(session: u32, private_key: u32, mechanism: u32, ciphertext: &[u8])
+    -> Result<Vec<u8>, CkRv>;
+```
+
+### 3.6 Object lifecycle / queries
+
+```rust
+pub fn destroy_object(session: u32, handle: u32) -> Result<(), CkRv>;
+
+/// Find an object handle by `CKA_ID`. Used by the KMIP store layer to
+/// recover the session-scoped handle from the stable PKCS#11 identifier
+/// it persists.
+pub fn find_by_cka_id(session: u32, cka_id: &[u8]) -> Result<Option<u32>, CkRv>;
+
+/// Read a single attribute. Returns `None` if absent.
+pub fn get_attribute(session: u32, handle: u32, attr_type: u32) -> Option<Vec<u8>>;
+```
+
+### 3.7 Token initialisation (for first-boot setup)
+
+```rust
+pub fn init_token(slot: u32, so_pin: &str, label: &str) -> Result<(), CkRv>;
+pub fn init_pin(session: u32, user_pin: &str) -> Result<(), CkRv>;
+```
+
+## 4. Threading model
+
+The engine's internal storage (`OBJECTS`, `SESSIONS`, `SIGN_STATE`,
+`ENCRYPT_STATE`, etc.) is currently `thread_local!`. That's correct for
+wasm32 (single-threaded execution model).
+
+For native callers (tokio multi-threaded), two viable approaches:
+
+### Option A — pinned engine thread (recommended)
+
+The `softhsmrustv3::native` API documents that **all calls must come from
+a single thread**. Native callers pin one OS thread (e.g.
+`tokio::task::spawn_blocking` onto a single-thread runtime) and route all
+crypto requests through it. Phase 4's `Session: !Send` already encodes
+this constraint.
+
+**Pros**: No engine changes. Thread-local storage is correct as-is. Lowest
+risk of state corruption.
+
+**Cons**: Caller has to manage thread affinity. KMIP `Deps` needs an
+`Arc<Mutex<Session>>` and all crypto goes through a single-thread executor.
+
+### Option B — replace thread_local with parking_lot::Mutex
+
+Convert `OBJECTS`, `SESSIONS`, `SIGN_STATE`, `ENCRYPT_STATE` to global
+`Mutex<HashMap<...>>`. Multi-threaded callers serialise via the mutex.
+
+**Pros**: API users don't need thread affinity.
+
+**Cons**: Wider engine change. Mutex contention under load. Risk of
+deadlocks if engine internals ever call out and back.
+
+### Decision: **Option A for v0.1; Option B as a future option if profiling shows contention.**
+
+The Phase 4 `Session: !Send` constraint already aligns the KMIP server
+with Option A. The KMIP server can route crypto through a single
+`tokio::task::spawn_blocking` thread without touching the engine.
+
+## 5. C ABI relationship
+
+The new `pub mod native` does **not** replace `pub mod ffi`. They coexist:
+
+- `ffi::C_GenerateKeyPair` (wasm32 PKCS#11 spec compliance) — unchanged.
+- `native::generate_ml_kem_keypair` (new) — same logic, typed args.
+
+Where practical, the implementation strategy is:
+
+1. **Extract** the keygen / encap / encrypt body from each `ffi::C_*`
+   handler into a private `_impl_*(typed args) -> Result<...>` function.
+2. **Wrap** the new private impl with the existing `ffi::C_*` (marshalling
+   raw pointers in) AND the new `native::*` (typed pass-through).
+
+The C ABI stays bit-exact (no behaviour change for WASM consumers). The
+native API is a parallel surface backed by the same internal logic.
+
+## 6. File-by-file plan
+
+| File | Action | Estimated LOC |
+|---|---|---|
+| `src/lib.rs` | Add `pub mod native;` | +1 |
+| `src/native/mod.rs` | Re-exports + module docs | ~40 |
+| `src/native/session.rs` | `init` / `open_session` / `close_session` / `init_token` / `init_pin` | ~120 |
+| `src/native/keygen.rs` | All 6 keygen functions (ML-KEM/ML-DSA/SLH-DSA/RSA/ECDSA/AES) — refactored from `ffi::C_GenerateKeyPair` + `ffi::C_GenerateKey` | ~250 |
+| `src/native/sign.rs` | `sign` / `verify` — thin dispatcher over `crypto::handlers::sign_*` + `verify_*` | ~80 |
+| `src/native/encrypt.rs` | `encrypt` / `decrypt` / `encapsulate` / `decapsulate` — refactored from `ffi::C_Encrypt*` + `ffi::C_*EncapsulateKey` | ~200 |
+| `src/native/object.rs` | `find_by_cka_id` / `destroy_object` / `get_attribute` | ~100 |
+| **Total new code** | | **~790 LOC** |
+| **Plus refactor** in `ffi.rs` to call into the new impl bodies | | ~200 LOC moved |
+
+## 7. Test plan
+
+| Layer | Test | Purpose |
+|---|---|---|
+| `tests/native_smoke.rs` (new) | Init engine → open session → generate ML-DSA-65 keypair → sign 32-byte msg → verify | Proves the native API actually works end-to-end on native |
+| `tests/native_parity.rs` (new) | Same operation via `ffi::C_*` (in wasm32 cfg) and via `native::*` (native cfg) produces byte-equivalent output | Proves the dual API doesn't drift |
+| Existing `pqctoday-mls-wasm-smoke` tests | Should still pass | Proves the C ABI refactor didn't break wasm32 callers |
+| KAT replay in `tests/` | Should still pass | No regression to NIST vector replay |
+
+## 8. Risks + mitigation
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Refactor breaks wasm32 callers | Medium | Existing `wasm-smoke` tests gate every commit; CI runs them |
+| Native API surface drift from C ABI | Medium | Parity test in `tests/native_parity.rs` exercises both paths against the same KAT |
+| Thread-local OBJECTS map needs Mutex for native | Low | Option A (pinned thread) deferred to caller — KMIP `Session: !Send` already aligns |
+| RNG state — engine uses thread-local CSPRNG | Low | Same as thread-local OBJECTS; pinned-thread caller handles it |
+
+## 9. This commit's scope
+
+This first commit ships **only the scoping doc + module skeleton**. The
+skeleton:
+
+- Adds `pub mod native;` to `src/lib.rs`.
+- Creates `src/native/mod.rs` with the function signatures from §3 as
+  `unimplemented!()` stubs.
+- Creates `src/native/{session,keygen,sign,encrypt,object}.rs` as empty
+  modules.
+
+**No implementations yet.** Follow-up commits land each
+sub-module's real impl + tests:
+
+| Commit | Sub-module | Tests |
+|---|---|---|
+| 2 | `native/session.rs` | `tests/native_session.rs` |
+| 3 | `native/keygen.rs` (ML-DSA + ML-KEM first) | `tests/native_keygen_pqc.rs` |
+| 4 | `native/sign.rs` | `tests/native_sign_verify.rs` |
+| 5 | `native/encrypt.rs` | `tests/native_encap_decap.rs` |
+| 6 | `native/keygen.rs` (classical: RSA, ECDSA, AES) | `tests/native_keygen_classical.rs` |
+| 7 | `native/object.rs` | `tests/native_object.rs` |
+| 8 | `tests/native_parity.rs` | (cross-validation) |
+
+Roughly **6–8 follow-up commits**, each ~150 LOC + a focused test. Each
+commit independently verifiable; CI gates against wasm32 regressions.
+
+## 10. Out of scope
+
+- Changing the wasm32 C ABI semantics (no behaviour change for existing
+  WASM consumers).
+- Adding async / multi-threaded engine internals.
+- Replacing thread-local storage with `Mutex` (deferred — see §4).
+- Adding new crypto primitives. The native API exposes what the engine
+  already implements.
+- Token persistence format changes.
+
+## 11. Open questions for review
+
+1. **Module name**: `native` vs `rust_api` vs `direct`. `native` is shortest
+   and contrasts cleanly with `ffi` (the C ABI). Other suggestions welcome.
+2. **Error type**: `Result<T, u32>` where `u32` is `CK_RV` keeps parity
+   with the existing crypto-primitive functions. Alternative: a typed
+   `enum NativeError` mirroring `pqctoday-kmip::pkcs11bridge::BridgeError`.
+   The `u32` path is simpler and lets KMIP wrap on its side.
+3. **Should `native::*` take `&mut Session` instead of raw `session: u32`**?
+   More type-safe but couples the native API to a Rust struct definition.
+   Counterargument: the C ABI uses `u32`; staying with `u32` keeps the two
+   APIs visually parallel.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod constants;
 pub mod crypto;
 pub mod ffi;
+pub mod native;
 pub mod state;
 
 pub use ffi::*;

--- a/rust/src/native/encrypt.rs
+++ b/rust/src/native/encrypt.rs
@@ -1,0 +1,60 @@
+//! Encrypt / Decrypt / Encapsulate / Decapsulate — typed wrappers.
+//!
+//! `encrypt` / `decrypt` cover the classical symmetric / asymmetric paths
+//! (AES-GCM, AES-CBC, RSA-OAEP). `encapsulate` / `decapsulate` are the
+//! ML-KEM-specific calls — separate functions because they return
+//! (ciphertext + shared_secret) rather than just ciphertext.
+//!
+//! Native wrappers around `ffi::C_EncryptInit` + `ffi::C_Encrypt`,
+//! `ffi::C_DecryptInit` + `ffi::C_Decrypt`, `ffi::C_EncapsulateKey`,
+//! `ffi::C_DecapsulateKey` — refactored to take typed args.
+//!
+//! Implementation lands in Phase 7b commit 5.
+
+use super::CkRv;
+
+/// Classical encrypt. `mechanism` ∈ {`CKM_AES_GCM`, `CKM_AES_CBC_PAD`,
+/// `CKM_RSA_PKCS_OAEP`, …}. `iv` carries IV for AES modes that need it
+/// (`None` for RSA-OAEP).
+pub fn encrypt(
+    _session: u32,
+    _key_handle: u32,
+    _mechanism: u32,
+    _plaintext: &[u8],
+    _iv: Option<&[u8]>,
+) -> Result<Vec<u8>, CkRv> {
+    unimplemented!("native::encrypt::encrypt — Phase 7b commit 5")
+}
+
+/// Classical decrypt.
+pub fn decrypt(
+    _session: u32,
+    _key_handle: u32,
+    _mechanism: u32,
+    _ciphertext: &[u8],
+    _iv: Option<&[u8]>,
+) -> Result<Vec<u8>, CkRv> {
+    unimplemented!("native::encrypt::decrypt — Phase 7b commit 5")
+}
+
+/// ML-KEM encapsulation. Returns `(ciphertext, shared_secret)`.
+/// `public_key_handle` MUST refer to an ML-KEM public-key object.
+/// `mechanism` is `CKM_ML_KEM` (or a vendor variant).
+pub fn encapsulate(
+    _session: u32,
+    _public_key_handle: u32,
+    _mechanism: u32,
+) -> Result<(Vec<u8>, Vec<u8>), CkRv> {
+    unimplemented!("native::encrypt::encapsulate — Phase 7b commit 5")
+}
+
+/// ML-KEM decapsulation. Returns the recovered shared secret.
+/// `ciphertext` is the encapsulation produced by `encapsulate`.
+pub fn decapsulate(
+    _session: u32,
+    _private_key_handle: u32,
+    _mechanism: u32,
+    _ciphertext: &[u8],
+) -> Result<Vec<u8>, CkRv> {
+    unimplemented!("native::encrypt::decapsulate — Phase 7b commit 5")
+}

--- a/rust/src/native/encrypt.rs
+++ b/rust/src/native/encrypt.rs
@@ -1,60 +1,414 @@
 //! Encrypt / Decrypt / Encapsulate / Decapsulate — typed wrappers.
 //!
-//! `encrypt` / `decrypt` cover the classical symmetric / asymmetric paths
-//! (AES-GCM, AES-CBC, RSA-OAEP). `encapsulate` / `decapsulate` are the
-//! ML-KEM-specific calls — separate functions because they return
-//! (ciphertext + shared_secret) rather than just ciphertext.
+//! - **`encapsulate`** / **`decapsulate`** are the ML-KEM-specific calls.
+//!   Unlike the C ABI's `C_EncapsulateKey` / `C_DecapsulateKey` (which
+//!   allocate engine OBJECTS for the shared secret and return a handle),
+//!   the native API returns the shared secret bytes directly — that's
+//!   the shape KMIP's `Encrypt`/`Decrypt` responses need, and it lets
+//!   the caller decide whether to wrap the SS in another HSM object.
 //!
-//! Native wrappers around `ffi::C_EncryptInit` + `ffi::C_Encrypt`,
-//! `ffi::C_DecryptInit` + `ffi::C_Decrypt`, `ffi::C_EncapsulateKey`,
-//! `ffi::C_DecapsulateKey` — refactored to take typed args.
+//! - **`encrypt`** / **`decrypt`** cover the classical symmetric paths
+//!   (AES-GCM in v0.1; AES-CBC, AES-CTR, RSA-OAEP can be added when
+//!   KMIP exposes them). Asymmetric encrypt (RSA-OAEP) and additional
+//!   AES modes are TODO; commit 5 ships the dispatch skeleton + ML-KEM
+//!   full coverage, classical AES tests follow in commit 6 alongside
+//!   `generate_aes_key`.
 //!
-//! Implementation lands in Phase 7b commit 5.
+//! Implementation mirrors `ffi::C_Encrypt` / `ffi::C_Decrypt` /
+//! `ffi::C_EncapsulateKey` / `ffi::C_DecapsulateKey` minus the wasm32
+//! pointer marshalling for templates + the SS-handle allocation path.
+//!
+//! See [`super`] for the typed-vs-FFI architectural relationship.
 
 use super::CkRv;
+use crate::constants::*;
+use crate::state::{get_object_param_set, get_object_value, OBJECTS};
 
-/// Classical encrypt. `mechanism` ∈ {`CKM_AES_GCM`, `CKM_AES_CBC_PAD`,
-/// `CKM_RSA_PKCS_OAEP`, …}. `iv` carries IV for AES modes that need it
-/// (`None` for RSA-OAEP).
-pub fn encrypt(
-    _session: u32,
-    _key_handle: u32,
-    _mechanism: u32,
-    _plaintext: &[u8],
-    _iv: Option<&[u8]>,
-) -> Result<Vec<u8>, CkRv> {
-    unimplemented!("native::encrypt::encrypt — Phase 7b commit 5")
-}
-
-/// Classical decrypt.
-pub fn decrypt(
-    _session: u32,
-    _key_handle: u32,
-    _mechanism: u32,
-    _ciphertext: &[u8],
-    _iv: Option<&[u8]>,
-) -> Result<Vec<u8>, CkRv> {
-    unimplemented!("native::encrypt::decrypt — Phase 7b commit 5")
-}
+// PKCS#11 v3.2 §5.18 — KEM permission flags. CKA_ENCAPSULATE / CKA_DECAPSULATE.
+use crate::constants::{CKA_DECAPSULATE, CKA_DECRYPT, CKA_ENCAPSULATE, CKA_ENCRYPT};
 
 /// ML-KEM encapsulation. Returns `(ciphertext, shared_secret)`.
-/// `public_key_handle` MUST refer to an ML-KEM public-key object.
-/// `mechanism` is `CKM_ML_KEM` (or a vendor variant).
+///
+/// `public_key_handle` MUST refer to an ML-KEM public-key object with
+/// `CKA_ENCAPSULATE = true`. `mechanism` is `CKM_ML_KEM`.
+///
+/// Ciphertext / shared-secret lengths per FIPS 203 §7:
+/// - ML-KEM-512:  ct = 768, ss = 32
+/// - ML-KEM-768:  ct = 1088, ss = 32
+/// - ML-KEM-1024: ct = 1568, ss = 32
 pub fn encapsulate(
     _session: u32,
-    _public_key_handle: u32,
-    _mechanism: u32,
+    public_key_handle: u32,
+    mechanism: u32,
 ) -> Result<(Vec<u8>, Vec<u8>), CkRv> {
-    unimplemented!("native::encrypt::encapsulate — Phase 7b commit 5")
+    use ml_kem::{kem::Encapsulate, EncodedSizeUser, KemCore};
+
+    if mechanism != CKM_ML_KEM {
+        return Err(CKR_MECHANISM_INVALID);
+    }
+    if !check_flag(public_key_handle, CKA_ENCAPSULATE) {
+        return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
+    }
+
+    let ps = get_object_param_set(public_key_handle);
+    let pub_key_bytes = get_object_value(public_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+    let mut rng = rand::rngs::OsRng;
+
+    let (ct, ss) = match ps {
+        CKP_ML_KEM_512 => {
+            let ek_enc = ml_kem::array::Array::try_from(pub_key_bytes.as_slice())
+                .map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
+            let ek = <ml_kem::MlKem512 as KemCore>::EncapsulationKey::from_bytes(&ek_enc);
+            let (ct, ss) =
+                Encapsulate::encapsulate(&ek, &mut rng).map_err(|_| CKR_FUNCTION_FAILED)?;
+            (ct.as_slice().to_vec(), ss.as_slice().to_vec())
+        }
+        CKP_ML_KEM_768 | 0 => {
+            let ek_enc = ml_kem::array::Array::try_from(pub_key_bytes.as_slice())
+                .map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
+            let ek = <ml_kem::MlKem768 as KemCore>::EncapsulationKey::from_bytes(&ek_enc);
+            let (ct, ss) =
+                Encapsulate::encapsulate(&ek, &mut rng).map_err(|_| CKR_FUNCTION_FAILED)?;
+            (ct.as_slice().to_vec(), ss.as_slice().to_vec())
+        }
+        CKP_ML_KEM_1024 => {
+            let ek_enc = ml_kem::array::Array::try_from(pub_key_bytes.as_slice())
+                .map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
+            let ek = <ml_kem::MlKem1024 as KemCore>::EncapsulationKey::from_bytes(&ek_enc);
+            let (ct, ss) =
+                Encapsulate::encapsulate(&ek, &mut rng).map_err(|_| CKR_FUNCTION_FAILED)?;
+            (ct.as_slice().to_vec(), ss.as_slice().to_vec())
+        }
+        _ => return Err(CKR_ARGUMENTS_BAD),
+    };
+    Ok((ct, ss))
 }
 
 /// ML-KEM decapsulation. Returns the recovered shared secret.
-/// `ciphertext` is the encapsulation produced by `encapsulate`.
+///
+/// `private_key_handle` MUST refer to an ML-KEM private-key object with
+/// `CKA_DECAPSULATE = true`. `ciphertext` length must match the
+/// parameter set's ML-KEM ct size (768 / 1088 / 1568 for 512 / 768 / 1024).
 pub fn decapsulate(
     _session: u32,
-    _private_key_handle: u32,
-    _mechanism: u32,
-    _ciphertext: &[u8],
+    private_key_handle: u32,
+    mechanism: u32,
+    ciphertext: &[u8],
 ) -> Result<Vec<u8>, CkRv> {
-    unimplemented!("native::encrypt::decapsulate — Phase 7b commit 5")
+    use ml_kem::{kem::Decapsulate, EncodedSizeUser, KemCore};
+
+    if mechanism != CKM_ML_KEM {
+        return Err(CKR_MECHANISM_INVALID);
+    }
+    if !check_flag(private_key_handle, CKA_DECAPSULATE) {
+        return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
+    }
+
+    let ps = get_object_param_set(private_key_handle);
+    let expected_ct_len: usize = match ps {
+        CKP_ML_KEM_512 => 768,
+        CKP_ML_KEM_768 | 0 => 1088,
+        CKP_ML_KEM_1024 => 1568,
+        _ => return Err(CKR_ARGUMENTS_BAD),
+    };
+    if ciphertext.len() != expected_ct_len {
+        return Err(CKR_ARGUMENTS_BAD);
+    }
+
+    let prv_key_bytes = get_object_value(private_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+
+    let ss = match ps {
+        CKP_ML_KEM_512 => {
+            let dk_enc = ml_kem::array::Array::try_from(prv_key_bytes.as_slice())
+                .map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
+            let dk = <ml_kem::MlKem512 as KemCore>::DecapsulationKey::from_bytes(&dk_enc);
+            let ct_enc =
+                ml_kem::array::Array::try_from(ciphertext).map_err(|_| CKR_ARGUMENTS_BAD)?;
+            Decapsulate::decapsulate(&dk, &ct_enc).map_err(|_| CKR_FUNCTION_FAILED)?
+        }
+        CKP_ML_KEM_768 | 0 => {
+            let dk_enc = ml_kem::array::Array::try_from(prv_key_bytes.as_slice())
+                .map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
+            let dk = <ml_kem::MlKem768 as KemCore>::DecapsulationKey::from_bytes(&dk_enc);
+            let ct_enc =
+                ml_kem::array::Array::try_from(ciphertext).map_err(|_| CKR_ARGUMENTS_BAD)?;
+            Decapsulate::decapsulate(&dk, &ct_enc).map_err(|_| CKR_FUNCTION_FAILED)?
+        }
+        CKP_ML_KEM_1024 => {
+            let dk_enc = ml_kem::array::Array::try_from(prv_key_bytes.as_slice())
+                .map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
+            let dk = <ml_kem::MlKem1024 as KemCore>::DecapsulationKey::from_bytes(&dk_enc);
+            let ct_enc =
+                ml_kem::array::Array::try_from(ciphertext).map_err(|_| CKR_ARGUMENTS_BAD)?;
+            Decapsulate::decapsulate(&dk, &ct_enc).map_err(|_| CKR_FUNCTION_FAILED)?
+        }
+        _ => return Err(CKR_ARGUMENTS_BAD),
+    };
+    Ok(ss.as_slice().to_vec())
+}
+
+/// Classical encrypt. v0.1 supports `CKM_AES_GCM`.
+///
+/// For AES-GCM, `iv` is the 12-byte nonce. Empty AAD is used; if KMIP
+/// ever exposes AAD in its Encrypt request, this function can grow an
+/// optional `aad` arg.
+///
+/// Other modes (AES-CBC, AES-CTR, RSA-OAEP) return
+/// `CKR_MECHANISM_INVALID` in v0.1 — easy to add when KMIP needs them.
+pub fn encrypt(
+    _session: u32,
+    key_handle: u32,
+    mechanism: u32,
+    plaintext: &[u8],
+    iv: Option<&[u8]>,
+) -> Result<Vec<u8>, CkRv> {
+    if !check_flag(key_handle, CKA_ENCRYPT) {
+        return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
+    }
+    let key_bytes = get_object_value(key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+
+    match mechanism {
+        CKM_AES_GCM => {
+            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
+            aes_gcm_encrypt(&key_bytes, iv, plaintext)
+        }
+        _ => Err(CKR_MECHANISM_INVALID),
+    }
+}
+
+/// Classical decrypt. v0.1 supports `CKM_AES_GCM`.
+pub fn decrypt(
+    _session: u32,
+    key_handle: u32,
+    mechanism: u32,
+    ciphertext: &[u8],
+    iv: Option<&[u8]>,
+) -> Result<Vec<u8>, CkRv> {
+    if !check_flag(key_handle, CKA_DECRYPT) {
+        return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
+    }
+    let key_bytes = get_object_value(key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+
+    match mechanism {
+        CKM_AES_GCM => {
+            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
+            aes_gcm_decrypt(&key_bytes, iv, ciphertext)
+        }
+        _ => Err(CKR_MECHANISM_INVALID),
+    }
+}
+
+// ── AES-GCM ─────────────────────────────────────────────────────────────────
+
+fn aes_gcm_encrypt(key: &[u8], iv: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, CkRv> {
+    use aes_gcm::aead::generic_array::GenericArray;
+    use aes_gcm::{aead::{Aead, Payload}, Aes128Gcm, Aes256Gcm, KeyInit};
+    if iv.len() != 12 {
+        return Err(CKR_ARGUMENTS_BAD);
+    }
+    let nonce = GenericArray::from_slice(iv);
+    let payload = Payload { msg: plaintext, aad: &[] };
+    match key.len() {
+        16 => {
+            let cipher = Aes128Gcm::new_from_slice(key).map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
+            cipher.encrypt(nonce, payload).map_err(|_| CKR_FUNCTION_FAILED)
+        }
+        32 => {
+            let cipher = Aes256Gcm::new_from_slice(key).map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
+            cipher.encrypt(nonce, payload).map_err(|_| CKR_FUNCTION_FAILED)
+        }
+        _ => Err(CKR_KEY_TYPE_INCONSISTENT),
+    }
+}
+
+fn aes_gcm_decrypt(key: &[u8], iv: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, CkRv> {
+    use aes_gcm::aead::generic_array::GenericArray;
+    use aes_gcm::{aead::{Aead, Payload}, Aes128Gcm, Aes256Gcm, KeyInit};
+    if iv.len() != 12 {
+        return Err(CKR_ARGUMENTS_BAD);
+    }
+    let nonce = GenericArray::from_slice(iv);
+    let payload = Payload { msg: ciphertext, aad: &[] };
+    match key.len() {
+        16 => {
+            let cipher = Aes128Gcm::new_from_slice(key).map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
+            // GCM tag failure → CKR_ENCRYPTED_DATA_INVALID (PKCS#11 v3.2 §6.13).
+            cipher.decrypt(nonce, payload).map_err(|_| CKR_ENCRYPTED_DATA_INVALID)
+        }
+        32 => {
+            let cipher = Aes256Gcm::new_from_slice(key).map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
+            cipher.decrypt(nonce, payload).map_err(|_| CKR_ENCRYPTED_DATA_INVALID)
+        }
+        _ => Err(CKR_KEY_TYPE_INCONSISTENT),
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Check a single CK_BBOOL attribute on the key. Returns `false` if the
+/// key is missing or the flag is not set. Mirrors `check_can_sign`
+/// in [`super::sign`].
+fn check_flag(key_handle: u32, attr_type: u32) -> bool {
+    OBJECTS.with(|o| {
+        o.borrow()
+            .get(&key_handle)
+            .and_then(|attrs| attrs.get(&attr_type))
+            .map(|v| !v.is_empty() && v[0] == 0x01)
+            .unwrap_or(false)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::keygen::{generate_ml_dsa_keypair, generate_ml_kem_keypair};
+    use crate::native::session::{bootstrap_default_token, close_session, finalize, init};
+    use crate::native::test_lock;
+
+    fn fresh_session() -> u32 {
+        let _ = finalize();
+        init().unwrap();
+        bootstrap_default_token(0, "so", "user", "native-encap-test").unwrap()
+    }
+
+    /// ML-KEM-768 round-trip: keygen → encap(pub_h) → decap(prv_h, ct) →
+    /// shared secrets match exactly. FIPS 203 §7.4 — ct=1088, ss=32.
+    #[test]
+    fn ml_kem_768_encap_decap_round_trip() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ml_kem_keypair(session, CKP_ML_KEM_768, b"\x01", "kem-768").unwrap();
+
+        let (ct, ss_enc) = encapsulate(session, pub_h, CKM_ML_KEM).unwrap();
+        assert_eq!(ct.len(), 1088, "FIPS 203 §7.4 ML-KEM-768 ct = 1088 bytes");
+        assert_eq!(ss_enc.len(), 32, "FIPS 203 §7.4 ML-KEM-768 ss = 32 bytes");
+
+        let ss_dec = decapsulate(session, prv_h, CKM_ML_KEM, &ct).unwrap();
+        assert_eq!(ss_enc, ss_dec, "encap SS must equal decap SS");
+
+        close_session(session).unwrap();
+    }
+
+    /// ML-KEM-512: ct=768, ss=32 (FIPS 203 §7.4).
+    #[test]
+    fn ml_kem_512_encap_decap_round_trip() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ml_kem_keypair(session, CKP_ML_KEM_512, b"\x01", "kem-512").unwrap();
+        let (ct, ss_enc) = encapsulate(session, pub_h, CKM_ML_KEM).unwrap();
+        assert_eq!(ct.len(), 768);
+        assert_eq!(ss_enc.len(), 32);
+        let ss_dec = decapsulate(session, prv_h, CKM_ML_KEM, &ct).unwrap();
+        assert_eq!(ss_enc, ss_dec);
+        close_session(session).unwrap();
+    }
+
+    /// ML-KEM-1024: ct=1568, ss=32.
+    #[test]
+    fn ml_kem_1024_encap_decap_round_trip() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ml_kem_keypair(session, CKP_ML_KEM_1024, b"\x01", "kem-1024").unwrap();
+        let (ct, ss_enc) = encapsulate(session, pub_h, CKM_ML_KEM).unwrap();
+        assert_eq!(ct.len(), 1568);
+        let ss_dec = decapsulate(session, prv_h, CKM_ML_KEM, &ct).unwrap();
+        assert_eq!(ss_enc, ss_dec);
+        close_session(session).unwrap();
+    }
+
+    /// Encap with the private-key handle (CKA_ENCAPSULATE = false on
+    /// private side) → CKR_KEY_FUNCTION_NOT_PERMITTED.
+    #[test]
+    fn encap_with_private_key_handle_is_denied() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (_pub_h, prv_h) =
+            generate_ml_kem_keypair(session, CKP_ML_KEM_768, b"\x01", "denied").unwrap();
+        let result = encapsulate(session, prv_h, CKM_ML_KEM);
+        assert_eq!(result.unwrap_err(), CKR_KEY_FUNCTION_NOT_PERMITTED);
+        close_session(session).unwrap();
+    }
+
+    /// Decap with the public-key handle (CKA_DECAPSULATE = false on
+    /// public side) → CKR_KEY_FUNCTION_NOT_PERMITTED.
+    #[test]
+    fn decap_with_public_key_handle_is_denied() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, _prv_h) =
+            generate_ml_kem_keypair(session, CKP_ML_KEM_768, b"\x01", "denied").unwrap();
+        let bogus_ct = vec![0u8; 1088];
+        let result = decapsulate(session, pub_h, CKM_ML_KEM, &bogus_ct);
+        assert_eq!(result.unwrap_err(), CKR_KEY_FUNCTION_NOT_PERMITTED);
+        close_session(session).unwrap();
+    }
+
+    /// Encap on an ML-DSA key (CKA_ENCAPSULATE=false on signing keys) →
+    /// CKR_KEY_FUNCTION_NOT_PERMITTED. Cross-family permission check.
+    #[test]
+    fn ml_dsa_key_cannot_encapsulate() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, _) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\x01", "dsa-not-kem").unwrap();
+        let result = encapsulate(session, pub_h, CKM_ML_KEM);
+        assert_eq!(result.unwrap_err(), CKR_KEY_FUNCTION_NOT_PERMITTED);
+        close_session(session).unwrap();
+    }
+
+    /// Wrong mechanism on encap → CKR_MECHANISM_INVALID.
+    #[test]
+    fn encap_with_wrong_mechanism_returns_err() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, _) =
+            generate_ml_kem_keypair(session, CKP_ML_KEM_768, b"\x01", "wrong-mech").unwrap();
+        let result = encapsulate(session, pub_h, CKM_ML_DSA);
+        assert_eq!(result.unwrap_err(), CKR_MECHANISM_INVALID);
+        close_session(session).unwrap();
+    }
+
+    /// Decap with wrong-length ciphertext → CKR_ARGUMENTS_BAD.
+    #[test]
+    fn decap_with_wrong_ciphertext_length_returns_err() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (_pub_h, prv_h) =
+            generate_ml_kem_keypair(session, CKP_ML_KEM_768, b"\x01", "wrong-len").unwrap();
+        // ML-KEM-768 expects ct.len() == 1088; pass 1024.
+        let result = decapsulate(session, prv_h, CKM_ML_KEM, &vec![0u8; 1024]);
+        assert_eq!(result.unwrap_err(), CKR_ARGUMENTS_BAD);
+        close_session(session).unwrap();
+    }
+
+    /// Distinct encap calls produce different ciphertexts but valid
+    /// decap each time (probabilistic encapsulation per FIPS 203 §6.2).
+    #[test]
+    fn encap_is_probabilistic_but_decap_recovers_each_time() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ml_kem_keypair(session, CKP_ML_KEM_768, b"\x01", "probabilistic").unwrap();
+        let (ct1, ss1) = encapsulate(session, pub_h, CKM_ML_KEM).unwrap();
+        let (ct2, ss2) = encapsulate(session, pub_h, CKM_ML_KEM).unwrap();
+        // Two distinct ciphertexts (overwhelming probability — both
+        // sampled from a 256-bit random space).
+        assert_ne!(ct1, ct2, "encap must be probabilistic");
+        assert_ne!(ss1, ss2);
+        // Each decapsulates to its own SS.
+        assert_eq!(decapsulate(session, prv_h, CKM_ML_KEM, &ct1).unwrap(), ss1);
+        assert_eq!(decapsulate(session, prv_h, CKM_ML_KEM, &ct2).unwrap(), ss2);
+        close_session(session).unwrap();
+    }
+
+    // ── AES-GCM tests deferred to commit 6 alongside generate_aes_key ──────
+    //
+    // The encrypt() / decrypt() dispatch + aes_gcm_{encrypt,decrypt}
+    // helpers are implemented in this commit (mirrors ffi::C_Encrypt's
+    // AES-GCM path) but need a real AES key to test against. Commit 6
+    // adds `generate_aes_key(session, bits, cka_id, label)` and the
+    // round-trip tests land alongside it.
 }

--- a/rust/src/native/keygen.rs
+++ b/rust/src/native/keygen.rs
@@ -21,10 +21,14 @@ use std::collections::HashMap;
 
 use super::CkRv;
 use crate::constants::*;
-use crate::crypto::{ALGO_ML_DSA, ALGO_ML_KEM, ALGO_SLH_DSA};
+use crate::crypto::{
+    ALGO_ECDSA, ALGO_ML_DSA, ALGO_ML_KEM, ALGO_RSA, ALGO_SLH_DSA, CURVE_K256, CURVE_P256,
+    CURVE_P384, CURVE_P521,
+};
 use crate::crypto::handlers::{
-    build_mldsa44_spki, build_mldsa65_spki, build_mldsa87_spki, build_mlkem512_spki,
-    build_mlkem768_spki, build_mlkem1024_spki, build_slhdsa_spki, Attributes,
+    build_ec_spki_p256, build_ec_spki_p384, build_ec_spki_p521, build_mldsa44_spki,
+    build_mldsa65_spki, build_mldsa87_spki, build_mlkem1024_spki, build_mlkem512_spki,
+    build_mlkem768_spki, build_slhdsa_spki, build_spki_from_parts, Attributes,
 };
 use crate::state::{
     allocate_handle, compute_kcv, finalize_private_key_attrs, store_algo_family, store_bool,
@@ -225,27 +229,253 @@ pub fn generate_slh_dsa_keypair(
     finalize_and_register(pub_attrs, prv_attrs)
 }
 
-// ── Classical (deferred to commit 6 per docs/NATIVE_API.md §9) ──────────────
+// ── Classical ───────────────────────────────────────────────────────────────
 
+/// Generate an RSA keypair. `bits` ∈ {2048, 3072, 4096} per FIPS 186-5
+/// transition (engine permits ≥ 2048). Returns `(public_handle,
+/// private_handle)`.
+///
+/// Mirrors `ffi::C_GenerateKeyPair @ CKM_RSA_PKCS_KEY_PAIR_GEN`:
+/// stores RSA modulus + public exponent on the public-key object as
+/// `CKA_MODULUS` + `CKA_PUBLIC_EXPONENT` (PKCS#11 v3.2 §2.1.2 — separate
+/// attributes, NOT packed into `CKA_VALUE`). Private key bytes are the
+/// PKCS#8-DER-encoded `RsaPrivateKey`.
+///
+/// Also writes an engine-specific packed `CKA_VALUE`
+/// (`[n_len:4LE][n][e]`) on the public-key object so the existing
+/// `C_Encrypt(CKM_RSA_PKCS_OAEP)` path can read the public key
+/// uniformly via `get_object_value()`.
 pub fn generate_rsa_keypair(
-    _session: u32, _bits: u32, _cka_id: &[u8], _label: &str,
+    _session: u32,
+    bits: u32,
+    cka_id: &[u8],
+    label: &str,
 ) -> Result<(u32, u32), CkRv> {
-    unimplemented!("native::keygen::generate_rsa_keypair — Phase 7b commit 6")
+    use rsa::pkcs8::EncodePrivateKey;
+    use rsa::traits::PublicKeyParts;
+
+    if !(2048..=4096).contains(&bits) {
+        return Err(CKR_ARGUMENTS_BAD);
+    }
+    let mut rng = rand::rngs::OsRng;
+    let private_key =
+        rsa::RsaPrivateKey::new(&mut rng, bits as usize).map_err(|_| CKR_FUNCTION_FAILED)?;
+    let public_key = rsa::RsaPublicKey::from(&private_key);
+
+    let sk_der = private_key.to_pkcs8_der().map_err(|_| CKR_FUNCTION_FAILED)?;
+    let n_bytes = public_key.n().to_bytes_be();
+    let e_bytes = public_key.e().to_bytes_be();
+
+    let mut pub_attrs: Attributes = HashMap::new();
+    let mut prv_attrs: Attributes = HashMap::new();
+
+    store_algo_family(&mut pub_attrs, ALGO_RSA);
+    store_algo_family(&mut prv_attrs, ALGO_RSA);
+
+    // PKCS#11 v3.2 — RSA public key defaults (CKA_VERIFY=true, CKA_ENCRYPT=true,
+    // CKA_WRAP=true; not CKA_SIGN/DECRYPT).
+    store_ulong(&mut pub_attrs, CKA_CLASS, CKO_PUBLIC_KEY);
+    store_ulong(&mut pub_attrs, CKA_KEY_TYPE, CKK_RSA);
+    store_ulong(&mut pub_attrs, CKA_KEY_GEN_MECHANISM, CKM_RSA_PKCS_KEY_PAIR_GEN);
+    store_bool(&mut pub_attrs, CKA_TOKEN, false);
+    store_bool(&mut pub_attrs, CKA_PRIVATE, false);
+    store_bool(&mut pub_attrs, CKA_ENCRYPT, true);
+    store_bool(&mut pub_attrs, CKA_VERIFY, true);
+    store_bool(&mut pub_attrs, CKA_WRAP, true);
+    store_bool(&mut pub_attrs, CKA_DERIVE, false);
+    store_bool(&mut pub_attrs, CKA_LOCAL, true);
+
+    // PKCS#11 v3.2 — RSA private key defaults.
+    store_ulong(&mut prv_attrs, CKA_CLASS, CKO_PRIVATE_KEY);
+    store_ulong(&mut prv_attrs, CKA_KEY_TYPE, CKK_RSA);
+    store_ulong(&mut prv_attrs, CKA_KEY_GEN_MECHANISM, CKM_RSA_PKCS_KEY_PAIR_GEN);
+    store_bool(&mut prv_attrs, CKA_TOKEN, false);
+    store_bool(&mut prv_attrs, CKA_PRIVATE, true);
+    store_bool(&mut prv_attrs, CKA_SENSITIVE, true);
+    store_bool(&mut prv_attrs, CKA_EXTRACTABLE, false);
+    store_bool(&mut prv_attrs, CKA_DECRYPT, true);
+    store_bool(&mut prv_attrs, CKA_SIGN, true);
+    store_bool(&mut prv_attrs, CKA_UNWRAP, true);
+    store_bool(&mut prv_attrs, CKA_DERIVE, false);
+    store_bool(&mut prv_attrs, CKA_LOCAL, true);
+
+    // PKCS#11 v3.2 §2.1.2 — modulus + exponent as distinct attributes.
+    pub_attrs.insert(CKA_MODULUS, n_bytes.clone());
+    pub_attrs.insert(CKA_PUBLIC_EXPONENT, e_bytes.clone());
+    store_ulong(&mut pub_attrs, CKA_MODULUS_BITS, bits);
+
+    // SubjectPublicKeyInfo DER (CKA_PUBLIC_KEY_INFO).
+    use rsa::pkcs8::EncodePublicKey;
+    if let Ok(spki_der) = public_key.to_public_key_der() {
+        pub_attrs.insert(CKA_PUBLIC_KEY_INFO, spki_der.as_bytes().to_vec());
+    }
+
+    // Engine-internal packed CKA_VALUE on the public key so C_Encrypt
+    // (CKM_RSA_PKCS_OAEP) can reconstruct via get_object_value().
+    // Format mirrors ffi.rs: [n_len:4LE][n_bytes][e_bytes].
+    let mut packed = Vec::with_capacity(4 + n_bytes.len() + e_bytes.len());
+    packed.extend_from_slice(&(n_bytes.len() as u32).to_le_bytes());
+    packed.extend_from_slice(&n_bytes);
+    packed.extend_from_slice(&e_bytes);
+    pub_attrs.insert(CKA_VALUE, packed);
+    prv_attrs.insert(CKA_VALUE, sk_der.as_bytes().to_vec());
+
+    insert_id_and_label(&mut pub_attrs, cka_id, label);
+    insert_id_and_label(&mut prv_attrs, cka_id, label);
+
+    finalize_and_register(pub_attrs, prv_attrs)
 }
+
+/// Generate an ECDSA keypair. `curve` is one of:
+///
+/// - `EccCurve::P256` (NIST P-256)
+/// - `EccCurve::P384` (NIST P-384)
+/// - `EccCurve::P521` (NIST P-521)
+/// - `EccCurve::Secp256K1`
+///
+/// Returns `(public_handle, private_handle)`.
+///
+/// **Pre-condition**: `session` must be a valid R/W user session.
 pub fn generate_ecdsa_keypair(
-    _session: u32, _curve_oid: &[u8], _cka_id: &[u8], _label: &str,
+    _session: u32,
+    curve: EccCurve,
+    cka_id: &[u8],
+    label: &str,
 ) -> Result<(u32, u32), CkRv> {
-    unimplemented!("native::keygen::generate_ecdsa_keypair — Phase 7b commit 6")
+    let mut pub_attrs: Attributes = HashMap::new();
+    let mut prv_attrs: Attributes = HashMap::new();
+
+    store_algo_family(&mut pub_attrs, ALGO_ECDSA);
+    store_algo_family(&mut prv_attrs, ALGO_ECDSA);
+
+    set_common_ec_pub_attrs(&mut pub_attrs);
+    set_common_ec_prv_attrs(&mut prv_attrs);
+
+    let mut rng = rand::rngs::OsRng;
+
+    // Per-curve keygen + attribute population.
+    match curve {
+        EccCurve::P256 => {
+            store_param_set(&mut pub_attrs, CURVE_P256);
+            store_param_set(&mut prv_attrs, CURVE_P256);
+            let sk = p256::ecdsa::SigningKey::random(&mut rng);
+            let vk = p256::ecdsa::VerifyingKey::from(&sk);
+            prv_attrs.insert(CKA_VALUE, sk.to_bytes().to_vec());
+            let vk_bytes = vk.to_encoded_point(false).as_bytes().to_vec();
+            // CKA_EC_POINT: DER OCTET STRING wrapping the uncompressed SEC1 point.
+            let mut ec_point = Vec::with_capacity(2 + vk_bytes.len());
+            ec_point.push(0x04);
+            ec_point.push(vk_bytes.len() as u8); // 65 fits in one byte (short-form)
+            ec_point.extend_from_slice(&vk_bytes);
+            pub_attrs.insert(CKA_EC_POINT, ec_point);
+            pub_attrs.insert(CKA_PUBLIC_KEY_INFO, build_ec_spki_p256(&vk_bytes));
+        }
+        EccCurve::P384 => {
+            store_param_set(&mut pub_attrs, CURVE_P384);
+            store_param_set(&mut prv_attrs, CURVE_P384);
+            let sk = p384::ecdsa::SigningKey::random(&mut rng);
+            let vk = p384::ecdsa::VerifyingKey::from(&sk);
+            prv_attrs.insert(CKA_VALUE, sk.to_bytes().to_vec());
+            let vk_bytes = vk.to_encoded_point(false).as_bytes().to_vec();
+            let mut ec_point = Vec::with_capacity(2 + vk_bytes.len());
+            ec_point.push(0x04);
+            ec_point.push(vk_bytes.len() as u8); // 97 fits in one byte
+            ec_point.extend_from_slice(&vk_bytes);
+            pub_attrs.insert(CKA_EC_POINT, ec_point);
+            pub_attrs.insert(CKA_PUBLIC_KEY_INFO, build_ec_spki_p384(&vk_bytes));
+        }
+        EccCurve::P521 => {
+            store_param_set(&mut pub_attrs, CURVE_P521);
+            store_param_set(&mut prv_attrs, CURVE_P521);
+            let sk = p521::ecdsa::SigningKey::random(&mut rng);
+            let vk = p521::ecdsa::VerifyingKey::from(&sk);
+            prv_attrs.insert(CKA_VALUE, sk.to_bytes().to_vec());
+            let vk_bytes = vk.to_encoded_point(false).as_bytes().to_vec();
+            // P-521 uncompressed point is 133 bytes — needs long-form DER length.
+            let mut ec_point = Vec::with_capacity(3 + vk_bytes.len());
+            ec_point.push(0x04);
+            ec_point.push(0x81); // multi-byte length tag
+            ec_point.push(vk_bytes.len() as u8); // 133
+            ec_point.extend_from_slice(&vk_bytes);
+            pub_attrs.insert(CKA_EC_POINT, ec_point);
+            pub_attrs.insert(CKA_PUBLIC_KEY_INFO, build_ec_spki_p521(&vk_bytes));
+        }
+        EccCurve::Secp256K1 => {
+            store_param_set(&mut pub_attrs, CURVE_K256);
+            store_param_set(&mut prv_attrs, CURVE_K256);
+            let sk = k256::ecdsa::SigningKey::random(&mut rng);
+            let vk = k256::ecdsa::VerifyingKey::from(&sk);
+            prv_attrs.insert(CKA_VALUE, sk.to_bytes().to_vec());
+            let vk_bytes = vk.to_encoded_point(false).as_bytes().to_vec();
+            let mut ec_point = Vec::with_capacity(2 + vk_bytes.len());
+            ec_point.push(0x04);
+            ec_point.push(vk_bytes.len() as u8);
+            ec_point.extend_from_slice(&vk_bytes);
+            pub_attrs.insert(CKA_EC_POINT, ec_point);
+            // secp256k1 SPKI uses its own algorithm-id OID (1.3.132.0.10).
+            // Same DER prefix the ffi path uses.
+            const SECP256K1_ALG_ID: &[u8] = &[
+                0x30, 0x10, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x05, 0x2b,
+                0x81, 0x04, 0x00, 0x0a,
+            ];
+            pub_attrs.insert(
+                CKA_PUBLIC_KEY_INFO,
+                build_spki_from_parts(SECP256K1_ALG_ID, &vk_bytes),
+            );
+        }
+    }
+
+    insert_id_and_label(&mut pub_attrs, cka_id, label);
+    insert_id_and_label(&mut prv_attrs, cka_id, label);
+
+    finalize_and_register(pub_attrs, prv_attrs)
 }
+
+/// Generate an AES secret key. `bits` ∈ {128, 256} (192 is permitted by
+/// PKCS#11 but the engine only supports 128 and 256 today).
 pub fn generate_aes_key(
-    _session: u32, _bits: u32, _cka_id: &[u8], _label: &str,
+    _session: u32,
+    bits: u32,
+    cka_id: &[u8],
+    label: &str,
 ) -> Result<u32, CkRv> {
-    unimplemented!("native::keygen::generate_aes_key — Phase 7b commit 6")
+    let bytes = match bits {
+        128 => 16usize,
+        256 => 32usize,
+        _ => return Err(CKR_ARGUMENTS_BAD),
+    };
+    let mut key = vec![0u8; bytes];
+    getrandom::getrandom(&mut key).map_err(|_| CKR_FUNCTION_FAILED)?;
+    let attrs = build_aes_attrs(key, bytes as u32, cka_id, label);
+    Ok(allocate_handle(finalize_secret_attrs(attrs)))
 }
+
+/// Generate a Generic-Secret key (HMAC etc.). `bits` ∈ [8, 4096] in
+/// multiples of 8 (engine permits 1..=512 bytes).
 pub fn generate_generic_secret(
-    _session: u32, _bits: u32, _cka_id: &[u8], _label: &str,
+    _session: u32,
+    bits: u32,
+    cka_id: &[u8],
+    label: &str,
 ) -> Result<u32, CkRv> {
-    unimplemented!("native::keygen::generate_generic_secret — Phase 7b commit 6")
+    if !(8..=4096).contains(&bits) || bits % 8 != 0 {
+        return Err(CKR_ARGUMENTS_BAD);
+    }
+    let bytes = (bits / 8) as usize;
+    let mut key = vec![0u8; bytes];
+    getrandom::getrandom(&mut key).map_err(|_| CKR_FUNCTION_FAILED)?;
+    let attrs = build_generic_secret_attrs(key, bytes as u32, cka_id, label);
+    Ok(allocate_handle(finalize_secret_attrs(attrs)))
+}
+
+/// ECDSA curve identifier used by [`generate_ecdsa_keypair`]. v0.1
+/// covers the four curves the engine supports.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum EccCurve {
+    P256,
+    P384,
+    P521,
+    Secp256K1,
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -294,6 +524,101 @@ fn set_common_prv_attrs(
     store_bool(attrs, CKA_UNWRAP, false);
     store_bool(attrs, CKA_DERIVE, false);
     store_bool(attrs, CKA_LOCAL, true);
+}
+
+/// Shared ECDSA public-key attribute defaults — mirrors `ffi::C_GenerateKeyPair @
+/// CKM_EC_KEY_PAIR_GEN`. CKA_VERIFY=true, CKA_ENCRYPT/WRAP/DERIVE=false.
+fn set_common_ec_pub_attrs(attrs: &mut Attributes) {
+    store_ulong(attrs, CKA_CLASS, CKO_PUBLIC_KEY);
+    store_ulong(attrs, CKA_KEY_TYPE, CKK_EC);
+    store_ulong(attrs, CKA_KEY_GEN_MECHANISM, CKM_EC_KEY_PAIR_GEN);
+    store_bool(attrs, CKA_TOKEN, false);
+    store_bool(attrs, CKA_PRIVATE, false);
+    store_bool(attrs, CKA_ENCRYPT, false);
+    store_bool(attrs, CKA_VERIFY, true);
+    store_bool(attrs, CKA_WRAP, false);
+    store_bool(attrs, CKA_DERIVE, false);
+    store_bool(attrs, CKA_LOCAL, true);
+}
+
+/// Shared ECDSA private-key attribute defaults. CKA_SIGN=true,
+/// CKA_DERIVE=true (supports ECDH), CKA_SENSITIVE+EXTRACTABLE per FIPS.
+fn set_common_ec_prv_attrs(attrs: &mut Attributes) {
+    store_ulong(attrs, CKA_CLASS, CKO_PRIVATE_KEY);
+    store_ulong(attrs, CKA_KEY_TYPE, CKK_EC);
+    store_ulong(attrs, CKA_KEY_GEN_MECHANISM, CKM_EC_KEY_PAIR_GEN);
+    store_bool(attrs, CKA_TOKEN, false);
+    store_bool(attrs, CKA_PRIVATE, true);
+    store_bool(attrs, CKA_SENSITIVE, true);
+    store_bool(attrs, CKA_EXTRACTABLE, false);
+    store_bool(attrs, CKA_DECRYPT, false);
+    store_bool(attrs, CKA_SIGN, true);
+    store_bool(attrs, CKA_UNWRAP, false);
+    store_bool(attrs, CKA_DERIVE, true); // ECDH-capable per PKCS#11 v3.2 §2.3
+    store_bool(attrs, CKA_LOCAL, true);
+}
+
+/// Build the attribute map for an AES secret key. Mirrors
+/// `ffi::C_GenerateKey @ CKM_AES_KEY_GEN`.
+fn build_aes_attrs(key: Vec<u8>, key_len_bytes: u32, cka_id: &[u8], label: &str) -> Attributes {
+    let mut attrs: Attributes = HashMap::new();
+    attrs.insert(CKA_VALUE, key);
+    store_ulong(&mut attrs, CKA_CLASS, CKO_SECRET_KEY);
+    store_ulong(&mut attrs, CKA_KEY_TYPE, CKK_AES);
+    store_ulong(&mut attrs, CKA_VALUE_LEN, key_len_bytes);
+    store_ulong(&mut attrs, CKA_KEY_GEN_MECHANISM, CKM_AES_KEY_GEN);
+    store_bool(&mut attrs, CKA_TOKEN, false);
+    store_bool(&mut attrs, CKA_PRIVATE, false);
+    store_bool(&mut attrs, CKA_SENSITIVE, false);
+    store_bool(&mut attrs, CKA_EXTRACTABLE, false);
+    store_bool(&mut attrs, CKA_ENCRYPT, true);
+    store_bool(&mut attrs, CKA_DECRYPT, true);
+    store_bool(&mut attrs, CKA_WRAP, true);
+    store_bool(&mut attrs, CKA_UNWRAP, true);
+    store_bool(&mut attrs, CKA_SIGN, false);
+    store_bool(&mut attrs, CKA_VERIFY, false);
+    store_bool(&mut attrs, CKA_DERIVE, false);
+    store_bool(&mut attrs, CKA_LOCAL, true);
+    insert_id_and_label(&mut attrs, cka_id, label);
+    attrs
+}
+
+/// Build the attribute map for a Generic-Secret key (HMAC). Mirrors
+/// `ffi::C_GenerateKey @ CKM_GENERIC_SECRET_KEY_GEN`.
+fn build_generic_secret_attrs(
+    key: Vec<u8>,
+    key_len_bytes: u32,
+    cka_id: &[u8],
+    label: &str,
+) -> Attributes {
+    let mut attrs: Attributes = HashMap::new();
+    attrs.insert(CKA_VALUE, key);
+    store_ulong(&mut attrs, CKA_CLASS, CKO_SECRET_KEY);
+    store_ulong(&mut attrs, CKA_KEY_TYPE, CKK_GENERIC_SECRET);
+    store_ulong(&mut attrs, CKA_VALUE_LEN, key_len_bytes);
+    store_ulong(&mut attrs, CKA_KEY_GEN_MECHANISM, CKM_GENERIC_SECRET_KEY_GEN);
+    store_bool(&mut attrs, CKA_TOKEN, false);
+    store_bool(&mut attrs, CKA_SENSITIVE, false);
+    store_bool(&mut attrs, CKA_EXTRACTABLE, false);
+    store_bool(&mut attrs, CKA_ENCRYPT, false);
+    store_bool(&mut attrs, CKA_DECRYPT, false);
+    store_bool(&mut attrs, CKA_WRAP, false);
+    store_bool(&mut attrs, CKA_UNWRAP, false);
+    store_bool(&mut attrs, CKA_SIGN, true); // HMAC signing
+    store_bool(&mut attrs, CKA_VERIFY, true);
+    store_bool(&mut attrs, CKA_DERIVE, false);
+    store_bool(&mut attrs, CKA_LOCAL, true);
+    insert_id_and_label(&mut attrs, cka_id, label);
+    attrs
+}
+
+/// Finalise a secret-key (AES / Generic Secret) attribute map: runs
+/// `finalize_private_key_attrs` (sets CKA_ALWAYS_SENSITIVE +
+/// CKA_NEVER_EXTRACTABLE) + `compute_kcv`.
+fn finalize_secret_attrs(mut attrs: Attributes) -> Attributes {
+    finalize_private_key_attrs(&mut attrs);
+    compute_kcv(&mut attrs);
+    attrs
 }
 
 fn insert_id_and_label(attrs: &mut Attributes, cka_id: &[u8], label: &str) {
@@ -465,6 +790,189 @@ mod tests {
         let stored_label = get_object_attr_bytes(pub_h, CKA_LABEL).expect("CKA_LABEL stored");
         assert_eq!(stored_label, label.as_bytes());
 
+        close_session(session).unwrap();
+    }
+
+    // ── Classical ──────────────────────────────────────────────────────────
+
+    /// RSA-2048 keygen: modulus stored as separate attribute (PKCS#11
+    /// v3.2 §2.1.2), CKA_MODULUS_BITS = 2048.
+    #[test]
+    fn rsa_2048_keygen_stores_modulus_and_exponent() {
+        use crate::state::{get_object_attr_bytes, get_object_attr_u32};
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, _prv_h) = generate_rsa_keypair(session, 2048, b"\x01", "rsa-2048").unwrap();
+        let modulus = get_object_attr_bytes(pub_h, CKA_MODULUS).expect("CKA_MODULUS");
+        assert!(
+            modulus.len() >= 254 && modulus.len() <= 256,
+            "RSA-2048 modulus byte length {}",
+            modulus.len()
+        );
+        let exponent = get_object_attr_bytes(pub_h, CKA_PUBLIC_EXPONENT).expect("CKA_PUBLIC_EXPONENT");
+        assert!(!exponent.is_empty(), "exponent stored");
+        let bits = get_object_attr_u32(pub_h, CKA_MODULUS_BITS).expect("CKA_MODULUS_BITS");
+        assert_eq!(bits, 2048);
+        close_session(session).unwrap();
+    }
+
+    /// RSA bits out of range → CKR_ARGUMENTS_BAD.
+    #[test]
+    fn rsa_invalid_bits_returns_err() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        assert_eq!(
+            generate_rsa_keypair(session, 1024, b"\x01", "small").unwrap_err(),
+            CKR_ARGUMENTS_BAD,
+        );
+        assert_eq!(
+            generate_rsa_keypair(session, 8192, b"\x01", "big").unwrap_err(),
+            CKR_ARGUMENTS_BAD,
+        );
+        close_session(session).unwrap();
+    }
+
+    /// ECDSA P-256: scalar = 32 bytes, uncompressed point = 65 bytes
+    /// (1 + 32 + 32).
+    #[test]
+    fn ecdsa_p256_keygen_produces_expected_lengths() {
+        use crate::state::{get_ec_point_sec1, get_object_value};
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ecdsa_keypair(session, EccCurve::P256, b"\x01", "ec-p256").unwrap();
+        let sk_bytes = get_object_value(prv_h).expect("CKA_VALUE on private");
+        assert_eq!(sk_bytes.len(), 32, "P-256 scalar = 32 bytes");
+        let ec_point = get_ec_point_sec1(pub_h).expect("CKA_EC_POINT");
+        assert_eq!(ec_point.len(), 65, "P-256 uncompressed point = 1+32+32");
+        assert_eq!(ec_point[0], 0x04, "uncompressed point starts with 0x04");
+        close_session(session).unwrap();
+    }
+
+    /// ECDSA P-384: scalar = 48, point = 97 bytes.
+    #[test]
+    fn ecdsa_p384_keygen_produces_expected_lengths() {
+        use crate::state::{get_ec_point_sec1, get_object_value};
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ecdsa_keypair(session, EccCurve::P384, b"\x01", "ec-p384").unwrap();
+        assert_eq!(get_object_value(prv_h).unwrap().len(), 48);
+        assert_eq!(get_ec_point_sec1(pub_h).unwrap().len(), 97);
+        close_session(session).unwrap();
+    }
+
+    /// ECDSA P-521: scalar = 66, point = 133 bytes.
+    #[test]
+    fn ecdsa_p521_keygen_produces_expected_lengths() {
+        use crate::state::{get_ec_point_sec1, get_object_value};
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ecdsa_keypair(session, EccCurve::P521, b"\x01", "ec-p521").unwrap();
+        assert_eq!(get_object_value(prv_h).unwrap().len(), 66);
+        assert_eq!(get_ec_point_sec1(pub_h).unwrap().len(), 133);
+        close_session(session).unwrap();
+    }
+
+    /// AES-128: 16-byte key.
+    #[test]
+    fn aes_128_keygen_produces_16_byte_key() {
+        use crate::state::{get_object_attr_u32, get_object_value};
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let handle = generate_aes_key(session, 128, b"\x01", "aes-128").unwrap();
+        assert_eq!(get_object_value(handle).unwrap().len(), 16);
+        assert_eq!(get_object_attr_u32(handle, CKA_VALUE_LEN).unwrap(), 16);
+        close_session(session).unwrap();
+    }
+
+    /// AES-256: 32-byte key.
+    #[test]
+    fn aes_256_keygen_produces_32_byte_key() {
+        use crate::state::get_object_value;
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let handle = generate_aes_key(session, 256, b"\x01", "aes-256").unwrap();
+        assert_eq!(get_object_value(handle).unwrap().len(), 32);
+        close_session(session).unwrap();
+    }
+
+    /// AES invalid bit length → CKR_ARGUMENTS_BAD.
+    #[test]
+    fn aes_invalid_bits_returns_err() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        assert_eq!(
+            generate_aes_key(session, 100, b"\x01", "x").unwrap_err(),
+            CKR_ARGUMENTS_BAD,
+        );
+        assert_eq!(
+            generate_aes_key(session, 192, b"\x01", "x").unwrap_err(),
+            CKR_ARGUMENTS_BAD,
+        );
+        close_session(session).unwrap();
+    }
+
+    /// Generic secret 256-bit (HMAC-SHA-256 key size).
+    #[test]
+    fn generic_secret_256_keygen_produces_32_byte_key() {
+        use crate::state::get_object_value;
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let handle = generate_generic_secret(session, 256, b"\x01", "hmac-key").unwrap();
+        assert_eq!(get_object_value(handle).unwrap().len(), 32);
+        close_session(session).unwrap();
+    }
+
+    /// AES-GCM encrypt → decrypt round-trip (deferred from commit 5
+    /// pending classical keygen — now wired).
+    #[test]
+    fn aes_256_gcm_encrypt_decrypt_round_trip() {
+        use crate::native::encrypt::{decrypt, encrypt};
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let handle = generate_aes_key(session, 256, b"\x01", "aes-gcm").unwrap();
+        let iv = vec![0x42u8; 12];
+        let plaintext = b"the quick brown fox";
+        let ciphertext = encrypt(session, handle, CKM_AES_GCM, plaintext, Some(&iv)).unwrap();
+        // AES-GCM ciphertext = plaintext.len() + 16-byte tag.
+        assert_eq!(ciphertext.len(), plaintext.len() + 16);
+        let recovered = decrypt(session, handle, CKM_AES_GCM, &ciphertext, Some(&iv)).unwrap();
+        assert_eq!(recovered, plaintext);
+        close_session(session).unwrap();
+    }
+
+    /// AES-GCM tampered ciphertext → CKR_ENCRYPTED_DATA_INVALID
+    /// (PKCS#11 v3.2 §6.13).
+    #[test]
+    fn aes_256_gcm_decrypt_tampered_ciphertext_returns_err() {
+        use crate::native::encrypt::{decrypt, encrypt};
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let handle = generate_aes_key(session, 256, b"\x01", "tamper").unwrap();
+        let iv = vec![0u8; 12];
+        let mut ct = encrypt(session, handle, CKM_AES_GCM, b"hello", Some(&iv)).unwrap();
+        ct[0] ^= 0xFF;
+        let err = decrypt(session, handle, CKM_AES_GCM, &ct, Some(&iv)).unwrap_err();
+        assert_eq!(err, CKR_ENCRYPTED_DATA_INVALID);
+        close_session(session).unwrap();
+    }
+
+    /// HMAC-SHA-256 sign + verify via the generic-secret key.
+    #[test]
+    fn hmac_sha256_via_generic_secret_round_trip() {
+        use crate::native::sign::{sign, verify};
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let handle = generate_generic_secret(session, 256, b"\x01", "hmac-key").unwrap();
+        let mac = sign(session, handle, CKM_SHA256_HMAC, b"data").unwrap();
+        assert_eq!(mac.len(), 32, "HMAC-SHA-256 output = 32 bytes");
+        assert!(verify(session, handle, CKM_SHA256_HMAC, b"data", &mac).unwrap());
+        // Tampered tag → Ok(false), not Err.
+        let mut bad = mac.clone();
+        bad[0] ^= 0xFF;
+        assert_eq!(verify(session, handle, CKM_SHA256_HMAC, b"data", &bad), Ok(false));
         close_session(session).unwrap();
     }
 }

--- a/rust/src/native/keygen.rs
+++ b/rust/src/native/keygen.rs
@@ -1,0 +1,93 @@
+//! Key generation — typed wrappers extracted from `ffi::C_GenerateKeyPair`
+//! and `ffi::C_GenerateKey`.
+//!
+//! Each function takes typed args (parameter set as `u32`, `CKA_ID` /
+//! label as `&[u8]` / `&str`), constructs the engine-internal
+//! `Attributes` map directly via `state::*`, calls the existing typed
+//! crypto primitives (e.g. `ml_kem::MlKem768::generate`), and returns
+//! handle(s). No CK_ATTRIBUTE template marshalling.
+//!
+//! See [`super`] for the typed-vs-FFI architectural relationship.
+//! Implementation lands in Phase 7b commit 3 (PQC) + commit 6 (classical).
+
+use super::CkRv;
+
+// ── PQC ─────────────────────────────────────────────────────────────────────
+
+/// Generate an ML-KEM keypair. `parameter_set` ∈ {`CKP_ML_KEM_512`,
+/// `CKP_ML_KEM_768`, `CKP_ML_KEM_1024`} (constants in
+/// `softhsmrustv3::constants`). Returns `(public_handle, private_handle)`.
+pub fn generate_ml_kem_keypair(
+    _session: u32,
+    _parameter_set: u32,
+    _cka_id: &[u8],
+    _label: &str,
+) -> Result<(u32, u32), CkRv> {
+    unimplemented!("native::keygen::generate_ml_kem_keypair — Phase 7b commit 3")
+}
+
+/// Generate an ML-DSA keypair. `parameter_set` ∈ {`CKP_ML_DSA_44`,
+/// `CKP_ML_DSA_65`, `CKP_ML_DSA_87`}.
+pub fn generate_ml_dsa_keypair(
+    _session: u32,
+    _parameter_set: u32,
+    _cka_id: &[u8],
+    _label: &str,
+) -> Result<(u32, u32), CkRv> {
+    unimplemented!("native::keygen::generate_ml_dsa_keypair — Phase 7b commit 3")
+}
+
+/// Generate an SLH-DSA keypair. `parameter_set` ∈ {`CKP_SLH_DSA_SHA2_128S`,
+/// …, `CKP_SLH_DSA_SHAKE_256F`} — 12 variants total.
+pub fn generate_slh_dsa_keypair(
+    _session: u32,
+    _parameter_set: u32,
+    _cka_id: &[u8],
+    _label: &str,
+) -> Result<(u32, u32), CkRv> {
+    unimplemented!("native::keygen::generate_slh_dsa_keypair — Phase 7b commit 3")
+}
+
+// ── Classical ───────────────────────────────────────────────────────────────
+
+/// Generate an RSA keypair. `bits` ∈ {2048, 3072, 4096}.
+pub fn generate_rsa_keypair(
+    _session: u32,
+    _bits: u32,
+    _cka_id: &[u8],
+    _label: &str,
+) -> Result<(u32, u32), CkRv> {
+    unimplemented!("native::keygen::generate_rsa_keypair — Phase 7b commit 6")
+}
+
+/// Generate an ECDSA keypair. `curve_oid` is the DER-encoded
+/// `CKA_EC_PARAMS` OID (e.g. P-256 = `06 08 2a 86 48 ce 3d 03 01 07`).
+pub fn generate_ecdsa_keypair(
+    _session: u32,
+    _curve_oid: &[u8],
+    _cka_id: &[u8],
+    _label: &str,
+) -> Result<(u32, u32), CkRv> {
+    unimplemented!("native::keygen::generate_ecdsa_keypair — Phase 7b commit 6")
+}
+
+/// Generate an AES key. `bits` ∈ {128, 192, 256}. Returns a single
+/// secret-key handle (not a keypair).
+pub fn generate_aes_key(
+    _session: u32,
+    _bits: u32,
+    _cka_id: &[u8],
+    _label: &str,
+) -> Result<u32, CkRv> {
+    unimplemented!("native::keygen::generate_aes_key — Phase 7b commit 6")
+}
+
+/// Generate a Generic-Secret key (for HMAC). `bits` ∈ {128, 256, 384, 512}.
+pub fn generate_generic_secret(
+    _session: u32,
+    _bits: u32,
+    _cka_id: &[u8],
+    _label: &str,
+) -> Result<u32, CkRv> {
+    unimplemented!("native::keygen::generate_generic_secret — Phase 7b commit 6")
+}

--- a/rust/src/native/keygen.rs
+++ b/rust/src/native/keygen.rs
@@ -1,93 +1,470 @@
-//! Key generation — typed wrappers extracted from `ffi::C_GenerateKeyPair`
-//! and `ffi::C_GenerateKey`.
+//! Key generation — typed wrappers around the engine's keygen logic.
 //!
 //! Each function takes typed args (parameter set as `u32`, `CKA_ID` /
 //! label as `&[u8]` / `&str`), constructs the engine-internal
-//! `Attributes` map directly via `state::*`, calls the existing typed
-//! crypto primitives (e.g. `ml_kem::MlKem768::generate`), and returns
-//! handle(s). No CK_ATTRIBUTE template marshalling.
+//! `Attributes` map directly via `state::*` helpers, calls the existing
+//! typed crypto primitives (`fips204::*` / `fips205::*` / `ml_kem::*`),
+//! and returns handle(s). No CK_ATTRIBUTE template marshalling.
+//!
+//! Implementation mirrors `ffi::C_GenerateKeyPair`'s per-mechanism arm:
+//! same attribute defaults (`CKA_CLASS`, `CKA_KEY_TYPE`, etc.), same
+//! crypto crate calls, same SPKI builder, same
+//! `finalize_private_key_attrs` + `compute_kcv` finalisation. The
+//! difference is **how the caller's CKA_ID + CKA_LABEL get in**: the C
+//! ABI absorbs them via `absorb_template_attrs(template_ptr, count)`;
+//! `native::*` accepts them as typed args and inserts them directly,
+//! avoiding the wasm32-only attribute-template ABI.
 //!
 //! See [`super`] for the typed-vs-FFI architectural relationship.
-//! Implementation lands in Phase 7b commit 3 (PQC) + commit 6 (classical).
+
+use std::collections::HashMap;
 
 use super::CkRv;
+use crate::constants::*;
+use crate::crypto::{ALGO_ML_DSA, ALGO_ML_KEM, ALGO_SLH_DSA};
+use crate::crypto::handlers::{
+    build_mldsa44_spki, build_mldsa65_spki, build_mldsa87_spki, build_mlkem512_spki,
+    build_mlkem768_spki, build_mlkem1024_spki, build_slhdsa_spki, Attributes,
+};
+use crate::state::{
+    allocate_handle, compute_kcv, finalize_private_key_attrs, store_algo_family, store_bool,
+    store_param_set, store_ulong,
+};
 
-// ── PQC ─────────────────────────────────────────────────────────────────────
+/// `CKA_LABEL` — PKCS#11 v3.2 standard attribute (not in the engine's
+/// `constants` module because the engine never reads it; it's
+/// caller-supplied bookkeeping). Codepoint per pkcs11t.h.
+pub const CKA_LABEL: u32 = 0x0000_0003;
 
-/// Generate an ML-KEM keypair. `parameter_set` ∈ {`CKP_ML_KEM_512`,
-/// `CKP_ML_KEM_768`, `CKP_ML_KEM_1024`} (constants in
-/// `softhsmrustv3::constants`). Returns `(public_handle, private_handle)`.
+/// `CKA_ID` — PKCS#11 v3.2 standard attribute. Codepoint per pkcs11t.h.
+pub const CKA_ID: u32 = 0x0000_0102;
+
+// ── ML-KEM ──────────────────────────────────────────────────────────────────
+
+/// Generate an ML-KEM keypair. `parameter_set` ∈
+/// {`CKP_ML_KEM_512`, `CKP_ML_KEM_768`, `CKP_ML_KEM_1024`}. Returns
+/// `(public_handle, private_handle)`.
+///
+/// **Pre-condition**: `session` must be a valid R/W user session
+/// (see [`super::session::open_session`]).
 pub fn generate_ml_kem_keypair(
     _session: u32,
-    _parameter_set: u32,
-    _cka_id: &[u8],
-    _label: &str,
+    parameter_set: u32,
+    cka_id: &[u8],
+    label: &str,
 ) -> Result<(u32, u32), CkRv> {
-    unimplemented!("native::keygen::generate_ml_kem_keypair — Phase 7b commit 3")
+    use ml_kem::{EncodedSizeUser, KemCore};
+
+    let mut pub_attrs: Attributes = HashMap::new();
+    let mut prv_attrs: Attributes = HashMap::new();
+
+    // PKCS#11 v3.2 defaults — mirrors ffi::C_GenerateKeyPair @ ML-KEM arm.
+    set_common_pub_attrs(&mut pub_attrs, parameter_set, ALGO_ML_KEM, CKK_ML_KEM, CKM_ML_KEM_KEY_PAIR_GEN);
+    set_common_prv_attrs(&mut prv_attrs, parameter_set, ALGO_ML_KEM, CKK_ML_KEM, CKM_ML_KEM_KEY_PAIR_GEN);
+    // ML-KEM-specific flags: encapsulate / decapsulate, NOT sign / verify.
+    store_bool(&mut pub_attrs, CKA_VERIFY, false);
+    store_bool(&mut pub_attrs, CKA_ENCAPSULATE, true);
+    store_bool(&mut prv_attrs, CKA_SIGN, false);
+    store_bool(&mut prv_attrs, CKA_DECAPSULATE, true);
+
+    // Caller bookkeeping.
+    insert_id_and_label(&mut pub_attrs, cka_id, label);
+    insert_id_and_label(&mut prv_attrs, cka_id, label);
+
+    // Crypto keygen.
+    let mut rng = rand::rngs::OsRng;
+    match parameter_set {
+        CKP_ML_KEM_512 => {
+            let (dk, ek) = ml_kem::MlKem512::generate(&mut rng);
+            pub_attrs.insert(CKA_VALUE, ek.as_bytes().as_slice().to_vec());
+            prv_attrs.insert(CKA_VALUE, dk.as_bytes().as_slice().to_vec());
+        }
+        CKP_ML_KEM_768 => {
+            let (dk, ek) = ml_kem::MlKem768::generate(&mut rng);
+            pub_attrs.insert(CKA_VALUE, ek.as_bytes().as_slice().to_vec());
+            prv_attrs.insert(CKA_VALUE, dk.as_bytes().as_slice().to_vec());
+        }
+        CKP_ML_KEM_1024 => {
+            let (dk, ek) = ml_kem::MlKem1024::generate(&mut rng);
+            pub_attrs.insert(CKA_VALUE, ek.as_bytes().as_slice().to_vec());
+            prv_attrs.insert(CKA_VALUE, dk.as_bytes().as_slice().to_vec());
+        }
+        _ => return Err(CKR_ARGUMENTS_BAD),
+    }
+
+    // SPKI — PKCS#11 v3.2 §4.14.
+    if let Some(pk_bytes) = pub_attrs.get(&CKA_VALUE).cloned() {
+        let spki = match parameter_set {
+            CKP_ML_KEM_512 => build_mlkem512_spki(&pk_bytes),
+            CKP_ML_KEM_768 => build_mlkem768_spki(&pk_bytes),
+            CKP_ML_KEM_1024 => build_mlkem1024_spki(&pk_bytes),
+            _ => Vec::new(),
+        };
+        if !spki.is_empty() {
+            pub_attrs.insert(CKA_PUBLIC_KEY_INFO, spki);
+        }
+    }
+
+    finalize_and_register(pub_attrs, prv_attrs)
 }
 
-/// Generate an ML-DSA keypair. `parameter_set` ∈ {`CKP_ML_DSA_44`,
-/// `CKP_ML_DSA_65`, `CKP_ML_DSA_87`}.
+// ── ML-DSA ──────────────────────────────────────────────────────────────────
+
+/// Generate an ML-DSA keypair. `parameter_set` ∈
+/// {`CKP_ML_DSA_44`, `CKP_ML_DSA_65`, `CKP_ML_DSA_87`}.
 pub fn generate_ml_dsa_keypair(
     _session: u32,
-    _parameter_set: u32,
-    _cka_id: &[u8],
-    _label: &str,
+    parameter_set: u32,
+    cka_id: &[u8],
+    label: &str,
 ) -> Result<(u32, u32), CkRv> {
-    unimplemented!("native::keygen::generate_ml_dsa_keypair — Phase 7b commit 3")
+    let mut pub_attrs: Attributes = HashMap::new();
+    let mut prv_attrs: Attributes = HashMap::new();
+
+    set_common_pub_attrs(&mut pub_attrs, parameter_set, ALGO_ML_DSA, CKK_ML_DSA, CKM_ML_DSA_KEY_PAIR_GEN);
+    set_common_prv_attrs(&mut prv_attrs, parameter_set, ALGO_ML_DSA, CKK_ML_DSA, CKM_ML_DSA_KEY_PAIR_GEN);
+    // ML-DSA: sign / verify, NOT encapsulate / decapsulate.
+    store_bool(&mut pub_attrs, CKA_VERIFY, true);
+    store_bool(&mut pub_attrs, CKA_ENCAPSULATE, false);
+    store_bool(&mut prv_attrs, CKA_SIGN, true);
+    store_bool(&mut prv_attrs, CKA_DECAPSULATE, false);
+
+    insert_id_and_label(&mut pub_attrs, cka_id, label);
+    insert_id_and_label(&mut prv_attrs, cka_id, label);
+
+    let mut rng = rand::rngs::OsRng;
+    match parameter_set {
+        CKP_ML_DSA_44 => match fips204::ml_dsa_44::try_keygen_with_rng(&mut rng) {
+            Ok((vk, sk)) => {
+                pub_attrs.insert(CKA_VALUE, fips204::traits::SerDes::into_bytes(vk).to_vec());
+                prv_attrs.insert(CKA_VALUE, fips204::traits::SerDes::into_bytes(sk).to_vec());
+            }
+            Err(_) => return Err(CKR_FUNCTION_FAILED),
+        },
+        CKP_ML_DSA_65 => match fips204::ml_dsa_65::try_keygen_with_rng(&mut rng) {
+            Ok((vk, sk)) => {
+                pub_attrs.insert(CKA_VALUE, fips204::traits::SerDes::into_bytes(vk).to_vec());
+                prv_attrs.insert(CKA_VALUE, fips204::traits::SerDes::into_bytes(sk).to_vec());
+            }
+            Err(_) => return Err(CKR_FUNCTION_FAILED),
+        },
+        CKP_ML_DSA_87 => match fips204::ml_dsa_87::try_keygen_with_rng(&mut rng) {
+            Ok((vk, sk)) => {
+                pub_attrs.insert(CKA_VALUE, fips204::traits::SerDes::into_bytes(vk).to_vec());
+                prv_attrs.insert(CKA_VALUE, fips204::traits::SerDes::into_bytes(sk).to_vec());
+            }
+            Err(_) => return Err(CKR_FUNCTION_FAILED),
+        },
+        _ => return Err(CKR_ARGUMENTS_BAD),
+    }
+
+    if let Some(pk_bytes) = pub_attrs.get(&CKA_VALUE).cloned() {
+        let spki = match parameter_set {
+            CKP_ML_DSA_44 => build_mldsa44_spki(&pk_bytes),
+            CKP_ML_DSA_65 => build_mldsa65_spki(&pk_bytes),
+            CKP_ML_DSA_87 => build_mldsa87_spki(&pk_bytes),
+            _ => Vec::new(),
+        };
+        if !spki.is_empty() {
+            pub_attrs.insert(CKA_PUBLIC_KEY_INFO, spki);
+        }
+    }
+
+    finalize_and_register(pub_attrs, prv_attrs)
 }
 
-/// Generate an SLH-DSA keypair. `parameter_set` ∈ {`CKP_SLH_DSA_SHA2_128S`,
-/// …, `CKP_SLH_DSA_SHAKE_256F`} — 12 variants total.
+// ── SLH-DSA ─────────────────────────────────────────────────────────────────
+
+/// Generate an SLH-DSA keypair. `parameter_set` ∈
+/// {`CKP_SLH_DSA_SHA2_128S`, …, `CKP_SLH_DSA_SHAKE_256F`} — 12 variants.
 pub fn generate_slh_dsa_keypair(
     _session: u32,
-    _parameter_set: u32,
-    _cka_id: &[u8],
-    _label: &str,
+    parameter_set: u32,
+    cka_id: &[u8],
+    label: &str,
 ) -> Result<(u32, u32), CkRv> {
-    unimplemented!("native::keygen::generate_slh_dsa_keypair — Phase 7b commit 3")
+    use fips205::traits::SerDes;
+
+    let mut pub_attrs: Attributes = HashMap::new();
+    let mut prv_attrs: Attributes = HashMap::new();
+
+    set_common_pub_attrs(&mut pub_attrs, parameter_set, ALGO_SLH_DSA, CKK_SLH_DSA, CKM_SLH_DSA_KEY_PAIR_GEN);
+    set_common_prv_attrs(&mut prv_attrs, parameter_set, ALGO_SLH_DSA, CKK_SLH_DSA, CKM_SLH_DSA_KEY_PAIR_GEN);
+    store_bool(&mut pub_attrs, CKA_VERIFY, true);
+    store_bool(&mut pub_attrs, CKA_ENCAPSULATE, false);
+    store_bool(&mut prv_attrs, CKA_SIGN, true);
+    store_bool(&mut prv_attrs, CKA_DECAPSULATE, false);
+
+    insert_id_and_label(&mut pub_attrs, cka_id, label);
+    insert_id_and_label(&mut prv_attrs, cka_id, label);
+
+    let mut rng = rand::rngs::OsRng;
+    match parameter_set {
+        CKP_SLH_DSA_SHA2_128S => slh_keygen!(fips205::slh_dsa_sha2_128s::try_keygen_with_rng, rng, pub_attrs, prv_attrs),
+        CKP_SLH_DSA_SHAKE_128S => slh_keygen!(fips205::slh_dsa_shake_128s::try_keygen_with_rng, rng, pub_attrs, prv_attrs),
+        CKP_SLH_DSA_SHA2_128F => slh_keygen!(fips205::slh_dsa_sha2_128f::try_keygen_with_rng, rng, pub_attrs, prv_attrs),
+        CKP_SLH_DSA_SHAKE_128F => slh_keygen!(fips205::slh_dsa_shake_128f::try_keygen_with_rng, rng, pub_attrs, prv_attrs),
+        CKP_SLH_DSA_SHA2_192S => slh_keygen!(fips205::slh_dsa_sha2_192s::try_keygen_with_rng, rng, pub_attrs, prv_attrs),
+        CKP_SLH_DSA_SHAKE_192S => slh_keygen!(fips205::slh_dsa_shake_192s::try_keygen_with_rng, rng, pub_attrs, prv_attrs),
+        CKP_SLH_DSA_SHA2_192F => slh_keygen!(fips205::slh_dsa_sha2_192f::try_keygen_with_rng, rng, pub_attrs, prv_attrs),
+        CKP_SLH_DSA_SHAKE_192F => slh_keygen!(fips205::slh_dsa_shake_192f::try_keygen_with_rng, rng, pub_attrs, prv_attrs),
+        CKP_SLH_DSA_SHA2_256S => slh_keygen!(fips205::slh_dsa_sha2_256s::try_keygen_with_rng, rng, pub_attrs, prv_attrs),
+        CKP_SLH_DSA_SHAKE_256S => slh_keygen!(fips205::slh_dsa_shake_256s::try_keygen_with_rng, rng, pub_attrs, prv_attrs),
+        CKP_SLH_DSA_SHA2_256F => slh_keygen!(fips205::slh_dsa_sha2_256f::try_keygen_with_rng, rng, pub_attrs, prv_attrs),
+        CKP_SLH_DSA_SHAKE_256F => slh_keygen!(fips205::slh_dsa_shake_256f::try_keygen_with_rng, rng, pub_attrs, prv_attrs),
+        _ => return Err(CKR_ARGUMENTS_BAD),
+    }
+
+    if let Some(pk_bytes) = pub_attrs.get(&CKA_VALUE).cloned() {
+        let spki = build_slhdsa_spki(parameter_set, &pk_bytes);
+        if !spki.is_empty() {
+            pub_attrs.insert(CKA_PUBLIC_KEY_INFO, spki);
+        }
+    }
+
+    finalize_and_register(pub_attrs, prv_attrs)
 }
 
-// ── Classical ───────────────────────────────────────────────────────────────
+// ── Classical (deferred to commit 6 per docs/NATIVE_API.md §9) ──────────────
 
-/// Generate an RSA keypair. `bits` ∈ {2048, 3072, 4096}.
 pub fn generate_rsa_keypair(
-    _session: u32,
-    _bits: u32,
-    _cka_id: &[u8],
-    _label: &str,
+    _session: u32, _bits: u32, _cka_id: &[u8], _label: &str,
 ) -> Result<(u32, u32), CkRv> {
     unimplemented!("native::keygen::generate_rsa_keypair — Phase 7b commit 6")
 }
-
-/// Generate an ECDSA keypair. `curve_oid` is the DER-encoded
-/// `CKA_EC_PARAMS` OID (e.g. P-256 = `06 08 2a 86 48 ce 3d 03 01 07`).
 pub fn generate_ecdsa_keypair(
-    _session: u32,
-    _curve_oid: &[u8],
-    _cka_id: &[u8],
-    _label: &str,
+    _session: u32, _curve_oid: &[u8], _cka_id: &[u8], _label: &str,
 ) -> Result<(u32, u32), CkRv> {
     unimplemented!("native::keygen::generate_ecdsa_keypair — Phase 7b commit 6")
 }
-
-/// Generate an AES key. `bits` ∈ {128, 192, 256}. Returns a single
-/// secret-key handle (not a keypair).
 pub fn generate_aes_key(
-    _session: u32,
-    _bits: u32,
-    _cka_id: &[u8],
-    _label: &str,
+    _session: u32, _bits: u32, _cka_id: &[u8], _label: &str,
 ) -> Result<u32, CkRv> {
     unimplemented!("native::keygen::generate_aes_key — Phase 7b commit 6")
 }
-
-/// Generate a Generic-Secret key (for HMAC). `bits` ∈ {128, 256, 384, 512}.
 pub fn generate_generic_secret(
-    _session: u32,
-    _bits: u32,
-    _cka_id: &[u8],
-    _label: &str,
+    _session: u32, _bits: u32, _cka_id: &[u8], _label: &str,
 ) -> Result<u32, CkRv> {
     unimplemented!("native::keygen::generate_generic_secret — Phase 7b commit 6")
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Shared public-key attribute defaults — matches the
+/// `ffi::C_GenerateKeyPair` body for all three PQC families.
+fn set_common_pub_attrs(
+    attrs: &mut Attributes,
+    parameter_set: u32,
+    algo_family: u32,
+    key_type: u32,
+    keygen_mechanism: u32,
+) {
+    store_param_set(attrs, parameter_set);
+    store_algo_family(attrs, algo_family);
+    store_ulong(attrs, CKA_CLASS, CKO_PUBLIC_KEY);
+    store_ulong(attrs, CKA_KEY_TYPE, key_type);
+    store_ulong(attrs, CKA_PARAMETER_SET, parameter_set);
+    store_ulong(attrs, CKA_KEY_GEN_MECHANISM, keygen_mechanism);
+    store_bool(attrs, CKA_TOKEN, false);
+    store_bool(attrs, CKA_PRIVATE, false);
+    store_bool(attrs, CKA_ENCRYPT, false);
+    store_bool(attrs, CKA_WRAP, false);
+    store_bool(attrs, CKA_DERIVE, false);
+    store_bool(attrs, CKA_LOCAL, true);
+}
+
+fn set_common_prv_attrs(
+    attrs: &mut Attributes,
+    parameter_set: u32,
+    algo_family: u32,
+    key_type: u32,
+    keygen_mechanism: u32,
+) {
+    store_param_set(attrs, parameter_set);
+    store_algo_family(attrs, algo_family);
+    store_ulong(attrs, CKA_CLASS, CKO_PRIVATE_KEY);
+    store_ulong(attrs, CKA_KEY_TYPE, key_type);
+    store_ulong(attrs, CKA_PARAMETER_SET, parameter_set);
+    store_ulong(attrs, CKA_KEY_GEN_MECHANISM, keygen_mechanism);
+    store_bool(attrs, CKA_TOKEN, false);
+    store_bool(attrs, CKA_PRIVATE, true);
+    store_bool(attrs, CKA_SENSITIVE, true);
+    store_bool(attrs, CKA_EXTRACTABLE, false);
+    store_bool(attrs, CKA_DECRYPT, false);
+    store_bool(attrs, CKA_UNWRAP, false);
+    store_bool(attrs, CKA_DERIVE, false);
+    store_bool(attrs, CKA_LOCAL, true);
+}
+
+fn insert_id_and_label(attrs: &mut Attributes, cka_id: &[u8], label: &str) {
+    if !cka_id.is_empty() {
+        attrs.insert(CKA_ID, cka_id.to_vec());
+    }
+    if !label.is_empty() {
+        attrs.insert(CKA_LABEL, label.as_bytes().to_vec());
+    }
+}
+
+/// Finalise attribute maps (private-key flags + KCV) and allocate
+/// engine object handles. Mirrors the tail of each `ffi::C_GenerateKeyPair`
+/// arm.
+fn finalize_and_register(
+    mut pub_attrs: Attributes,
+    mut prv_attrs: Attributes,
+) -> Result<(u32, u32), CkRv> {
+    finalize_private_key_attrs(&mut prv_attrs);
+    compute_kcv(&mut pub_attrs);
+    compute_kcv(&mut prv_attrs);
+    let pub_h = allocate_handle(pub_attrs);
+    let prv_h = allocate_handle(prv_attrs);
+    Ok((pub_h, prv_h))
+}
+
+/// SLH-DSA keygen — wraps the `fips205::*::try_keygen_with_rng` calls
+/// with the same shape so the per-variant match stays a single line.
+/// `$func` is the fully-qualified keygen path; `$rng` is `OsRng`;
+/// `$pub_attrs` / `$prv_attrs` are the maps to populate with `CKA_VALUE`.
+macro_rules! slh_keygen {
+    ($func:path, $rng:ident, $pub_attrs:expr, $prv_attrs:expr) => {{
+        match $func(&mut $rng) {
+            Ok((vk, sk)) => {
+                $pub_attrs.insert(CKA_VALUE, vk.into_bytes().to_vec());
+                $prv_attrs.insert(CKA_VALUE, sk.into_bytes().to_vec());
+            }
+            Err(_) => return Err(CKR_FUNCTION_FAILED),
+        }
+    }};
+}
+use slh_keygen;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::session::{bootstrap_default_token, close_session, finalize, init};
+    use crate::state::get_object_value;
+    use crate::native::test_lock;
+
+    fn fresh_session() -> u32 {
+        let _ = finalize();
+        init().unwrap();
+        bootstrap_default_token(0, "so", "user", "pqctoday-test").unwrap()
+    }
+
+    /// ML-KEM-768 keygen produces a valid keypair. FIPS 203 §7.4 — the
+    /// encapsulation key is 1184 bytes.
+    #[test]
+    fn ml_kem_768_keygen_produces_expected_length() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ml_kem_keypair(session, CKP_ML_KEM_768, b"\x01\x02\x03", "kem-test").unwrap();
+        assert!(pub_h > 0 && prv_h > 0 && pub_h != prv_h);
+
+        let pub_value = get_object_value(pub_h).expect("public key CKA_VALUE");
+        assert_eq!(pub_value.len(), 1184, "FIPS 203 §7.4 ML-KEM-768 ek = 1184 bytes");
+        let prv_value = get_object_value(prv_h).expect("private key CKA_VALUE");
+        assert_eq!(prv_value.len(), 2400, "FIPS 203 §7.4 ML-KEM-768 dk = 2400 bytes");
+
+        close_session(session).unwrap();
+    }
+
+    /// ML-KEM-1024: FIPS 203 §7.4 — ek = 1568 bytes, dk = 3168 bytes.
+    #[test]
+    fn ml_kem_1024_keygen_produces_expected_length() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ml_kem_keypair(session, CKP_ML_KEM_1024, b"\x01", "kem1024").unwrap();
+        assert_eq!(get_object_value(pub_h).unwrap().len(), 1568);
+        assert_eq!(get_object_value(prv_h).unwrap().len(), 3168);
+        close_session(session).unwrap();
+    }
+
+    /// ML-DSA-65: FIPS 204 §5 — verification key = 1952 bytes,
+    /// signing key = 4032 bytes.
+    #[test]
+    fn ml_dsa_65_keygen_produces_expected_length() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\xaa\xbb", "sig-test").unwrap();
+        assert_eq!(get_object_value(pub_h).unwrap().len(), 1952, "FIPS 204 §5 ML-DSA-65 vk");
+        assert_eq!(get_object_value(prv_h).unwrap().len(), 4032, "FIPS 204 §5 ML-DSA-65 sk");
+        close_session(session).unwrap();
+    }
+
+    /// ML-DSA-87: FIPS 204 §5 — vk = 2592, sk = 4896.
+    #[test]
+    fn ml_dsa_87_keygen_produces_expected_length() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_87, b"\x01", "ml-dsa-87").unwrap();
+        assert_eq!(get_object_value(pub_h).unwrap().len(), 2592);
+        assert_eq!(get_object_value(prv_h).unwrap().len(), 4896);
+        close_session(session).unwrap();
+    }
+
+    /// SLH-DSA-SHA2-128F: FIPS 205 §10 — pk = 32, sk = 64 bytes.
+    #[test]
+    fn slh_dsa_sha2_128f_keygen_produces_expected_length() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) = generate_slh_dsa_keypair(
+            session,
+            CKP_SLH_DSA_SHA2_128F,
+            b"\x01",
+            "slh-test",
+        )
+        .unwrap();
+        assert_eq!(get_object_value(pub_h).unwrap().len(), 32, "FIPS 205 §10 SLH-DSA-128 pk");
+        assert_eq!(get_object_value(prv_h).unwrap().len(), 64, "FIPS 205 §10 SLH-DSA-128 sk");
+        close_session(session).unwrap();
+    }
+
+    /// SLH-DSA-SHA2-256S: pk = 64, sk = 128 bytes.
+    #[test]
+    fn slh_dsa_sha2_256s_keygen_produces_expected_length() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) = generate_slh_dsa_keypair(
+            session,
+            CKP_SLH_DSA_SHA2_256S,
+            b"\x02",
+            "slh-256",
+        )
+        .unwrap();
+        assert_eq!(get_object_value(pub_h).unwrap().len(), 64);
+        assert_eq!(get_object_value(prv_h).unwrap().len(), 128);
+        close_session(session).unwrap();
+    }
+
+    /// Bad parameter set → CKR_ARGUMENTS_BAD.
+    #[test]
+    fn ml_kem_invalid_parameter_set_returns_err() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let result = generate_ml_kem_keypair(session, 0xDEADBEEF, b"\x01", "x");
+        assert!(matches!(result, Err(CKR_ARGUMENTS_BAD)));
+        close_session(session).unwrap();
+    }
+
+    /// CKA_ID + CKA_LABEL are stored and retrievable.
+    #[test]
+    fn caller_supplied_id_and_label_are_stored() {
+        use crate::state::get_object_attr_bytes;
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let cka_id = b"unique-key-id-12345";
+        let label = "my-ml-dsa-key";
+        let (pub_h, _) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_65, cka_id, label).unwrap();
+
+        let stored_id = get_object_attr_bytes(pub_h, CKA_ID).expect("CKA_ID stored");
+        assert_eq!(stored_id, cka_id);
+        let stored_label = get_object_attr_bytes(pub_h, CKA_LABEL).expect("CKA_LABEL stored");
+        assert_eq!(stored_label, label.as_bytes());
+
+        close_session(session).unwrap();
+    }
 }

--- a/rust/src/native/mod.rs
+++ b/rust/src/native/mod.rs
@@ -57,3 +57,27 @@ pub use sign::*;
 /// so KMIP can map them to KMIP `ResultReason` without an intermediate
 /// type. `CKR_OK = 0x00000000` is `Ok(_)`; any other `CK_RV` is `Err(_)`.
 pub type CkRv = u32;
+
+#[cfg(test)]
+pub(crate) mod test_lock {
+    //! Shared mutex serialising every test in `native::*` that touches
+    //! engine state.
+    //!
+    //! Engine storage (`OBJECTS`, `SESSIONS`, `TOKEN_STORE`) is
+    //! `lazy_static! ref _: Mutex<T>` — **global**, not `thread_local!`.
+    //! cargo test runs tests in parallel by default; without this lock,
+    //! the engine's lifecycle dance (`init_token` → SO login →
+    //! `init_pin` → logout → user login) races across threads, producing
+    //! `CKR_SESSION_EXISTS` (0xB6) or `CKR_USER_NOT_LOGGED_IN` (0x101).
+    //!
+    //! Acquire at the top of every `#[test]` body that calls
+    //! `native::*`: `let _guard = test_lock::acquire();`.
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    pub fn acquire() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+}

--- a/rust/src/native/mod.rs
+++ b/rust/src/native/mod.rs
@@ -1,0 +1,59 @@
+//! `softhsmrustv3::native` — typed Rust API for native callers.
+//!
+//! See [`docs/NATIVE_API.md`](../../docs/NATIVE_API.md) for the full
+//! scoping document.
+//!
+//! ## Problem this module solves
+//!
+//! `pub mod ffi` exposes the PKCS#11 C ABI designed for wasm32:
+//! `CK_ATTRIBUTE.pValue` is a 32-bit pointer (cast through `as usize as
+//! *const u8`). On wasm32 pointers ARE 32 bits and this works. On native
+//! 64-bit hosts the pointer is silently truncated, leading to garbage
+//! reads or UB on dereference. The `pqctoday-hsm/openmls-provider/
+//! wasm-smoke/` crate gates its `softhsmrustv3` dep behind
+//! `cfg(target_arch = "wasm32")` for exactly this reason.
+//!
+//! `pub mod native` exposes the **same engine functionality** through
+//! typed Rust signatures — no pointer marshalling, no CK_ATTRIBUTE
+//! templates — so the `pqctoday-hsm/kmip/` native server can drive the
+//! engine without the wasm32 ABI hazards.
+//!
+//! ## Status
+//!
+//! **Skeleton** (this commit). All functions are `unimplemented!()` stubs.
+//! Implementations land in the follow-up commits enumerated in §9 of the
+//! scoping doc — one sub-module per commit, each with focused tests.
+//!
+//! ## Architectural relationship to `ffi`
+//!
+//! `native::*` and `ffi::C_*` are **parallel surfaces** over the same
+//! engine internals (`crypto::handlers::sign_*` / `verify_*` typed
+//! primitives, plus `state::*` typed object storage). The `ffi` surface
+//! is the marshalling layer for wasm32 + PKCS#11 spec compliance; the
+//! `native` surface is the typed pass-through for native Rust callers.
+//! No behaviour change to `ffi` is allowed — see `docs/NATIVE_API.md` §5.
+//!
+//! ## Threading model
+//!
+//! Native callers MUST pin all `native::*` calls to one OS thread (the
+//! engine's `OBJECTS` / `SESSIONS` storage is `thread_local!`). Phase 4's
+//! `Session: !Send` in `pqctoday-hsm/kmip/` already aligns the KMIP
+//! server with this constraint. See `docs/NATIVE_API.md` §4 (Option A).
+
+pub mod encrypt;
+pub mod keygen;
+pub mod object;
+pub mod session;
+pub mod sign;
+
+pub use encrypt::*;
+pub use keygen::*;
+pub use object::*;
+pub use session::*;
+pub use sign::*;
+
+/// `CK_RV` (PKCS#11 return value). Matches `ffi::CkRv` / the C ABI's
+/// `CKR_*` codepoints. The native API surfaces these as `Result<T, CkRv>`
+/// so KMIP can map them to KMIP `ResultReason` without an intermediate
+/// type. `CKR_OK = 0x00000000` is `Ok(_)`; any other `CK_RV` is `Err(_)`.
+pub type CkRv = u32;

--- a/rust/src/native/mod.rs
+++ b/rust/src/native/mod.rs
@@ -59,6 +59,9 @@ pub use sign::*;
 pub type CkRv = u32;
 
 #[cfg(test)]
+mod parity;
+
+#[cfg(test)]
 pub(crate) mod test_lock {
     //! Shared mutex serialising every test in `native::*` that touches
     //! engine state.

--- a/rust/src/native/object.rs
+++ b/rust/src/native/object.rs
@@ -1,0 +1,45 @@
+//! Object lifecycle + attribute queries — typed wrappers around the
+//! `state::*` typed object storage (which already accepts typed args).
+//!
+//! Implementation lands in Phase 7b commit 7.
+
+use super::CkRv;
+
+/// Destroy an object by handle. Wraps `ffi::C_DestroyObject`. After this
+/// call the handle is invalid; subsequent ops return
+/// `CKR_OBJECT_HANDLE_INVALID`.
+pub fn destroy_object(_session: u32, _handle: u32) -> Result<(), CkRv> {
+    unimplemented!("native::object::destroy_object — Phase 7b commit 7")
+}
+
+/// Look up an object handle by `CKA_ID`. Returns `Ok(None)` if no object
+/// matches. Used by the KMIP `Sqlite`/`Memory` store layer to recover
+/// the session-scoped `CK_OBJECT_HANDLE` from the stable `CKA_ID` it
+/// persists per KMIP UID.
+///
+/// Wraps `ffi::C_FindObjectsInit` + `ffi::C_FindObjects` +
+/// `ffi::C_FindObjectsFinal`.
+pub fn find_by_cka_id(_session: u32, _cka_id: &[u8]) -> Result<Option<u32>, CkRv> {
+    unimplemented!("native::object::find_by_cka_id — Phase 7b commit 7")
+}
+
+/// Read a single attribute. Returns `None` if the attribute is absent OR
+/// the object's policy marks it sensitive (`CKA_SENSITIVE = true` on
+/// private-key material).
+///
+/// For known-sized scalar attrs (`CKA_KEY_TYPE`, `CKA_CLASS`,
+/// `CKA_PARAMETER_SET`, …) the caller decodes the returned bytes as a
+/// `u32` (little-endian, matching the engine's storage convention).
+pub fn get_attribute(_session: u32, _handle: u32, _attr_type: u32) -> Option<Vec<u8>> {
+    unimplemented!("native::object::get_attribute — Phase 7b commit 7")
+}
+
+/// Read a single `u32` attribute. Convenience over [`get_attribute`].
+pub fn get_attribute_u32(_session: u32, _handle: u32, _attr_type: u32) -> Option<u32> {
+    unimplemented!("native::object::get_attribute_u32 — Phase 7b commit 7")
+}
+
+/// Read a boolean attribute. Convenience over [`get_attribute`].
+pub fn get_attribute_bool(_session: u32, _handle: u32, _attr_type: u32) -> Option<bool> {
+    unimplemented!("native::object::get_attribute_bool — Phase 7b commit 7")
+}

--- a/rust/src/native/object.rs
+++ b/rust/src/native/object.rs
@@ -1,45 +1,307 @@
 //! Object lifecycle + attribute queries — typed wrappers around the
-//! `state::*` typed object storage (which already accepts typed args).
+//! engine's typed object storage (`state::*`, `OBJECTS`).
 //!
-//! Implementation lands in Phase 7b commit 7.
+//! The engine's storage layer is already typed Rust; this module just
+//! exposes the operations KMIP needs as typed APIs (no CK_ATTRIBUTE
+//! template marshalling).
+//!
+//! See [`super`] for the typed-vs-FFI architectural relationship.
 
 use super::CkRv;
+use super::keygen::CKA_ID;
+use crate::constants::*;
+use crate::state::{
+    get_object_attr_bytes, get_object_attr_u32 as state_get_object_attr_u32, OBJECTS,
+};
 
-/// Destroy an object by handle. Wraps `ffi::C_DestroyObject`. After this
-/// call the handle is invalid; subsequent ops return
+/// Destroy an object by handle. Wraps `ffi::C_DestroyObject`'s engine
+/// logic: removes the object from `OBJECTS`, zeroises `CKA_VALUE`,
+/// and cleans up any in-flight sign / verify / encrypt / decrypt state
+/// that referenced the handle.
+///
+/// After this call the handle is invalid; subsequent ops return
 /// `CKR_OBJECT_HANDLE_INVALID`.
-pub fn destroy_object(_session: u32, _handle: u32) -> Result<(), CkRv> {
-    unimplemented!("native::object::destroy_object — Phase 7b commit 7")
+pub fn destroy_object(_session: u32, handle: u32) -> Result<(), CkRv> {
+    use crate::state::{DECRYPT_STATE, ENCRYPT_STATE, SIGN_STATE, VERIFY_STATE};
+    use zeroize::Zeroize;
+
+    let removed = OBJECTS.with(|objs| {
+        let mut store = objs.borrow_mut();
+        if let Some(mut attrs) = store.remove(&handle) {
+            // Zeroise key material before deallocation (RS-02 — matches
+            // ffi::C_DestroyObject).
+            if let Some(val) = attrs.get_mut(&CKA_VALUE) {
+                val.zeroize();
+            }
+            true
+        } else {
+            false
+        }
+    });
+
+    if !removed {
+        return Err(CKR_OBJECT_HANDLE_INVALID);
+    }
+
+    // PKCS#11 v3.2 — clean up any active operation state referencing the
+    // destroyed key. Without this, a session that called native::sign +
+    // then native::destroy_object would hold a stale key handle in the
+    // sign-state map.
+    SIGN_STATE.with(|s| s.borrow_mut().retain(|_, v| v.1 != handle));
+    VERIFY_STATE.with(|s| s.borrow_mut().retain(|_, v| v.1 != handle));
+    ENCRYPT_STATE.with(|s| s.borrow_mut().retain(|_, ctx| ctx.key_handle != handle));
+    DECRYPT_STATE.with(|s| s.borrow_mut().retain(|_, ctx| ctx.key_handle != handle));
+    Ok(())
 }
 
 /// Look up an object handle by `CKA_ID`. Returns `Ok(None)` if no object
-/// matches. Used by the KMIP `Sqlite`/`Memory` store layer to recover
-/// the session-scoped `CK_OBJECT_HANDLE` from the stable `CKA_ID` it
-/// persists per KMIP UID.
+/// matches.
 ///
-/// Wraps `ffi::C_FindObjectsInit` + `ffi::C_FindObjects` +
-/// `ffi::C_FindObjectsFinal`.
-pub fn find_by_cka_id(_session: u32, _cka_id: &[u8]) -> Result<Option<u32>, CkRv> {
-    unimplemented!("native::object::find_by_cka_id — Phase 7b commit 7")
+/// Used by the KMIP `MemoryStore` / `SqliteStore` layer to recover the
+/// engine-scoped `CK_OBJECT_HANDLE` from the stable `CKA_ID` the KMIP
+/// store persists per KMIP UID. If multiple objects share the same
+/// `CKA_ID` (e.g. matched public + private keypair from
+/// [`super::keygen::generate_ml_dsa_keypair`]), returns the first match —
+/// callers needing per-class filtering should add a `class` arg or use
+/// [`find_all_by_cka_id`].
+pub fn find_by_cka_id(_session: u32, cka_id: &[u8]) -> Result<Option<u32>, CkRv> {
+    let handles = find_all_by_cka_id(_session, cka_id)?;
+    Ok(handles.first().copied())
+}
+
+/// Same as [`find_by_cka_id`] but returns ALL handles matching the
+/// `CKA_ID`. Typical use: looking up both halves of a freshly-generated
+/// keypair (pub + prv share the CKA_ID set at keygen time).
+pub fn find_all_by_cka_id(_session: u32, cka_id: &[u8]) -> Result<Vec<u32>, CkRv> {
+    let matches: Vec<u32> = OBJECTS.with(|o| {
+        o.borrow()
+            .iter()
+            .filter_map(|(handle, attrs)| match attrs.get(&CKA_ID) {
+                Some(v) if v == cka_id => Some(*handle),
+                _ => None,
+            })
+            .collect()
+    });
+    Ok(matches)
 }
 
 /// Read a single attribute. Returns `None` if the attribute is absent OR
-/// the object's policy marks it sensitive (`CKA_SENSITIVE = true` on
-/// private-key material).
+/// the object's policy marks it sensitive on a private/secret key
+/// (`CKA_SENSITIVE = true` blocks access to `CKA_VALUE` — same rule
+/// `ffi::C_GetAttributeValue` enforces per PKCS#11 v3.2 §4.7).
 ///
-/// For known-sized scalar attrs (`CKA_KEY_TYPE`, `CKA_CLASS`,
-/// `CKA_PARAMETER_SET`, …) the caller decodes the returned bytes as a
-/// `u32` (little-endian, matching the engine's storage convention).
-pub fn get_attribute(_session: u32, _handle: u32, _attr_type: u32) -> Option<Vec<u8>> {
-    unimplemented!("native::object::get_attribute — Phase 7b commit 7")
+/// For known-sized scalar attrs the caller decodes the returned bytes as
+/// LE u32 etc.; convenience wrappers [`get_attribute_u32`] and
+/// [`get_attribute_bool`] do the decode.
+pub fn get_attribute(_session: u32, handle: u32, attr_type: u32) -> Option<Vec<u8>> {
+    // Honour the same sensitivity gate as the C ABI: private + secret
+    // keys with CKA_SENSITIVE=true refuse to expose CKA_VALUE.
+    if attr_type == CKA_VALUE {
+        let blocked = OBJECTS.with(|o| {
+            o.borrow().get(&handle).map(|attrs| {
+                let class = attrs
+                    .get(&CKA_CLASS)
+                    .filter(|v| v.len() >= 4)
+                    .map(|v| u32::from_le_bytes([v[0], v[1], v[2], v[3]]))
+                    .unwrap_or(CKO_PUBLIC_KEY);
+                let is_private_or_secret = class == CKO_PRIVATE_KEY || class == CKO_SECRET_KEY;
+                let sensitive = is_private_or_secret
+                    && attrs.get(&CKA_SENSITIVE).map(|v| !v.is_empty() && v[0] == 0x01).unwrap_or(false);
+                sensitive
+            })
+        });
+        if blocked == Some(true) {
+            return None;
+        }
+    }
+    get_object_attr_bytes(handle, attr_type)
 }
 
-/// Read a single `u32` attribute. Convenience over [`get_attribute`].
-pub fn get_attribute_u32(_session: u32, _handle: u32, _attr_type: u32) -> Option<u32> {
-    unimplemented!("native::object::get_attribute_u32 — Phase 7b commit 7")
+/// Read a `u32` attribute (4-byte little-endian — engine's storage
+/// convention). Returns `None` if the attribute is absent or is
+/// blocked by sensitivity policy.
+pub fn get_attribute_u32(_session: u32, handle: u32, attr_type: u32) -> Option<u32> {
+    if attr_type == CKA_VALUE && get_attribute(_session, handle, CKA_VALUE).is_none() {
+        return None;
+    }
+    state_get_object_attr_u32(handle, attr_type)
 }
 
-/// Read a boolean attribute. Convenience over [`get_attribute`].
-pub fn get_attribute_bool(_session: u32, _handle: u32, _attr_type: u32) -> Option<bool> {
-    unimplemented!("native::object::get_attribute_bool — Phase 7b commit 7")
+/// Read a `CK_BBOOL` attribute (1 byte: 0x01 = true, 0x00 = false).
+/// Returns `None` if the attribute is absent.
+pub fn get_attribute_bool(_session: u32, handle: u32, attr_type: u32) -> Option<bool> {
+    OBJECTS.with(|o| {
+        o.borrow()
+            .get(&handle)
+            .and_then(|attrs| attrs.get(&attr_type))
+            .map(|v| !v.is_empty() && v[0] == 0x01)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::keygen::{generate_aes_key, generate_ml_dsa_keypair, generate_ml_kem_keypair};
+    use crate::native::session::{bootstrap_default_token, close_session, finalize, init};
+    use crate::native::test_lock;
+
+    fn fresh_session() -> u32 {
+        let _ = finalize();
+        init().unwrap();
+        bootstrap_default_token(0, "so", "user", "native-object-test").unwrap()
+    }
+
+    /// destroy_object removes the handle; subsequent
+    /// get_attribute returns None.
+    #[test]
+    fn destroy_object_removes_handle() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let handle = generate_aes_key(session, 256, b"\x01", "destroy-me").unwrap();
+        assert!(get_attribute_bool(session, handle, CKA_ENCRYPT).unwrap());
+        destroy_object(session, handle).unwrap();
+        // Handle no longer resolves.
+        assert!(get_attribute_bool(session, handle, CKA_ENCRYPT).is_none());
+        close_session(session).unwrap();
+    }
+
+    /// destroy_object on a stale handle returns CKR_OBJECT_HANDLE_INVALID.
+    #[test]
+    fn destroy_object_on_stale_handle_returns_err() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let err = destroy_object(session, 999_999).unwrap_err();
+        assert_eq!(err, CKR_OBJECT_HANDLE_INVALID);
+        close_session(session).unwrap();
+    }
+
+    /// destroy_object zeroises CKA_VALUE for symmetric keys. After
+    /// destruction the bytes are wiped (and subsequent get_attribute
+    /// returns None since the handle is gone).
+    #[test]
+    fn destroy_object_zeroises_value() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let handle = generate_aes_key(session, 256, b"\x01", "wipe-me").unwrap();
+        destroy_object(session, handle).unwrap();
+        // Handle gone — CKA_VALUE no longer fetchable.
+        assert!(get_attribute(session, handle, CKA_VALUE).is_none());
+        close_session(session).unwrap();
+    }
+
+    /// find_by_cka_id returns the public + private handles produced by
+    /// a single keypair generation (both halves share the CKA_ID).
+    #[test]
+    fn find_by_cka_id_locates_keypair_handles() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let cka_id = b"\xde\xad\xbe\xef";
+        let (pub_h, prv_h) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_65, cka_id, "found-me").unwrap();
+
+        let all = find_all_by_cka_id(session, cka_id).unwrap();
+        assert_eq!(all.len(), 2, "pub + prv share CKA_ID");
+        assert!(all.contains(&pub_h));
+        assert!(all.contains(&prv_h));
+
+        let first = find_by_cka_id(session, cka_id).unwrap().unwrap();
+        assert!(first == pub_h || first == prv_h);
+        close_session(session).unwrap();
+    }
+
+    /// find_by_cka_id returns None when no object matches.
+    #[test]
+    fn find_by_cka_id_returns_none_when_absent() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        // No objects with this CKA_ID.
+        let result = find_by_cka_id(session, b"nonexistent").unwrap();
+        assert_eq!(result, None);
+        close_session(session).unwrap();
+    }
+
+    /// find_by_cka_id discriminates between different CKA_IDs — two
+    /// keypairs with different CKA_IDs return their own handles only.
+    #[test]
+    fn find_by_cka_id_discriminates_between_objects() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_a, prv_a) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"id-a", "keypair-a").unwrap();
+        let (pub_b, prv_b) =
+            generate_ml_kem_keypair(session, CKP_ML_KEM_768, b"id-b", "keypair-b").unwrap();
+
+        let found_a = find_all_by_cka_id(session, b"id-a").unwrap();
+        assert_eq!(found_a.len(), 2);
+        assert!(found_a.contains(&pub_a) && found_a.contains(&prv_a));
+        assert!(!found_a.contains(&pub_b) && !found_a.contains(&prv_b));
+
+        let found_b = find_all_by_cka_id(session, b"id-b").unwrap();
+        assert_eq!(found_b.len(), 2);
+        assert!(found_b.contains(&pub_b) && found_b.contains(&prv_b));
+        close_session(session).unwrap();
+    }
+
+    /// get_attribute returns the stored CKA_LABEL for a public key
+    /// (no sensitivity gate on public objects).
+    #[test]
+    fn get_attribute_returns_stored_label() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, _) = generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\x01", "my-label").unwrap();
+        let label = get_attribute(session, pub_h, super::super::keygen::CKA_LABEL).unwrap();
+        assert_eq!(label, b"my-label");
+        close_session(session).unwrap();
+    }
+
+    /// get_attribute_u32 decodes CKA_VALUE_LEN on an AES key.
+    #[test]
+    fn get_attribute_u32_decodes_value_len() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let handle = generate_aes_key(session, 256, b"\x01", "aes-len").unwrap();
+        assert_eq!(get_attribute_u32(session, handle, CKA_VALUE_LEN), Some(32));
+        close_session(session).unwrap();
+    }
+
+    /// get_attribute_bool decodes CKA_ENCRYPT on an AES key (true).
+    #[test]
+    fn get_attribute_bool_decodes_flag() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let handle = generate_aes_key(session, 256, b"\x01", "aes-flag").unwrap();
+        assert_eq!(get_attribute_bool(session, handle, CKA_ENCRYPT), Some(true));
+        assert_eq!(get_attribute_bool(session, handle, CKA_SIGN), Some(false));
+        close_session(session).unwrap();
+    }
+
+    /// get_attribute on CKA_VALUE for a private key with CKA_SENSITIVE
+    /// = true (ML-DSA keygen default) returns None. PKCS#11 v3.2 §4.7
+    /// sensitivity gate.
+    #[test]
+    fn get_attribute_blocks_value_on_sensitive_private_key() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (_, prv_h) = generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\x01", "sensitive").unwrap();
+        // CKA_SENSITIVE is true on PQC private keys by keygen default.
+        assert_eq!(get_attribute_bool(session, prv_h, CKA_SENSITIVE), Some(true));
+        // CKA_VALUE access is blocked.
+        assert!(
+            get_attribute(session, prv_h, CKA_VALUE).is_none(),
+            "sensitive private-key CKA_VALUE must be blocked"
+        );
+        close_session(session).unwrap();
+    }
+
+    /// get_attribute on CKA_VALUE for a PUBLIC key returns the bytes
+    /// (no sensitivity gate on public objects per PKCS#11 v3.2 §4.7).
+    #[test]
+    fn get_attribute_allows_value_on_public_key() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, _) = generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\x01", "public-ok").unwrap();
+        let value = get_attribute(session, pub_h, CKA_VALUE).expect("public CKA_VALUE allowed");
+        assert_eq!(value.len(), 1952, "ML-DSA-65 vk = 1952 bytes (FIPS 204 §5)");
+        close_session(session).unwrap();
+    }
 }

--- a/rust/src/native/parity.rs
+++ b/rust/src/native/parity.rs
@@ -1,0 +1,279 @@
+//! Cross-API parity tests — `ffi::C_*` vs `native::*` produce the
+//! same cryptographic output against the same engine state.
+//!
+//! ## Why this exists
+//!
+//! `softhsmrustv3::ffi` (PKCS#11 C ABI, wasm32-targeted) and
+//! `softhsmrustv3::native` (typed Rust API, native-targeted) are
+//! **parallel surfaces over the same engine internals**
+//! (`crypto::handlers::*` + `state::*`). The dual-API contract
+//! documented in `docs/NATIVE_API.md` §5 says: any future engine
+//! change MUST preserve byte-equivalent output across both surfaces
+//! for the operations both expose.
+//!
+//! These tests lock that contract in.
+//!
+//! ## What we test (and what we deliberately skip)
+//!
+//! The C ABI's attribute-template marshalling uses **32-bit pointers**
+//! (`pValue as u32 as usize as *const u8`). On native 64-bit, this
+//! silently truncates pointers, so we **cannot** call `ffi::C_*`
+//! functions that take `CK_ATTRIBUTE` templates from native code
+//! (`C_CreateObject`, `C_GenerateKeyPair`, `C_GenerateKey`,
+//! `C_FindObjectsInit`).
+//!
+//! The C ABI functions we CAN exercise from native — they take only
+//! plain `*mut u8` data buffers + `*mut u32` length pointers, no
+//! templates:
+//!
+//! - `C_SignInit` / `C_Sign` — mechanism struct has null `pParameter`
+//!   for unparametrised algs (HMAC, ML-DSA, EdDSA basic)
+//! - `C_VerifyInit` / `C_Verify` — same
+//! - `C_EncryptInit` / `C_Encrypt` — for ML-KEM no params; AES-GCM
+//!   needs `CK_GCM_PARAMS` (skipped — would need 32-bit-addressable
+//!   params)
+//! - `C_DecryptInit` / `C_Decrypt` — same
+//! - `C_DestroyObject` — handle only, no template
+//! - `C_Initialize` / `C_Finalize` / `C_OpenSession` / `C_Login` /
+//!   `C_Logout` / `C_CloseSession` — already exercised by
+//!   `native::session` (which wraps these).
+//!
+//! So this module focuses on the operations that **don't** need
+//! template marshalling:
+//!
+//! 1. **HMAC byte-exact parity** — HMAC is deterministic. Same key,
+//!    same data → byte-identical MAC from `native::sign` and
+//!    `ffi::C_Sign`.
+//! 2. **ML-DSA cross-verify** — ML-DSA signing is non-deterministic
+//!    (random hedge), so the bytes differ between two `sign` calls.
+//!    But: signatures from one API must verify against the other.
+//!    Native sign → ffi verify and ffi sign → native verify both
+//!    succeed.
+//! 3. **destroy_object semantics** — `native::destroy_object` and
+//!    `ffi::C_DestroyObject` produce the same final state (handle
+//!    removed, sign-state cleaned up).
+//!
+//! ML-KEM encap/decap parity is **deferred to PR-side integration
+//! testing** because `ffi::C_EncapsulateKey` / `C_DecapsulateKey`
+//! both take attribute templates for the resulting shared-secret
+//! object — calling them from native would hit the wasm32 ABI
+//! mismatch. The parity that matters in production is exercised by
+//! the headline KMIP demo (Phase 12 dev-sandbox MVP), not by these
+//! unit tests.
+
+#![cfg(test)]
+
+use crate::constants::*;
+use crate::native::keygen::{generate_generic_secret, generate_ml_dsa_keypair};
+use crate::native::object::destroy_object;
+use crate::native::session::{bootstrap_default_token, close_session, finalize, init};
+use crate::native::sign::{sign, verify};
+use crate::native::test_lock;
+
+use crate::ffi as ffi;
+
+fn fresh_session() -> u32 {
+    let _ = finalize();
+    init().unwrap();
+    bootstrap_default_token(0, "so", "user", "parity-test").unwrap()
+}
+
+/// HMAC-SHA-256: deterministic — `native::sign` and `ffi::C_Sign`
+/// against the same key and data MUST produce byte-identical MACs.
+#[test]
+fn hmac_sha256_byte_exact_parity() {
+    let _guard = test_lock::acquire();
+    let session = fresh_session();
+    let key = generate_generic_secret(session, 256, b"hmac-parity", "hmac-parity").unwrap();
+    let message = b"identical input on both APIs";
+
+    // Native path.
+    let mac_native = sign(session, key, CKM_SHA256_HMAC, message).unwrap();
+    assert_eq!(mac_native.len(), 32);
+
+    // FFI path: CK_MECHANISM { mech_type: CKM_SHA256_HMAC, p_param: 0, len: 0 }
+    let mut mech: [u32; 3] = [CKM_SHA256_HMAC, 0, 0];
+    let rv = ffi::C_SignInit(session, mech.as_mut_ptr() as *mut u8, key);
+    assert_eq!(rv, CKR_OK, "ffi::C_SignInit HMAC: 0x{rv:x}");
+
+    let mut sig_buf = vec![0u8; 32];
+    let mut sig_len: u32 = 32;
+    let mut data_buf = message.to_vec();
+    let rv = ffi::C_Sign(
+        session,
+        data_buf.as_mut_ptr(),
+        data_buf.len() as u32,
+        sig_buf.as_mut_ptr(),
+        &mut sig_len,
+    );
+    assert_eq!(rv, CKR_OK, "ffi::C_Sign HMAC: 0x{rv:x}");
+    assert_eq!(sig_len, 32);
+
+    assert_eq!(mac_native, sig_buf, "HMAC MACs MUST be byte-equivalent");
+    close_session(session).unwrap();
+}
+
+/// ML-DSA cross-verify: native sign → ffi verify succeeds.
+///
+/// ML-DSA is non-deterministic so we can't byte-compare signatures
+/// directly, but a signature from one API must verify with the other.
+#[test]
+fn ml_dsa_65_native_sign_then_ffi_verify_succeeds() {
+    let _guard = test_lock::acquire();
+    let session = fresh_session();
+    let (pub_h, prv_h) =
+        generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"cross-1", "cross-verify").unwrap();
+    let message = b"hello world";
+
+    // Native sign.
+    let sig = sign(session, prv_h, CKM_ML_DSA, message).unwrap();
+    assert_eq!(sig.len(), 3309, "FIPS 204 §5 ML-DSA-65 sig = 3309 bytes");
+
+    // FFI verify.
+    let mut mech: [u32; 3] = [CKM_ML_DSA, 0, 0];
+    let rv = ffi::C_VerifyInit(session, mech.as_mut_ptr() as *mut u8, pub_h);
+    assert_eq!(rv, CKR_OK, "ffi::C_VerifyInit: 0x{rv:x}");
+
+    let mut data_buf = message.to_vec();
+    let mut sig_buf = sig.clone();
+    let rv = ffi::C_Verify(
+        session,
+        data_buf.as_mut_ptr(),
+        data_buf.len() as u32,
+        sig_buf.as_mut_ptr(),
+        sig_buf.len() as u32,
+    );
+    assert_eq!(rv, CKR_OK, "ffi::C_Verify must accept native sig: 0x{rv:x}");
+    close_session(session).unwrap();
+}
+
+/// ML-DSA cross-verify reverse direction: ffi sign → native verify.
+#[test]
+fn ml_dsa_65_ffi_sign_then_native_verify_succeeds() {
+    let _guard = test_lock::acquire();
+    let session = fresh_session();
+    let (pub_h, prv_h) =
+        generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"cross-2", "rev-verify").unwrap();
+    let message = b"reverse direction";
+
+    // FFI sign.
+    let mut mech: [u32; 3] = [CKM_ML_DSA, 0, 0];
+    let rv = ffi::C_SignInit(session, mech.as_mut_ptr() as *mut u8, prv_h);
+    assert_eq!(rv, CKR_OK);
+
+    let mut sig_buf = vec![0u8; 3309];
+    let mut sig_len: u32 = 3309;
+    let mut data_buf = message.to_vec();
+    let rv = ffi::C_Sign(
+        session,
+        data_buf.as_mut_ptr(),
+        data_buf.len() as u32,
+        sig_buf.as_mut_ptr(),
+        &mut sig_len,
+    );
+    assert_eq!(rv, CKR_OK, "ffi::C_Sign ML-DSA: 0x{rv:x}");
+
+    // Native verify.
+    let valid = verify(session, pub_h, CKM_ML_DSA, message, &sig_buf).unwrap();
+    assert!(valid, "native verify must accept ffi-produced ML-DSA sig");
+    close_session(session).unwrap();
+}
+
+/// HMAC tampered tag — both APIs reject identically.
+#[test]
+fn hmac_tampered_tag_rejected_by_both_apis() {
+    let _guard = test_lock::acquire();
+    let session = fresh_session();
+    let key = generate_generic_secret(session, 256, b"tamper-parity", "tamper").unwrap();
+    let message = b"data";
+
+    let mut mac = sign(session, key, CKM_SHA256_HMAC, message).unwrap();
+    mac[0] ^= 0xFF;
+
+    // Native: Ok(false) (KMIP ValidityIndicator semantics).
+    assert_eq!(
+        verify(session, key, CKM_SHA256_HMAC, message, &mac),
+        Ok(false)
+    );
+
+    // FFI: returns CKR_SIGNATURE_INVALID.
+    let mut mech: [u32; 3] = [CKM_SHA256_HMAC, 0, 0];
+    let rv = ffi::C_VerifyInit(session, mech.as_mut_ptr() as *mut u8, key);
+    assert_eq!(rv, CKR_OK);
+    let mut data_buf = message.to_vec();
+    let mut mac_buf = mac.clone();
+    let rv = ffi::C_Verify(
+        session,
+        data_buf.as_mut_ptr(),
+        data_buf.len() as u32,
+        mac_buf.as_mut_ptr(),
+        mac_buf.len() as u32,
+    );
+    assert_eq!(rv, CKR_SIGNATURE_INVALID, "ffi tampered → CKR_SIGNATURE_INVALID");
+    close_session(session).unwrap();
+}
+
+/// destroy_object: native and ffi produce the same final state —
+/// handle removed, subsequent ffi::C_DestroyObject returns
+/// CKR_OBJECT_HANDLE_INVALID, native::destroy_object returns the same.
+#[test]
+fn destroy_object_parity_native_then_ffi() {
+    let _guard = test_lock::acquire();
+    let session = fresh_session();
+    let (_, prv_h) =
+        generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"destroy-1", "destroy").unwrap();
+
+    // Native destroys it.
+    destroy_object(session, prv_h).unwrap();
+
+    // FFI sees the same final state — handle is invalid.
+    let rv = ffi::C_DestroyObject(session, prv_h);
+    assert_eq!(rv, CKR_OBJECT_HANDLE_INVALID, "ffi sees handle gone");
+    close_session(session).unwrap();
+}
+
+#[test]
+fn destroy_object_parity_ffi_then_native() {
+    let _guard = test_lock::acquire();
+    let session = fresh_session();
+    let (_, prv_h) =
+        generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"destroy-2", "destroy").unwrap();
+
+    let rv = ffi::C_DestroyObject(session, prv_h);
+    assert_eq!(rv, CKR_OK);
+    // Native sees the same final state.
+    assert_eq!(
+        destroy_object(session, prv_h).unwrap_err(),
+        CKR_OBJECT_HANDLE_INVALID
+    );
+    close_session(session).unwrap();
+}
+
+/// After destroy, sign with the destroyed handle must fail through
+/// both APIs. Proves the SIGN_STATE cleanup hook destroy_object
+/// inherits from ffi::C_DestroyObject works through native too.
+#[test]
+fn sign_after_destroy_fails_in_both_apis() {
+    let _guard = test_lock::acquire();
+    let session = fresh_session();
+    let (_, prv_h) =
+        generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\x01", "sign-after-destroy").unwrap();
+    destroy_object(session, prv_h).unwrap();
+
+    // Native sign on destroyed handle — get_object_value returns None
+    // (object gone), so the gate is hit before reaching the sign primitive.
+    let err = sign(session, prv_h, CKM_ML_DSA, b"data").unwrap_err();
+    // The exact error depends on which check fires first
+    // (CKA_SIGN gate or CKA_VALUE missing); both are valid failure modes.
+    assert!(
+        err == CKR_KEY_FUNCTION_NOT_PERMITTED || err == CKR_ARGUMENTS_BAD,
+        "destroyed handle: got rv=0x{err:x}"
+    );
+
+    // FFI sign on destroyed handle — CKR_KEY_FUNCTION_NOT_PERMITTED
+    // (CKA_SIGN check fails because the handle has no attributes).
+    let mut mech: [u32; 3] = [CKM_ML_DSA, 0, 0];
+    let rv = ffi::C_SignInit(session, mech.as_mut_ptr() as *mut u8, prv_h);
+    assert_eq!(rv, CKR_KEY_FUNCTION_NOT_PERMITTED);
+    close_session(session).unwrap();
+}

--- a/rust/src/native/session.rs
+++ b/rust/src/native/session.rs
@@ -1,0 +1,44 @@
+//! Session lifecycle — typed wrappers around `ffi::C_Initialize`,
+//! `ffi::C_OpenSession`, `ffi::C_Login`, `ffi::C_CloseSession`,
+//! `ffi::C_InitToken`, `ffi::C_InitPIN`.
+//!
+//! These four don't take attribute templates, so they DO work
+//! ABI-correctly from native today (Phase 4 `pqctoday-hsm/kmip/
+//! src/pkcs11bridge/session.rs` proves this). The `native::` versions
+//! exist for **API consistency** so the KMIP server doesn't have to
+//! reach across to `ffi::*` for session ops while using `native::*` for
+//! everything else.
+//!
+//! See [`super`] for the typed-vs-FFI architectural relationship.
+
+use super::CkRv;
+
+/// Idempotent engine initialisation. Calls `ffi::C_Initialize`; treats
+/// `CKR_CRYPTOKI_ALREADY_INITIALIZED` (0x00000191) as success.
+pub fn init() -> Result<(), CkRv> {
+    unimplemented!("native::session::init — Phase 7b commit 2")
+}
+
+/// Open an R/W user session against `slot` and login with `pin`.
+/// Combines `ffi::C_OpenSession` + `ffi::C_Login`. Returns the session
+/// handle.
+pub fn open_session(_slot: u32, _pin: &str) -> Result<u32, CkRv> {
+    unimplemented!("native::session::open_session — Phase 7b commit 2")
+}
+
+/// Close a session handle.
+pub fn close_session(_session: u32) -> Result<(), CkRv> {
+    unimplemented!("native::session::close_session — Phase 7b commit 2")
+}
+
+/// Initialise a token on `slot` with the security-officer PIN.
+/// Token state survives `close_session` but not engine restart unless
+/// the storage backend persists it.
+pub fn init_token(_slot: u32, _so_pin: &str, _label: &str) -> Result<(), CkRv> {
+    unimplemented!("native::session::init_token — Phase 7b commit 2")
+}
+
+/// Set the normal-user PIN on an SO-authenticated session.
+pub fn init_pin(_session: u32, _user_pin: &str) -> Result<(), CkRv> {
+    unimplemented!("native::session::init_pin — Phase 7b commit 2")
+}

--- a/rust/src/native/session.rs
+++ b/rust/src/native/session.rs
@@ -12,33 +12,246 @@
 //! See [`super`] for the typed-vs-FFI architectural relationship.
 
 use super::CkRv;
+use crate::constants::{CKF_RW_SESSION, CKF_SERIAL_SESSION, CKR_OK, CKU_SO, CKU_USER};
+use crate::ffi as ffi;
 
-/// Idempotent engine initialisation. Calls `ffi::C_Initialize`; treats
-/// `CKR_CRYPTOKI_ALREADY_INITIALIZED` (0x00000191) as success.
+/// Initialise the engine. The wasm32 C ABI's `C_Initialize` always
+/// returns `CKR_OK` (the engine handles re-init idempotently via
+/// [`crate::state::init_token_store`]). Documented as `Result<(), CkRv>`
+/// for API parity with the rest of `native::*`; today the call cannot
+/// fail except via implementation bugs in the engine.
+///
+/// Native callers pin all subsequent `native::*` calls to the same OS
+/// thread as the `init()` call (`thread_local!` storage in the engine).
 pub fn init() -> Result<(), CkRv> {
-    unimplemented!("native::session::init — Phase 7b commit 2")
+    let rv = ffi::C_Initialize(std::ptr::null_mut());
+    if rv == CKR_OK {
+        Ok(())
+    } else {
+        Err(rv)
+    }
 }
 
-/// Open an R/W user session against `slot` and login with `pin`.
-/// Combines `ffi::C_OpenSession` + `ffi::C_Login`. Returns the session
-/// handle.
-pub fn open_session(_slot: u32, _pin: &str) -> Result<u32, CkRv> {
-    unimplemented!("native::session::open_session — Phase 7b commit 2")
+/// Open an R/W user session against `slot` and login with `pin` as
+/// `CKU_USER`. Combines `ffi::C_OpenSession` + `ffi::C_Login`. Returns
+/// the session handle.
+///
+/// **Pre-condition**: `slot` must hold an **initialised** token with a
+/// **user PIN set**. First-boot setup is typically:
+///
+/// ```ignore
+/// init()?;
+/// init_token(0, "so-pin", "pqctoday-dev")?;
+/// // open an SO session, set the user PIN, close
+/// let so = open_session_so(0, "so-pin")?;
+/// init_pin(so, "user-pin")?;
+/// close_session(so)?;
+/// // now the normal user can open
+/// let user = open_session(0, "user-pin")?;
+/// ```
+///
+/// Or use [`bootstrap_default_token`] which does the full sequence.
+pub fn open_session(slot: u32, pin: &str) -> Result<u32, CkRv> {
+    open_session_inner(slot, pin, CKU_USER)
 }
 
-/// Close a session handle.
-pub fn close_session(_session: u32) -> Result<(), CkRv> {
-    unimplemented!("native::session::close_session — Phase 7b commit 2")
+/// Open an R/W security-officer session (for [`init_pin`]). Same as
+/// [`open_session`] but logs in as `CKU_SO`.
+pub fn open_session_so(slot: u32, so_pin: &str) -> Result<u32, CkRv> {
+    open_session_inner(slot, so_pin, CKU_SO)
 }
 
-/// Initialise a token on `slot` with the security-officer PIN.
-/// Token state survives `close_session` but not engine restart unless
-/// the storage backend persists it.
-pub fn init_token(_slot: u32, _so_pin: &str, _label: &str) -> Result<(), CkRv> {
-    unimplemented!("native::session::init_token — Phase 7b commit 2")
+fn open_session_inner(slot: u32, pin: &str, user_type: u32) -> Result<u32, CkRv> {
+    let mut handle: u32 = 0;
+    let rv = ffi::C_OpenSession(
+        slot,
+        CKF_SERIAL_SESSION | CKF_RW_SESSION,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        &mut handle,
+    );
+    if rv != CKR_OK {
+        return Err(rv);
+    }
+    // C_Login reads the PIN bytes only; the spec annotates the param as
+    // `CK_UTF8CHAR_PTR pPin` even though it's effectively read-only.
+    let mut pin_bytes: Vec<u8> = pin.as_bytes().to_vec();
+    let rv = ffi::C_Login(handle, user_type, pin_bytes.as_mut_ptr(), pin_bytes.len() as u32);
+    if rv != CKR_OK {
+        // Best-effort: close the session we just opened so we don't leak
+        // it on a bad PIN. C_CloseSession can return CKR_SESSION_HANDLE_INVALID
+        // if the engine already cleaned up; we ignore that here.
+        let _ = ffi::C_CloseSession(handle);
+        return Err(rv);
+    }
+    Ok(handle)
 }
 
-/// Set the normal-user PIN on an SO-authenticated session.
-pub fn init_pin(_session: u32, _user_pin: &str) -> Result<(), CkRv> {
-    unimplemented!("native::session::init_pin — Phase 7b commit 2")
+/// Tear down the engine — clears `OBJECTS`, `SESSIONS`, `TOKEN_STORE`,
+/// and all per-session operation state on the current thread. Wraps
+/// `ffi::C_Finalize`. Idempotent.
+///
+/// Used by tests for thread-local isolation (cargo test reuses threads
+/// across tests; without `finalize()` between them, slot/session state
+/// leaks from one test to the next). Production callers use this for
+/// graceful shutdown.
+pub fn finalize() -> Result<(), CkRv> {
+    let rv = ffi::C_Finalize(std::ptr::null_mut());
+    if rv == CKR_OK { Ok(()) } else { Err(rv) }
+}
+
+/// Logout the current user on `session`. The engine's `C_CloseSession`
+/// intentionally does NOT auto-logout (PKCS#11 §11.4) — the slot's
+/// login state persists across session close. Callers that need to
+/// switch user types on the same slot (SO → USER) must explicitly
+/// logout first.
+pub fn logout(session: u32) -> Result<(), CkRv> {
+    let rv = ffi::C_Logout(session);
+    if rv == CKR_OK { Ok(()) } else { Err(rv) }
+}
+
+/// Close a session handle. Tolerates a stale handle (returns
+/// `CKR_SESSION_HANDLE_INVALID` as `Err`).
+///
+/// Does NOT logout — see [`logout`]. Combining the two:
+/// `logout(session).and_then(|()| close_session(session))`.
+pub fn close_session(session: u32) -> Result<(), CkRv> {
+    let rv = ffi::C_CloseSession(session);
+    if rv == CKR_OK { Ok(()) } else { Err(rv) }
+}
+
+/// Initialise a token on `slot` with the security-officer PIN + label.
+/// Token state survives `close_session` and engine `init()` re-entries
+/// within the same process (storage is `thread_local!`).
+///
+/// `label` is padded with spaces to PKCS#11's required 32 bytes by the
+/// engine; callers pass any printable string.
+pub fn init_token(slot: u32, so_pin: &str, label: &str) -> Result<(), CkRv> {
+    let mut pin_bytes: Vec<u8> = so_pin.as_bytes().to_vec();
+    // PKCS#11 §11.5: label is 32 bytes, space-padded. Engine does the
+    // padding internally but expects a buffer pointer here; we pass the
+    // raw label and let the engine pad.
+    let mut label_bytes: Vec<u8> = label.as_bytes().to_vec();
+    let rv = ffi::C_InitToken(
+        slot,
+        pin_bytes.as_mut_ptr(),
+        pin_bytes.len() as u32,
+        label_bytes.as_mut_ptr(),
+    );
+    if rv == CKR_OK { Ok(()) } else { Err(rv) }
+}
+
+/// Set the normal-user PIN on an SO-authenticated session. The session
+/// must have been opened via [`open_session_so`] (CKU_SO login + R/W).
+pub fn init_pin(session: u32, user_pin: &str) -> Result<(), CkRv> {
+    let mut pin_bytes: Vec<u8> = user_pin.as_bytes().to_vec();
+    let rv = ffi::C_InitPIN(session, pin_bytes.as_mut_ptr(), pin_bytes.len() as u32);
+    if rv == CKR_OK { Ok(()) } else { Err(rv) }
+}
+
+/// Convenience: full first-boot sequence on a fresh engine.
+///
+/// 1. [`init`] — initialise the engine.
+/// 2. [`init_token`]`(slot, so_pin, label)` — initialise the slot's token.
+/// 3. [`open_session_so`]`(slot, so_pin)` — SO-authenticated session.
+/// 4. [`init_pin`]`(so_session, user_pin)` — set the user PIN.
+/// 5. [`close_session`]`(so_session)` — release the SO session.
+/// 6. [`open_session`]`(slot, user_pin)` — return the user session handle.
+///
+/// Returns the user session handle ready for keygen / sign / etc.
+///
+/// Sandbox / test convenience only — production should run the steps
+/// individually so operators can audit each one.
+pub fn bootstrap_default_token(
+    slot: u32,
+    so_pin: &str,
+    user_pin: &str,
+    label: &str,
+) -> Result<u32, CkRv> {
+    init()?;
+    init_token(slot, so_pin, label)?;
+    let so = open_session_so(slot, so_pin)?;
+    init_pin(so, user_pin)?;
+    // PKCS#11 §11.4 — C_CloseSession does NOT auto-logout. Must explicitly
+    // logout the SO before opening as USER on the same slot, otherwise
+    // C_Login(USER) returns CKR_USER_ANOTHER_ALREADY_LOGGED_IN (0x104).
+    logout(so)?;
+    close_session(so)?;
+    open_session(slot, user_pin)
+}
+
+// Suppress unused-import warning when only some constants are referenced
+// (cfg-dependent paths may consume only a subset).
+#[allow(dead_code)]
+const _CONSTS_USED: (u32, u32, u32, u32) = (CKF_SERIAL_SESSION, CKF_RW_SESSION, CKU_USER, CKU_SO);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reset thread-local engine state before a test that depends on
+    /// fresh slot / session / object stores. `cargo test` reuses OS
+    /// threads across tests, so without this helper one test's state
+    /// leaks into the next.
+    fn reset_engine() {
+        let _ = finalize();
+        init().expect("re-init after finalize");
+    }
+
+    /// Engine `init()` is idempotent in this engine — `C_Initialize`
+    /// always returns `CKR_OK`. Multiple calls within one test are safe.
+    #[test]
+    fn init_returns_ok() {
+        reset_engine();
+        init().expect("init must succeed");
+        // Second call is fine — engine handles re-init via init_token_store.
+        init().expect("re-init must succeed");
+    }
+
+    /// First-boot bootstrap end-to-end: init engine → init token → set
+    /// user PIN → open user session → close. Proves the typed API's
+    /// session lifecycle works against the engine.
+    #[test]
+    fn bootstrap_default_token_round_trip() {
+        reset_engine();
+        let session = bootstrap_default_token(0, "so-1234", "user-1234", "pqctoday-test")
+            .expect("bootstrap must succeed");
+        // Session handle is a positive u32 (engine starts at 1).
+        assert!(session > 0, "session handle must be positive, got {session}");
+        close_session(session).expect("close must succeed");
+    }
+
+    /// open_session against an uninitialised token must fail —
+    /// the engine refuses logins before init_pin has set a user PIN.
+    #[test]
+    fn open_session_without_init_pin_fails() {
+        reset_engine();
+        // No init_token / init_pin → login should fail.
+        let result = open_session(0, "anything");
+        assert!(result.is_err(), "login against uninit token must fail");
+    }
+
+    /// Closing a stale session handle returns Err rather than panicking.
+    #[test]
+    fn close_session_on_stale_handle_returns_err() {
+        reset_engine();
+        let result = close_session(99999);
+        assert!(result.is_err(), "stale handle close must return Err");
+    }
+
+    /// init_token on a non-existent slot returns Err.
+    #[test]
+    fn init_token_invalid_slot_returns_err() {
+        reset_engine();
+        let result = init_token(99, "so-pin", "test");
+        assert!(result.is_err(), "init_token on bad slot must return Err");
+    }
+
+    /// finalize() is idempotent — running it twice (or against an
+    /// already-clean engine) returns Ok.
+    #[test]
+    fn finalize_is_idempotent() {
+        let _ = finalize(); // works whether engine had state or not
+        let _ = finalize(); // and a second time
+    }
 }

--- a/rust/src/native/session.rs
+++ b/rust/src/native/session.rs
@@ -188,11 +188,12 @@ const _CONSTS_USED: (u32, u32, u32, u32) = (CKF_SERIAL_SESSION, CKF_RW_SESSION, 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::native::test_lock;
 
-    /// Reset thread-local engine state before a test that depends on
-    /// fresh slot / session / object stores. `cargo test` reuses OS
-    /// threads across tests, so without this helper one test's state
-    /// leaks into the next.
+    /// Reset engine state. Engine storage is `lazy_static! ref _: Mutex<T>`
+    /// (global, not `thread_local!`), so cargo test's default parallel
+    /// execution races on it. Every test acquires [`test_lock::acquire`]
+    /// before touching engine state — see `native::test_lock`.
     fn reset_engine() {
         let _ = finalize();
         init().expect("re-init after finalize");
@@ -202,7 +203,7 @@ mod tests {
     /// always returns `CKR_OK`. Multiple calls within one test are safe.
     #[test]
     fn init_returns_ok() {
-        reset_engine();
+        let _guard = test_lock::acquire(); reset_engine();
         init().expect("init must succeed");
         // Second call is fine — engine handles re-init via init_token_store.
         init().expect("re-init must succeed");
@@ -213,7 +214,7 @@ mod tests {
     /// session lifecycle works against the engine.
     #[test]
     fn bootstrap_default_token_round_trip() {
-        reset_engine();
+        let _guard = test_lock::acquire(); reset_engine();
         let session = bootstrap_default_token(0, "so-1234", "user-1234", "pqctoday-test")
             .expect("bootstrap must succeed");
         // Session handle is a positive u32 (engine starts at 1).
@@ -225,7 +226,7 @@ mod tests {
     /// the engine refuses logins before init_pin has set a user PIN.
     #[test]
     fn open_session_without_init_pin_fails() {
-        reset_engine();
+        let _guard = test_lock::acquire(); reset_engine();
         // No init_token / init_pin → login should fail.
         let result = open_session(0, "anything");
         assert!(result.is_err(), "login against uninit token must fail");
@@ -234,7 +235,7 @@ mod tests {
     /// Closing a stale session handle returns Err rather than panicking.
     #[test]
     fn close_session_on_stale_handle_returns_err() {
-        reset_engine();
+        let _guard = test_lock::acquire(); reset_engine();
         let result = close_session(99999);
         assert!(result.is_err(), "stale handle close must return Err");
     }
@@ -242,7 +243,7 @@ mod tests {
     /// init_token on a non-existent slot returns Err.
     #[test]
     fn init_token_invalid_slot_returns_err() {
-        reset_engine();
+        let _guard = test_lock::acquire(); reset_engine();
         let result = init_token(99, "so-pin", "test");
         assert!(result.is_err(), "init_token on bad slot must return Err");
     }
@@ -251,6 +252,7 @@ mod tests {
     /// already-clean engine) returns Ok.
     #[test]
     fn finalize_is_idempotent() {
+        let _guard = test_lock::acquire();
         let _ = finalize(); // works whether engine had state or not
         let _ = finalize(); // and a second time
     }

--- a/rust/src/native/sign.rs
+++ b/rust/src/native/sign.rs
@@ -2,36 +2,304 @@
 //! `crypto::handlers::verify_*` (which already accept typed args).
 //!
 //! Resolves the key handle to its stored bytes via `state::*`, dispatches
-//! on `mechanism` + key type, calls the right typed primitive. Returns
-//! the signature as `Vec<u8>` (no caller-allocated output buffer).
+//! on `mechanism` based on the engine's existing per-family logic, calls
+//! the right typed primitive. Returns the signature as `Vec<u8>` (no
+//! caller-allocated output buffer).
+//!
+//! Mirrors the dispatch logic in `ffi::C_Sign` / `ffi::C_Verify` exactly,
+//! minus the wasm32 pointer marshalling and the stateful HSS / XMSS / LMS
+//! paths (those require coordinated `CKA_STATEFUL_KEY_STATE` updates
+//! that don't map cleanly to the Result<Vec<u8>, _> shape; KMIP doesn't
+//! need them per Phase 4.5 FIPS-only scope).
 //!
 //! See [`super`] for the typed-vs-FFI architectural relationship.
-//! Implementation lands in Phase 7b commit 4.
 
 use super::CkRv;
+use crate::constants::*;
+use crate::crypto::handlers::{
+    is_prehash_ml_dsa, is_prehash_slh_dsa, sign_ecdsa, sign_eddsa, sign_eddsa_ph, sign_hmac,
+    sign_kmac, sign_ml_dsa, sign_rsa, sign_slh_dsa, verify_ecdsa, verify_eddsa, verify_eddsa_ph,
+    verify_hmac, verify_ml_dsa, verify_rsa, verify_slh_dsa,
+};
+use crate::state::{
+    get_ec_point_sec1, get_object_attr_u32, get_object_param_set, get_object_value,
+    get_rsa_public_components, OBJECTS,
+};
+
+// PKCS#11 v3.2 §5.12.4 — `CKA_SIGN` (private key) / `CKA_VERIFY` (public key)
+// must be true before sign / verify is permitted. Engine constants:
+use crate::constants::{CKA_SIGN, CKA_VERIFY};
 
 /// Sign `data` with the key at `key_handle` using `mechanism`. Dispatches
-/// to `crypto::handlers::sign_{ml_dsa, slh_dsa, rsa, ecdsa, eddsa, hmac}`
-/// based on the stored key's algorithm.
+/// to `crypto::handlers::sign_{ml_dsa, slh_dsa, rsa, ecdsa, eddsa, hmac,
+/// kmac}` based on `mechanism`.
+///
+/// **Pre-conditions**:
+/// - `key_handle` must refer to a key with `CKA_SIGN = true`. For PQC
+///   sig algorithms this is the **private** key from
+///   [`super::keygen::generate_ml_dsa_keypair`] / `generate_slh_dsa_keypair`.
+/// - `mechanism` must match the key's algorithm family
+///   (`CKM_ML_DSA` for ML-DSA keys, `CKM_SLH_DSA` for SLH-DSA, etc.).
+///
+/// **Returns** the raw signature bytes — length is per FIPS spec
+/// (e.g. ML-DSA-65: 3309, ML-DSA-87: 4627).
 pub fn sign(
     _session: u32,
-    _key_handle: u32,
-    _mechanism: u32,
-    _data: &[u8],
+    key_handle: u32,
+    mechanism: u32,
+    data: &[u8],
 ) -> Result<Vec<u8>, CkRv> {
-    unimplemented!("native::sign::sign — Phase 7b commit 4")
+    // CKA_SIGN gate.
+    if !check_can_sign(key_handle, CKA_SIGN) {
+        return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
+    }
+
+    let sk_bytes = get_object_value(key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+    let ps = get_object_param_set(key_handle);
+
+    match mechanism {
+        m if m == CKM_ML_DSA || is_prehash_ml_dsa(m) => sign_ml_dsa(m, ps, &sk_bytes, data),
+        m if m == CKM_SLH_DSA || is_prehash_slh_dsa(m) => {
+            // v0.1: SLH-DSA signing uses empty context + non-deterministic
+            // (random hedge). FIPS 205 §10. KMIP's Phase-5 Sign handler
+            // doesn't expose a context param yet; if it ever does, this
+            // signature can grow optional args.
+            sign_slh_dsa(m, ps, &sk_bytes, data, &[], false)
+        }
+        CKM_SHA256_HMAC | CKM_SHA384_HMAC | CKM_SHA512_HMAC | CKM_SHA3_256_HMAC
+        | CKM_SHA3_512_HMAC => sign_hmac(mechanism, &sk_bytes, data),
+        CKM_KMAC_128 | CKM_KMAC_256 => sign_kmac(mechanism, &sk_bytes, data),
+        CKM_SHA256_RSA_PKCS | CKM_SHA256_RSA_PKCS_PSS => sign_rsa(mechanism, &sk_bytes, data),
+        CKM_ECDSA | CKM_ECDSA_SHA256 | CKM_ECDSA_SHA384 | CKM_ECDSA_SHA512 => {
+            sign_ecdsa(mechanism, ps, &sk_bytes, data)
+        }
+        CKM_EDDSA => sign_eddsa(&sk_bytes, data),
+        CKM_EDDSA_PH => sign_eddsa_ph(&sk_bytes, data),
+        _ => Err(CKR_MECHANISM_INVALID),
+    }
 }
 
 /// Verify `signature` over `data` with the key at `key_handle` using
-/// `mechanism`. Returns `Ok(true)` on valid signature, `Ok(false)` on
-/// invalid (NOT an error — matches the KMIP `validity_indicator` model).
-/// `Err(_)` is for protocol-level failures (wrong key type, etc.).
+/// `mechanism`.
+///
+/// **Returns**:
+/// - `Ok(true)` — signature is valid.
+/// - `Ok(false)` — signature is invalid (matches KMIP's
+///   `validity_indicator` model — a failed verification is NOT a
+///   protocol error).
+/// - `Err(_)` — protocol-level failure (wrong key type, bad mechanism,
+///   missing key material, …).
 pub fn verify(
     _session: u32,
-    _key_handle: u32,
-    _mechanism: u32,
-    _data: &[u8],
-    _signature: &[u8],
+    key_handle: u32,
+    mechanism: u32,
+    data: &[u8],
+    signature: &[u8],
 ) -> Result<bool, CkRv> {
-    unimplemented!("native::sign::verify — Phase 7b commit 4")
+    // CKA_VERIFY gate.
+    if !check_can_sign(key_handle, CKA_VERIFY) {
+        return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
+    }
+
+    // For most algorithms `CKA_VALUE` holds the verification key bytes
+    // (ML-DSA, SLH-DSA, EdDSA, HMAC, KMAC). RSA/ECDSA public keys are
+    // stored in dedicated attributes (modulus+exp / EC point).
+    let pk_bytes = get_object_value(key_handle).unwrap_or_default();
+    let ps = get_object_param_set(key_handle);
+
+    let result: Result<(), CkRv> = match mechanism {
+        m if m == CKM_ML_DSA || is_prehash_ml_dsa(m) => {
+            verify_ml_dsa(m, ps, &pk_bytes, data, signature)
+        }
+        m if m == CKM_SLH_DSA || is_prehash_slh_dsa(m) => {
+            verify_slh_dsa(m, ps, &pk_bytes, data, signature, &[])
+        }
+        CKM_SHA256_HMAC | CKM_SHA384_HMAC | CKM_SHA512_HMAC | CKM_SHA3_256_HMAC
+        | CKM_SHA3_512_HMAC => verify_hmac(mechanism, &pk_bytes, data, signature),
+        CKM_KMAC_128 | CKM_KMAC_256 => {
+            // KMAC verify is constant-time signature comparison against a
+            // fresh MAC, mirroring `ffi::C_Verify` behaviour.
+            match sign_kmac(mechanism, &pk_bytes, data) {
+                Ok(mac) => {
+                    use subtle::ConstantTimeEq;
+                    if mac.len() == signature.len() && mac.ct_eq(signature).into() {
+                        Ok(())
+                    } else {
+                        Err(CKR_SIGNATURE_INVALID)
+                    }
+                }
+                Err(e) => Err(e),
+            }
+        }
+        CKM_SHA256_RSA_PKCS | CKM_SHA256_RSA_PKCS_PSS => match get_rsa_public_components(key_handle) {
+            Some((n, e)) => verify_rsa(mechanism, &n, &e, data, signature),
+            None => Err(CKR_KEY_TYPE_INCONSISTENT),
+        },
+        CKM_ECDSA | CKM_ECDSA_SHA256 | CKM_ECDSA_SHA384 | CKM_ECDSA_SHA512 => {
+            match get_ec_point_sec1(key_handle) {
+                Some(point) => verify_ecdsa(mechanism, ps, &point, data, signature),
+                None => Err(CKR_KEY_TYPE_INCONSISTENT),
+            }
+        }
+        CKM_EDDSA => verify_eddsa(&pk_bytes, data, signature),
+        CKM_EDDSA_PH => verify_eddsa_ph(&pk_bytes, data, signature),
+        _ => Err(CKR_MECHANISM_INVALID),
+    };
+
+    match result {
+        Ok(()) => Ok(true),
+        // CKR_SIGNATURE_INVALID is the "valid call, signature didn't
+        // verify" outcome — surface as Ok(false), matching the KMIP
+        // ValidityIndicator model.
+        Err(CKR_SIGNATURE_INVALID) => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+/// Check `CKA_SIGN` (for sign) or `CKA_VERIFY` (for verify) on the key.
+/// Returns `false` if the key is missing or the flag is not set.
+fn check_can_sign(key_handle: u32, attr_type: u32) -> bool {
+    // PKCS#11 v3.2 §5.12.4 — single-byte CK_BBOOL: 0x01 = true.
+    OBJECTS.with(|o| {
+        o.borrow()
+            .get(&key_handle)
+            .and_then(|attrs| attrs.get(&attr_type))
+            .map(|v| !v.is_empty() && v[0] == 0x01)
+            .unwrap_or(false)
+    })
+}
+
+// Suppress unused-import warning when not all dispatch paths reference
+// every helper (e.g. get_object_attr_u32 only used by future LMS path).
+#[allow(dead_code)]
+fn _suppress_unused() {
+    let _: fn(u32, u32) -> Option<u32> = get_object_attr_u32;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::keygen::{generate_ml_dsa_keypair, generate_ml_kem_keypair};
+    use crate::native::session::{bootstrap_default_token, close_session, finalize, init};
+    use crate::native::test_lock;
+
+    fn fresh_session() -> u32 {
+        let _ = finalize();
+        init().unwrap();
+        bootstrap_default_token(0, "so", "user", "native-sign-test").unwrap()
+    }
+
+    /// ML-DSA-65 round-trip: keygen → sign → verify(correct) → Ok(true).
+    /// FIPS 204 §5 — ML-DSA-65 signature is 3309 bytes.
+    #[test]
+    fn ml_dsa_65_sign_then_verify_returns_valid() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\x01\x02", "sig-key").unwrap();
+
+        let message = b"the quick brown fox jumps over the lazy dog";
+        let sig = sign(session, prv_h, CKM_ML_DSA, message).expect("sign must succeed");
+        assert_eq!(sig.len(), 3309, "FIPS 204 §5 ML-DSA-65 signature = 3309 bytes");
+
+        let valid = verify(session, pub_h, CKM_ML_DSA, message, &sig).expect("verify must succeed");
+        assert!(valid, "freshly-signed message must verify");
+
+        close_session(session).unwrap();
+    }
+
+    /// ML-DSA-87: signature = 4627 bytes (FIPS 204 §5).
+    #[test]
+    fn ml_dsa_87_sign_then_verify_returns_valid() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_87, b"\x03", "sig-87").unwrap();
+        let sig = sign(session, prv_h, CKM_ML_DSA, b"hello").unwrap();
+        assert_eq!(sig.len(), 4627);
+        assert!(verify(session, pub_h, CKM_ML_DSA, b"hello", &sig).unwrap());
+        close_session(session).unwrap();
+    }
+
+    /// Tampered signature → Ok(false), NOT Err. Matches KMIP
+    /// `ValidityIndicator::Invalid` semantics.
+    #[test]
+    fn tampered_signature_returns_ok_false_not_err() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\x01", "tamper").unwrap();
+        let mut sig = sign(session, prv_h, CKM_ML_DSA, b"data").unwrap();
+        // Flip a byte in the middle of the signature.
+        let mid = sig.len() / 2;
+        sig[mid] ^= 0xFF;
+        let result = verify(session, pub_h, CKM_ML_DSA, b"data", &sig);
+        assert_eq!(result, Ok(false), "tampered sig is Ok(false), not Err");
+        close_session(session).unwrap();
+    }
+
+    /// Signing with the public-key handle (CKA_SIGN = false) →
+    /// CKR_KEY_FUNCTION_NOT_PERMITTED.
+    #[test]
+    fn sign_with_public_key_handle_is_denied() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, _prv_h) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\x01", "denied").unwrap();
+        let result = sign(session, pub_h, CKM_ML_DSA, b"data");
+        assert_eq!(result, Err(CKR_KEY_FUNCTION_NOT_PERMITTED));
+        close_session(session).unwrap();
+    }
+
+    /// Verifying with the private-key handle (CKA_VERIFY = false) →
+    /// CKR_KEY_FUNCTION_NOT_PERMITTED.
+    #[test]
+    fn verify_with_private_key_handle_is_denied() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (_pub_h, prv_h) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\x01", "denied").unwrap();
+        let result = verify(session, prv_h, CKM_ML_DSA, b"data", b"\x00" .repeat(3309).as_slice());
+        assert_eq!(result, Err(CKR_KEY_FUNCTION_NOT_PERMITTED));
+        close_session(session).unwrap();
+    }
+
+    /// Unknown mechanism → CKR_MECHANISM_INVALID.
+    #[test]
+    fn unknown_mechanism_returns_err() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (_pub_h, prv_h) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\x01", "unknown-mech").unwrap();
+        let result = sign(session, prv_h, 0xDEAD_BEEF, b"data");
+        assert_eq!(result, Err(CKR_MECHANISM_INVALID));
+        close_session(session).unwrap();
+    }
+
+    /// Sign with an ML-KEM key (CKA_SIGN=false) → denied. Cross-family
+    /// check that the permission gate works.
+    #[test]
+    fn ml_kem_key_cannot_be_used_for_signing() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (_pub_h, prv_h) =
+            generate_ml_kem_keypair(session, CKP_ML_KEM_768, b"\x01", "kem-not-sig").unwrap();
+        let result = sign(session, prv_h, CKM_ML_DSA, b"data");
+        assert_eq!(result, Err(CKR_KEY_FUNCTION_NOT_PERMITTED));
+        close_session(session).unwrap();
+    }
+
+    /// Empty message — ML-DSA is well-defined for any message length
+    /// per FIPS 204. Signature still 3309 bytes.
+    #[test]
+    fn ml_dsa_65_sign_empty_message() {
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_h, prv_h) =
+            generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\x01", "empty-msg").unwrap();
+        let sig = sign(session, prv_h, CKM_ML_DSA, b"").unwrap();
+        assert_eq!(sig.len(), 3309);
+        assert!(verify(session, pub_h, CKM_ML_DSA, b"", &sig).unwrap());
+        close_session(session).unwrap();
+    }
 }

--- a/rust/src/native/sign.rs
+++ b/rust/src/native/sign.rs
@@ -1,0 +1,37 @@
+//! Sign / Verify — typed dispatcher over `crypto::handlers::sign_*` and
+//! `crypto::handlers::verify_*` (which already accept typed args).
+//!
+//! Resolves the key handle to its stored bytes via `state::*`, dispatches
+//! on `mechanism` + key type, calls the right typed primitive. Returns
+//! the signature as `Vec<u8>` (no caller-allocated output buffer).
+//!
+//! See [`super`] for the typed-vs-FFI architectural relationship.
+//! Implementation lands in Phase 7b commit 4.
+
+use super::CkRv;
+
+/// Sign `data` with the key at `key_handle` using `mechanism`. Dispatches
+/// to `crypto::handlers::sign_{ml_dsa, slh_dsa, rsa, ecdsa, eddsa, hmac}`
+/// based on the stored key's algorithm.
+pub fn sign(
+    _session: u32,
+    _key_handle: u32,
+    _mechanism: u32,
+    _data: &[u8],
+) -> Result<Vec<u8>, CkRv> {
+    unimplemented!("native::sign::sign — Phase 7b commit 4")
+}
+
+/// Verify `signature` over `data` with the key at `key_handle` using
+/// `mechanism`. Returns `Ok(true)` on valid signature, `Ok(false)` on
+/// invalid (NOT an error — matches the KMIP `validity_indicator` model).
+/// `Err(_)` is for protocol-level failures (wrong key type, etc.).
+pub fn verify(
+    _session: u32,
+    _key_handle: u32,
+    _mechanism: u32,
+    _data: &[u8],
+    _signature: &[u8],
+) -> Result<bool, CkRv> {
+    unimplemented!("native::sign::verify — Phase 7b commit 4")
+}


### PR DESCRIPTION
## Summary

Scoping doc + module skeleton for a new \`softhsmrustv3::native\` module
that exposes the engine's functionality through typed Rust signatures,
bypassing the wasm32-targeted PKCS#11 C ABI.

**This PR is for design review only** — no implementations yet. Real
code lands in 6-8 focused follow-up commits on this branch, each
implementing one sub-module (session → keygen-PQC → sign → encap/decap
→ keygen-classical → object → parity tests).

## Why this exists

Discovered during Phase 7b: the existing \`pub mod ffi\` was designed for
wasm32 — \`CK_ATTRIBUTE.pValue\` is a 32-bit pointer cast through
\`as usize as *const u8\`. Works in wasm32 (pointers ARE 32 bits there).
**Silently truncates on native 64-bit** when callers build attribute
templates from heap-allocated \`Vec<u8>\`. The existing native-Rust
consumer (\`openmls-provider/wasm-smoke\`) gates its \`softhsmrustv3\`
path-dep behind \`cfg(target_arch = \"wasm32\")\` for exactly this reason
(see \`openmls-provider/wasm-smoke/Cargo.toml:13\`).

\`pqctoday-hsm/kmip/\` is a native binary. Phase 7b needs to drive the
engine from native; can't use the C ABI directly without UB.

## What I learned from the existing engine code

The engine **already has typed Rust APIs at the primitive layer** —
\`crypto::handlers::sign_ml_dsa\`, \`verify_ml_dsa\`, \`sign_rsa\`,
\`sign_ecdsa\`, \`sign_eddsa\`, etc. all take typed args (\`&[u8]\`, \`u32\`)
and return \`Result<Vec<u8>, u32>\`. \`state::*\` has typed object
storage (\`allocate_handle\`, \`get_object_value\`,
\`set_object_attr_bytes\`, \`store_param_set\`, etc.). The C ABI handlers
in \`ffi.rs\` are **already** the marshalling layer over these.

So this isn't \"add a new layer\" — it's \"expose the typed layer that
already exists, with composite operations (keygen + storage + sign in
one call) packaged for KMIP-style callers.\"

## What's in the PR

| File | Purpose | LOC |
|---|---|---|
| \`rust/docs/NATIVE_API.md\` | Full scoping doc — 11 sections | 462 |
| \`rust/src/lib.rs\` | \`pub mod native;\` added | +1 |
| \`rust/src/native/mod.rs\` | Re-exports + module docs | 56 |
| \`rust/src/native/session.rs\` | Session lifecycle stubs (init / open / close / init_token / init_pin) | 44 |
| \`rust/src/native/keygen.rs\` | 7 keygen stubs (3 PQC + 3 classical asymmetric + 2 symmetric) | 86 |
| \`rust/src/native/sign.rs\` | sign / verify dispatcher stubs | 40 |
| \`rust/src/native/encrypt.rs\` | encrypt / decrypt / encapsulate / decapsulate stubs | 53 |
| \`rust/src/native/object.rs\` | destroy / find_by_cka_id / get_attribute(_u32/_bool) stubs | 42 |

Every stub is tagged with the follow-up commit number that will
implement it (commits 2-7).

## Architectural relationship to \`ffi\`

\`native::*\` and \`ffi::C_*\` are **parallel surfaces** over the same
engine internals. The C ABI stays bit-exact for WASM consumers + PKCS#11
spec compliance; the native API is the typed pass-through for native
Rust callers. No behaviour change to \`ffi\` is allowed (see
\`docs/NATIVE_API.md §5\`).

## Threading model (locked: Option A)

Native callers MUST pin all \`native::*\` calls to one OS thread (the
engine's \`OBJECTS\` / \`SESSIONS\` storage is \`thread_local!\`). Phase 4's
\`Session: !Send\` in \`pqctoday-hsm/kmip/\` already aligns the KMIP server
with this. Option B (Mutex over thread-local) deferred to v0.2 if
profiling shows contention. Full discussion in \`docs/NATIVE_API.md §4\`.

## Open questions for review (\`docs/NATIVE_API.md §11\`)

1. **Module name**: \`native\` vs \`rust_api\` vs \`direct\`?
2. **Error type**: \`Result<T, u32>\` (matches existing primitives) vs
   a typed \`enum NativeError\`?
3. **Should functions take \`&mut Session\` instead of raw \`session: u32\`?**

## Test plan

- [x] Engine builds — \`cargo build --lib\` clean
- [x] Engine tests pass — \`cargo test --lib\` 1/1
- [x] Native consumer (\`wasm-smoke\`) still builds on native — empty
      rlib as before
- [ ] Commits 2-7: each adds one sub-module implementation + tests
- [ ] Commit 8 (final on this branch): cross-validation parity test
      asserting byte-equivalent output from \`ffi::C_*\` (wasm32) vs
      \`native::*\` (native) for representative ML-DSA / ML-KEM ops

## What this unblocks

Phase 7b for the KMIP server. Once \`native::*\` is implemented, the 12
KMIP op handlers in \`pqctoday-hsm/kmip/src/ops/\` can replace their
SHA-256 placeholder bytes with real \`softhsmrustv3::native::sign(...)\` /
\`encapsulate(...)\` / etc. calls. Closes the §12.7.7 lock from the KMIP
\`IMPLEMENTATION_PLAN.md\` (\"real softhsmrustv3 wiring required before
MVP ships\").

🤖 Generated with [Claude Code](https://claude.com/claude-code)