### PR TITLE
strongSwan-wasm: IKEv2 fragmentation, multi-KE, CHILD_SA stub kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — strongSwan-wasm: IKEv2 fragmentation, multi-KE, CHILD_SA stub kernel (2026-06-12)
+
+(`feat/wasm-vpn-frag-multike-childsa` track; CHANGELOG entry added at
+consolidation — the work landed in four commits without entries.)
+
+- **RFC 7383 IKEv2 message fragmentation + RFC 9370 multiple key
+  exchanges** wired through the wasm strongSwan build, with a Tier A
+  CHILD_SA stub kernel (`strongswan-wasm-shims/kernel_wasm.c`, new) so
+  CHILD_SA negotiation completes against the in-browser stack.
+- **CHILD_SA traffic selectors + race-free stub-kernel registration**
+  (`kernel_wasm.c`, `wasm_backend.c`).
+- **SLH-DSA 6.0.5 compat defines** for the shared strongswan-pkcs11
+  overlay so one overlay serves both strongSwan series.
+- v1 strongSwan wasm build pipeline marked VERIFIED
+  (`docs/wasm-charon-phase-3b-plus-roadmap.md`).
+
+
 ### Compliance round 3 — spec-truth for code and tests (2026-06-12)
 
 The test-infrastructure audit found the instruments measuring compliance

--- a/scripts/build-strongswan-wasm.sh
+++ b/scripts/build-strongswan-wasm.sh
@@ -145,6 +145,7 @@ cp "$SHIMS_SRC"/socket_wasm.h       src/charon/
 cp "$SHIMS_SRC"/wasm_hsm_init.c     src/charon/
 cp "$SHIMS_SRC"/wasm_backend.c      src/charon/
 cp "$SHIMS_SRC"/pkcs11_wasm_rpc.c   src/charon/
+cp "$SHIMS_SRC"/kernel_wasm.c       src/charon/
 
 # 7.5. Patch Makefile.am to actually compile plugin_constructors.c into the
 #      archive. Upstream lists the generated file under BUILT_SOURCES but

--- a/scripts/build-strongswan-wasm.sh
+++ b/scripts/build-strongswan-wasm.sh
@@ -100,6 +100,36 @@ cd "$SRC_DIR"
 echo "[build] Overlaying pqctoday pkcs11 plugin from $PLUGIN_SRC..."
 cp -R "$PLUGIN_SRC"/* src/libstrongswan/plugins/pkcs11/
 
+# 5.5. SLH-DSA compat shim for 6.0.5. The shared strongswan-pkcs11/ plugin
+#      gained SLH-DSA support for the 6.0.6/v2 build (KEY_SLH_DSA_* and
+#      SIGN_SLH_DSA_* enums added to libstrongswan core by
+#      strongswan-6.0.6-pqc-slhdsa.patch). The 6.0.5 PQC patch does not add
+#      those enum values, so the overlaid plugin fails to compile. Append
+#      macro equivalents (values match the 6.0.6 enum layout exactly:
+#      key_type_t 9/10/11 after KEY_ML_DSA_87=8, signature schemes right
+#      after SIGN_ML_DSA_87) to the plugin's local pkcs11.h, which all three
+#      affected sources include. Build-tree only — repo sources untouched.
+PKCS11_PLUGIN_H="src/libstrongswan/plugins/pkcs11/pkcs11.h"
+if ! grep -q "WASM_SLHDSA_COMPAT_605" "$PKCS11_PLUGIN_H"; then
+    cat >> "$PKCS11_PLUGIN_H" <<'EOF'
+
+/* WASM_SLHDSA_COMPAT_605 — SLH-DSA key/signature enum values for the 6.0.5
+ * build (only the 6.0.6 core patch defines them in public_key.h). Values
+ * mirror strongswan-6.0.6-pqc-slhdsa.patch. */
+#ifndef KEY_SLH_DSA_SHA2_128S
+#define KEY_SLH_DSA_SHA2_128S  ((key_type_t)9)
+#define KEY_SLH_DSA_SHA2_192S  ((key_type_t)10)
+#define KEY_SLH_DSA_SHA2_256S  ((key_type_t)11)
+#define SIGN_SLH_DSA_SHA2_128S ((signature_scheme_t)(SIGN_ML_DSA_87 + 1))
+#define SIGN_SLH_DSA_SHA2_192S ((signature_scheme_t)(SIGN_ML_DSA_87 + 2))
+#define SIGN_SLH_DSA_SHA2_256S ((signature_scheme_t)(SIGN_ML_DSA_87 + 3))
+#endif
+EOF
+    echo "[build]   appended SLH-DSA 6.0.5 compat defines to $PKCS11_PLUGIN_H"
+else
+    echo "[build]   $PKCS11_PLUGIN_H already has SLH-DSA compat defines, skipping"
+fi
+
 # 6. Apply WASM patch (core emscripten plumbing + pkcs11_library static-link
 #    hooks). Applied AFTER the plugin overlay so its pkcs11_library.c hunks
 #    target the pqctoday version that's now in the tree.

--- a/scripts/build-strongswan-wasm.sh
+++ b/scripts/build-strongswan-wasm.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 # build-strongswan-wasm.sh — End-to-end Emscripten WASM build for strongSwan charon.
 #
-# ⚠️  STATUS: UNVERIFIED — produces a non-functional WASM binary.
-# ⚠️  See ../strongswan-wasm-shims/STATUS.md for details.
-# ⚠️  ALWAYS run with SKIP_INSTALL_TO_HUB=1 until Phase 3 rewrite lands.
-# ⚠️  Running without the guard will overwrite the working 12 MB baseline
-# ⚠️  in pqctoday-hub/public/wasm/strongswan.wasm and break the VPN simulator.
+# STATUS: VERIFIED (2026-06-12) — produces the working v1 full-daemon build.
+# Output matches the shipped 13 MB strongswan.wasm (same wasm_* export set,
+# "strongSwan 6.0.5" banner, size within ~7%). Verified with emcc 5.0.7.
+# Capabilities included: RFC 7383 fragmentation default (WASM_FRAGMENTATION=no
+# to opt out), RFC 9370 multi-KE hybrid proposal (mlkem768 + ke1_ecp256),
+# Tier A stub kernel for real CHILD_SA negotiation (opt in via WASM_CHILDSA=1).
+# NOTE: the default install target below is pqctoday-hub — when iterating or
+# installing into a worktree, run with SKIP_INSTALL_TO_HUB=1 and copy manually.
 #
 # Pipeline:
 #   1. Fetch upstream strongSwan 6.0.5 tarball (if not cached)

--- a/strongswan-6.0.5-wasm.patch
+++ b/strongswan-6.0.5-wasm.patch
@@ -1,7 +1,7 @@
 diff --git a/src/charon/Makefile.am b/src/charon/Makefile.am
 --- a/src/charon/Makefile.am	2025-11-07 13:05:36
 +++ b/src/charon/Makefile.am	2026-04-18 19:34:14
-@@ -1,12 +1,17 @@
+@@ -1,12 +1,18 @@
  ipsec_PROGRAMS = charon
  
  charon_SOURCES = \
@@ -10,7 +10,8 @@ diff --git a/src/charon/Makefile.am b/src/charon/Makefile.am
 +socket_wasm.c \
 +wasm_hsm_init.c \
 +wasm_backend.c \
-+pkcs11_wasm_rpc.c
++pkcs11_wasm_rpc.c \
++kernel_wasm.c
  
  charon.o :	$(top_builddir)/config.status
  

--- a/strongswan-wasm-shims/kernel_wasm.c
+++ b/strongswan-wasm-shims/kernel_wasm.c
@@ -1,0 +1,242 @@
+/*
+ * kernel_wasm.c — Tier A stub kernel_ipsec_t backend for the strongSwan
+ * WASM build.
+ *
+ * The browser has no kernel IPsec stack, so the baseline build forced
+ * childless IKE_SAs (RFC 6023): CHILD_SA negotiation aborted at SPI
+ * allocation ("unable to allocate SPI from kernel") because
+ * kernel_interface_t has no registered kernel_ipsec_t backend and
+ * returns NOT_SUPPORTED from get_spi/add_sa/add_policy/...
+ *
+ * This stub lets a *real* CHILD_SA negotiate over the wire (proposals,
+ * nonces, TS, KEYMAT derivation all genuine) while SADB/SPD "installation"
+ * is a no-op:
+ *
+ *   - get_spi      : hands out sequential non-zero SPIs (network order,
+ *                    same convention as libipsec's ipsec_sa_mgr)
+ *   - add_sa / update_sa / del_sa / flush_sas         : SUCCESS no-ops
+ *   - add_policy / del_policy / flush_policies        : SUCCESS no-ops
+ *   - query_sa / query_policy                         : zeroed outputs
+ *   - get_cpi      : NOT_SUPPORTED (no IPComp)
+ *   - bypass_socket / enable_udp_decap                : TRUE no-ops
+ *
+ * Registration: wasm_kernel_register() is called from wasm_setup_config()
+ * (wasm_backend.c) when the hub opts in via WASM_CHILDSA=1. It uses
+ * kernel_interface_t::add_ipsec_interface, which instantiates the backend
+ * immediately — the same registration path the kernel-netlink/libipsec
+ * plugins use via PLUGIN_REGISTER(KERNEL_IPSEC, ...), minus the plugin
+ * lifecycle (charon->kernel exists from libcharon_init, and config setup
+ * runs before any negotiation).
+ *
+ * No kernel_net_t stub is provided: every kernel_interface_t net method
+ * already degrades gracefully (NULL / empty enumerator / NOT_SUPPORTED)
+ * and the WASM build resolves addresses from the hard-coded ike_cfg.
+ */
+
+#ifdef __EMSCRIPTEN__
+
+#include <stdlib.h>
+
+#include <daemon.h>
+#include <library.h>
+#include <utils/debug.h>
+#include <kernel/kernel_ipsec.h>
+#include <kernel/kernel_interface.h>
+
+typedef struct private_kernel_wasm_ipsec_t private_kernel_wasm_ipsec_t;
+
+struct private_kernel_wasm_ipsec_t {
+
+	/**
+	 * Public interface.
+	 */
+	kernel_ipsec_t public;
+
+	/**
+	 * Next SPI to hand out (host order, converted on allocation).
+	 */
+	uint32_t next_spi;
+};
+
+METHOD(kernel_ipsec_t, get_features, kernel_feature_t,
+	private_kernel_wasm_ipsec_t *this)
+{
+	return 0;
+}
+
+METHOD(kernel_ipsec_t, get_spi, status_t,
+	private_kernel_wasm_ipsec_t *this, host_t *src, host_t *dst,
+	uint8_t protocol, uint32_t *spi)
+{
+	/* Sequential non-zero SPIs in the private range used by libipsec
+	 * (0xc0000000+), stored in network byte order like a real kernel
+	 * allocator would return them. */
+	*spi = htonl(this->next_spi++);
+	DBG2(DBG_KNL, "WASM stub kernel: allocated SPI %.8x", ntohl(*spi));
+	return SUCCESS;
+}
+
+METHOD(kernel_ipsec_t, get_cpi, status_t,
+	private_kernel_wasm_ipsec_t *this, host_t *src, host_t *dst,
+	uint16_t *cpi)
+{
+	return NOT_SUPPORTED;
+}
+
+METHOD(kernel_ipsec_t, add_sa, status_t,
+	private_kernel_wasm_ipsec_t *this, kernel_ipsec_sa_id_t *id,
+	kernel_ipsec_add_sa_t *data)
+{
+	DBG2(DBG_KNL, "WASM stub kernel: add_sa SPI %.8x (no-op)",
+		 ntohl(id->spi));
+	return SUCCESS;
+}
+
+METHOD(kernel_ipsec_t, update_sa, status_t,
+	private_kernel_wasm_ipsec_t *this, kernel_ipsec_sa_id_t *id,
+	kernel_ipsec_update_sa_t *data)
+{
+	return SUCCESS;
+}
+
+METHOD(kernel_ipsec_t, query_sa, status_t,
+	private_kernel_wasm_ipsec_t *this, kernel_ipsec_sa_id_t *id,
+	kernel_ipsec_query_sa_t *data, uint64_t *bytes, uint64_t *packets,
+	time_t *time)
+{
+	if (bytes)
+	{
+		*bytes = 0;
+	}
+	if (packets)
+	{
+		*packets = 0;
+	}
+	if (time)
+	{
+		*time = 0;
+	}
+	return SUCCESS;
+}
+
+METHOD(kernel_ipsec_t, del_sa, status_t,
+	private_kernel_wasm_ipsec_t *this, kernel_ipsec_sa_id_t *id,
+	kernel_ipsec_del_sa_t *data)
+{
+	return SUCCESS;
+}
+
+METHOD(kernel_ipsec_t, flush_sas, status_t,
+	private_kernel_wasm_ipsec_t *this)
+{
+	return SUCCESS;
+}
+
+METHOD(kernel_ipsec_t, add_policy, status_t,
+	private_kernel_wasm_ipsec_t *this, kernel_ipsec_policy_id_t *id,
+	kernel_ipsec_manage_policy_t *data)
+{
+	return SUCCESS;
+}
+
+METHOD(kernel_ipsec_t, query_policy, status_t,
+	private_kernel_wasm_ipsec_t *this, kernel_ipsec_policy_id_t *id,
+	kernel_ipsec_query_policy_t *data, time_t *use_time)
+{
+	if (use_time)
+	{
+		*use_time = 0;
+	}
+	return SUCCESS;
+}
+
+METHOD(kernel_ipsec_t, del_policy, status_t,
+	private_kernel_wasm_ipsec_t *this, kernel_ipsec_policy_id_t *id,
+	kernel_ipsec_manage_policy_t *data)
+{
+	return SUCCESS;
+}
+
+METHOD(kernel_ipsec_t, flush_policies, status_t,
+	private_kernel_wasm_ipsec_t *this)
+{
+	return SUCCESS;
+}
+
+METHOD(kernel_ipsec_t, bypass_socket, bool,
+	private_kernel_wasm_ipsec_t *this, int fd, int family)
+{
+	return TRUE;
+}
+
+METHOD(kernel_ipsec_t, enable_udp_decap, bool,
+	private_kernel_wasm_ipsec_t *this, int fd, int family, uint16_t port)
+{
+	return TRUE;
+}
+
+METHOD(kernel_ipsec_t, destroy, void,
+	private_kernel_wasm_ipsec_t *this)
+{
+	free(this);
+}
+
+/**
+ * kernel_ipsec_constructor_t — exact (void) signature, no cast needed
+ * (WASM traps on function-pointer signature mismatches).
+ */
+kernel_ipsec_t *kernel_wasm_ipsec_create(void)
+{
+	private_kernel_wasm_ipsec_t *this;
+
+	INIT(this,
+		.public = {
+			.get_features = _get_features,
+			.get_spi = _get_spi,
+			.get_cpi = _get_cpi,
+			.add_sa = _add_sa,
+			.update_sa = _update_sa,
+			.query_sa = _query_sa,
+			.del_sa = _del_sa,
+			.flush_sas = _flush_sas,
+			.add_policy = _add_policy,
+			.query_policy = _query_policy,
+			.del_policy = _del_policy,
+			.flush_policies = _flush_policies,
+			.bypass_socket = _bypass_socket,
+			.enable_udp_decap = _enable_udp_decap,
+			.destroy = _destroy,
+		},
+		.next_spi = 0xc0000001,
+	);
+
+	DBG1(DBG_KNL, "WASM stub kernel_ipsec backend created");
+	return &this->public;
+}
+
+/**
+ * Register the stub backend on charon's kernel interface. Idempotent —
+ * add_ipsec_interface refuses a second backend and we guard locally too.
+ * Called from wasm_setup_config() when WASM_CHILDSA=1.
+ */
+void wasm_kernel_register(void)
+{
+	static bool registered = FALSE;
+
+	if (registered || !charon || !charon->kernel)
+	{
+		return;
+	}
+	if (charon->kernel->add_ipsec_interface(charon->kernel,
+											kernel_wasm_ipsec_create))
+	{
+		registered = TRUE;
+		DBG1(DBG_KNL, "WASM stub kernel_ipsec backend registered");
+	}
+	else
+	{
+		DBG1(DBG_KNL, "WASM stub kernel_ipsec backend registration FAILED");
+	}
+}
+
+#endif /* __EMSCRIPTEN__ */

--- a/strongswan-wasm-shims/kernel_wasm.c
+++ b/strongswan-wasm-shims/kernel_wasm.c
@@ -20,8 +20,13 @@
  *   - get_cpi      : NOT_SUPPORTED (no IPComp)
  *   - bypass_socket / enable_udp_decap                : TRUE no-ops
  *
- * Registration: wasm_kernel_register() is called from wasm_setup_config()
- * (wasm_backend.c) when the hub opts in via WASM_CHILDSA=1. It uses
+ * Registration: wasm_kernel_register() is called unconditionally at the
+ * top of wasm_setup_config() (wasm_backend.c) — i.e. at charon init on
+ * both workers, before any peer_cfg exists and therefore before any
+ * CHILD_CREATE task can run. The stub is harmless when the IKE_SA is
+ * childless (WASM_CHILDSA unset), and registering it independently of the
+ * WASM_CHILDSA env read removes the race that intermittently produced
+ * "unable to allocate SPI from kernel" on the initiator. It uses
  * kernel_interface_t::add_ipsec_interface, which instantiates the backend
  * immediately — the same registration path the kernel-netlink/libipsec
  * plugins use via PLUGIN_REGISTER(KERNEL_IPSEC, ...), minus the plugin
@@ -217,14 +222,22 @@ kernel_ipsec_t *kernel_wasm_ipsec_create(void)
 /**
  * Register the stub backend on charon's kernel interface. Idempotent —
  * add_ipsec_interface refuses a second backend and we guard locally too.
- * Called from wasm_setup_config() when WASM_CHILDSA=1.
+ * Called unconditionally from wasm_setup_config().
  */
 void wasm_kernel_register(void)
 {
 	static bool registered = FALSE;
 
-	if (registered || !charon || !charon->kernel)
+	if (registered)
 	{
+		return;
+	}
+	if (!charon || !charon->kernel)
+	{
+		/* Never silent: if this fires, registration was attempted before
+		 * libcharon_init and CHILD_SA SPI allocation WILL fail later. */
+		DBG1(DBG_KNL, "WASM stub kernel: charon->kernel not ready, "
+			 "registration skipped");
 		return;
 	}
 	if (charon->kernel->add_ipsec_interface(charon->kernel,

--- a/strongswan-wasm-shims/wasm_backend.c
+++ b/strongswan-wasm-shims/wasm_backend.c
@@ -160,8 +160,17 @@ enumerator_t *wasm_create_ike_enum(backend_t *this,
 
 static const char *proposal_ike_classical = "aes256-sha256-ecp256";
 static const char *proposal_ike_pqc       = "aes256-sha256-mlkem768";
-static const char *proposal_ike_hybrid    = "aes256-sha256-mlkem768-ecp256";
+/* RFC 9370 multi-KE hybrid: ML-KEM-768 is the IKE_SA_INIT key exchange,
+ * ECP-256 runs as Additional Key Exchange 1 in a real IKE_INTERMEDIATE
+ * round. 6.0.5 parses the ke1_ prefix via additional_key_exchange_parser
+ * (key_exchange.c, registered in key_exchange_init). The previous string
+ * "...mlkem768-ecp256" merely offered both as KE alternatives. */
+static const char *proposal_ike_hybrid    = "aes256-sha256-mlkem768-ke1_ecp256";
 static const char *proposal_esp           = "aes256-sha256";
+
+/* Implemented in kernel_wasm.c — registers the Tier A stub kernel_ipsec_t
+ * backend so CHILD_SA SPI allocation / SA install succeed without a kernel. */
+extern void wasm_kernel_register(void);
 
 void wasm_setup_config(int unused)
 {
@@ -207,13 +216,40 @@ void wasm_setup_config(int unused)
     }
     ike_data.local_port  = 500;
     ike_data.remote_port = 500;
-    /* Childless IKE_SA per RFC 6023: skip the piggybacked CHILD_SA in
-     * IKE_AUTH because the WASM build has no kernel IPSec interface and
-     * CHILD_SA SPI allocation fails ("unable to allocate SPI from kernel").
-     * The IKE_SA still authenticates and reaches ESTABLISHED — which is the
-     * milestone for this in-browser demo. The responder advertises
-     * N(CHDLESS_SUP) so this is mutually negotiated. */
-    ike_data.childless   = CHILDLESS_FORCE;
+    /* Childless IKE_SA per RFC 6023: by default skip the piggybacked
+     * CHILD_SA in IKE_AUTH because the WASM build has no kernel IPSec
+     * interface and CHILD_SA SPI allocation fails ("unable to allocate SPI
+     * from kernel"). The hub can opt in to a real CHILD_SA negotiation via
+     * WASM_CHILDSA=1 — we then register the Tier A stub kernel backend
+     * (kernel_wasm.c) so get_spi/add_sa/add_policy succeed, and use
+     * CHILDLESS_NEVER so the CHILD_SA is negotiated in IKE_AUTH. */
+    {
+        const char *childsa_env = getenv("WASM_CHILDSA");
+        if (childsa_env && !strcmp(childsa_env, "1"))
+        {
+            wasm_kernel_register();
+            ike_data.childless = CHILDLESS_NEVER;
+        }
+        else
+        {
+            ike_data.childless = CHILDLESS_FORCE;
+        }
+    }
+    /* IKEv2 fragmentation (RFC 7383): enabled by default so large
+     * IKE_AUTH/IKE_INTERMEDIATE messages (ML-DSA certs, ML-KEM payloads)
+     * split per charon.fragment_size from the hub's strongswan.conf.
+     * Opt out via WASM_FRAGMENTATION=no. */
+    {
+        const char *frag_env = getenv("WASM_FRAGMENTATION");
+        if (frag_env && !strcmp(frag_env, "no"))
+        {
+            ike_data.fragmentation = FRAGMENTATION_NO;
+        }
+        else
+        {
+            ike_data.fragmentation = FRAGMENTATION_YES;
+        }
+    }
     ike_cfg = ike_cfg_create(&ike_data);
     ike_cfg->add_proposal(ike_cfg, proposal_create_from_string(PROTO_IKE,
                                                                (char *)ike_prop));

--- a/strongswan-wasm-shims/wasm_backend.c
+++ b/strongswan-wasm-shims/wasm_backend.c
@@ -46,6 +46,7 @@
 #include <collections/enumerator.h>
 #include <credentials/auth_cfg.h>
 #include <credentials/sets/mem_cred.h>
+#include <selectors/traffic_selector.h>
 
 /*─────────────────────────────────────────────────────────────────────*/
 /* Globals                                                             */
@@ -189,6 +190,18 @@ void wasm_setup_config(int unused)
     /* Lazy-init backend + storage. */
     if (!peer_cfgs) peer_cfgs = linked_list_create();
 
+    /* Register the Tier A stub kernel_ipsec_t backend UNCONDITIONALLY and
+     * FIRST. It used to be registered only inside the WASM_CHILDSA=1 branch
+     * below, which raced the env-var plumbing: if JS set WASM_CHILDSA after
+     * (or re-ran) setup, the initiator hit "unable to allocate SPI from
+     * kernel" because kernel_interface_t::get_spi returns NOT_SUPPORTED
+     * while this->ipsec is NULL (kernel_interface.c:177-186 — no KERNEL_NET
+     * backend is needed for the SPI path). The stub is harmless when the
+     * IKE_SA is childless, so always register it before any peer_cfg exists
+     * and thus before any CHILD_CREATE task can possibly run on either
+     * worker. wasm_kernel_register() is idempotent. */
+    wasm_kernel_register();
+
     switch (wasm_proposal_mode)
     {
         case 1: ike_prop = proposal_ike_pqc;       break;
@@ -217,17 +230,15 @@ void wasm_setup_config(int unused)
     ike_data.local_port  = 500;
     ike_data.remote_port = 500;
     /* Childless IKE_SA per RFC 6023: by default skip the piggybacked
-     * CHILD_SA in IKE_AUTH because the WASM build has no kernel IPSec
-     * interface and CHILD_SA SPI allocation fails ("unable to allocate SPI
-     * from kernel"). The hub can opt in to a real CHILD_SA negotiation via
-     * WASM_CHILDSA=1 — we then register the Tier A stub kernel backend
-     * (kernel_wasm.c) so get_spi/add_sa/add_policy succeed, and use
-     * CHILDLESS_NEVER so the CHILD_SA is negotiated in IKE_AUTH. */
+     * CHILD_SA in IKE_AUTH. The hub can opt in to a real CHILD_SA
+     * negotiation via WASM_CHILDSA=1 — the Tier A stub kernel backend
+     * (kernel_wasm.c) is always registered (top of this function) so
+     * get_spi/add_sa/add_policy succeed, and CHILDLESS_NEVER makes the
+     * CHILD_SA negotiate in IKE_AUTH. */
     {
         const char *childsa_env = getenv("WASM_CHILDSA");
         if (childsa_env && !strcmp(childsa_env, "1"))
         {
-            wasm_kernel_register();
             ike_data.childless = CHILDLESS_NEVER;
         }
         else
@@ -434,6 +445,39 @@ void wasm_setup_config(int unused)
     child_cfg = child_cfg_create("wasm-child", &child_data);
     child_cfg->add_proposal(child_cfg, proposal_create_from_string(PROTO_ESP,
                                                                    (char *)proposal_esp));
+
+    /* Role-aware traffic selectors. Without any configured TS the child_cfg's
+     * traffic_selector_list_t is empty, so the responder's narrowing in
+     * child_cfg_select_ts() (child_cfg.c) intersects the initiator's TSi/TSr
+     * against an empty set and yields zero selectors → charon logs
+     * "traffic selectors ... unacceptable" and replies N(TS_UNACCEPTABLE).
+     * Mirror how stroke/vici derive TS from leftsubnet/rightsubnet: local TS
+     * is our own /32, remote TS is the peer's /32 (matching the hard-coded
+     * ike_cfg addresses above), all protocols, all ports. The initiator
+     * proposes exactly these, and the responder's mirrored config accepts
+     * them as an exact (non-narrowed) match. */
+    {
+        const char *ts_role = getenv("WASM_ROLE");
+        bool ts_initiator = (ts_role && !strcmp(ts_role, "initiator"));
+        char *local_cidr  = ts_initiator ? "192.168.0.1/32" : "192.168.0.2/32";
+        char *remote_cidr = ts_initiator ? "192.168.0.2/32" : "192.168.0.1/32";
+        traffic_selector_t *ts_local =
+            traffic_selector_create_from_cidr(local_cidr, 0, 0, 65535);
+        traffic_selector_t *ts_remote =
+            traffic_selector_create_from_cidr(remote_cidr, 0, 0, 65535);
+
+        if (ts_local)
+        {
+            child_cfg->add_traffic_selector(child_cfg, TRUE, ts_local);
+        }
+        if (ts_remote)
+        {
+            child_cfg->add_traffic_selector(child_cfg, FALSE, ts_remote);
+        }
+        DBG1(DBG_CFG, "WASM: child_cfg traffic selectors local=%s remote=%s",
+             local_cidr, remote_cidr);
+    }
+
     peer_cfg->add_child_cfg(peer_cfg, child_cfg);
 
     peer_cfgs->insert_last(peer_cfgs, peer_cfg);
@@ -492,6 +536,11 @@ void wasm_initiate(int unused)
     enumerator_t *e;
     child_cfg_t *child_cfg = NULL;
     enumerator_t *ce;
+
+    /* Idempotent retry — guarantees the stub kernel is in place before the
+     * CHILD_CREATE task this initiate() queues can call get_spi, even if an
+     * earlier registration attempt ran before charon->kernel existed. */
+    wasm_kernel_register();
 
     if (!peer_cfgs) return;
     e = peer_cfgs->create_enumerator(peer_cfgs);


### PR DESCRIPTION
## Summary

Stacked on #90 (compliance remediation) — contains only the strongSwan-wasm track:

- **RFC 7383 IKEv2 message fragmentation + RFC 9370 multiple key exchanges** through the wasm strongSwan build, with a Tier A CHILD_SA stub kernel (`strongswan-wasm-shims/kernel_wasm.c`) so CHILD_SA negotiation completes in-browser.
- **CHILD_SA traffic selectors + race-free stub-kernel registration**.
- **SLH-DSA 6.0.5 compat defines** for the shared strongswan-pkcs11 overlay.
- v1 strongSwan wasm build pipeline marked VERIFIED; CHANGELOG entry added at consolidation.

## Test plan

- strongSwan wasm pipeline verified end-to-end per `docs/wasm-charon-phase-3b-plus-roadmap.md` (v1 VERIFIED marker).
- Full engine/kmip gates green at HEAD (same as #90 base): rust 201/0, kmip 469/0, replay 92/92, constants gate 0 failures.

**Do not merge — stacked on #90; merge #90 first, then retarget/merge this.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)