### PR TITLE
fix(kmip): Locate orphan filter regressed OASIS conformance 92→89 (store-only objects dropped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed — KMIP Locate orphan filter regressed OASIS conformance 92→89 (2026-06-13)
+
+A conformance-harness accuracy/completeness audit found `main` was at **89 PASS
+/ 3 FAIL**, not the claimed 92/0 — a regression hidden by a stale
+`conformance/REPLAY_REPORT.md` (a 1-test partial run). The Phase 7b.1 "Locate
+orphan filter" (`9176662`) dropped every Locate result whose PKCS#11 handle was
+absent from the engine, including legitimately **store-only** objects (Raw AES /
+cert / secret-data Registers that are never engine-imported) — so a freshly
+Registered key vanished from its own Locate (BL-M-1/4/14: empty payload where a
+UniqueIdentifier was expected). The filter now keys on `ObjectRecord.key_material`:
+store-backed objects (`Some`) stay locatable; only true engine-only orphans
+(`None` + missing handle) are hidden, preserving the persistent-store/volatile-
+engine guard the filter was written for. Replay restored to **92 PASS / 0 FAIL /
+10 SKIP**; `REPLAY_REPORT` regenerated from a full run.
+
+Audit findings (no code change, recorded for accuracy): the replay harness is
+sound — it drives the real compiled server over TLS with exact tree-wise
+comparison and no error-as-PASS path, and all 10 SKIPs are legitimate
+(5 deprecated DES/3DES/DSA, 2 cross-transcript precondition, 3 mutually-exclusive
+RNG policy variants). The checked-in corpus is the **complete** official OASIS
+KMIP 3.0 package (102/102 transcripts, 1234/1234 messages, byte-identical). Two
+honest scope limits: (1) crypto outputs (signature/ciphertext/MAC/digest) are
+placeholder-bound, not KAT-verified — the claim is protocol/structural/status
+conformance, not cryptographic-correctness; (2) the replay is **not CI-gated**,
+which is how this regression slipped in — wiring it is recommended follow-up.
+
 ### Fixed — C++ engine: token encrypt/decrypt hardening + C++17 enforcement (2026-06-13)
 
 A security hardening sweep over all 111 `Token::encrypt`/`decrypt` call sites in

--- a/kmip/conformance/REPLAY_REPORT.json
+++ b/kmip/conformance/REPLAY_REPORT.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": 1781130302,
+  "generated_at": 1781370771,
   "summary": {
     "pass": 92,
     "fail": 0,

--- a/kmip/conformance/REPLAY_REPORT.md
+++ b/kmip/conformance/REPLAY_REPORT.md
@@ -1,6 +1,6 @@
 # OASIS KMIP 3.0 Dispatcher Replay Report
 
-Generated: 2026-06-10 22:25:02 UTC
+Generated: 2026-06-13 17:12:51 UTC
 
 
 ## Aggregate

--- a/kmip/src/ops/locate.rs
+++ b/kmip/src/ops/locate.rs
@@ -84,8 +84,32 @@ pub fn locate(deps: &Deps, req: LocateRequest, correlation_id: &str) -> Result<L
     // persistent-SQLite + volatile-engine restart case where store
     // metadata outlives the token. Runs before paging so `Offset Items`
     // and `Maximum Items` operate on live records only.
+    //
+    // The probe applies ONLY to records whose key bytes live exclusively
+    // inside the engine (`key_material == None` — Create / CreateKeyPair,
+    // see `ObjectRecord::key_material` doc). For those a vanished handle
+    // is a genuine orphan: the object can no longer be served at all
+    // (`Get` falls through to the engine — get.rs §"engine-held"), so
+    // returning its UID from Locate would be a dangling reference.
+    //
+    // Records that carry their own `key_material` (Register / Import of
+    // Raw symmetric keys, certificates, secret data, …) are store-backed:
+    // `Get` serves them straight from the store without touching the
+    // engine, so they remain valid and locatable even when no engine
+    // handle exists. Many were never engine-imported in the first place
+    // (e.g. AES Register has no import branch in register_import_export),
+    // so probing them would spuriously drop legitimately store-only
+    // objects — the Phase 7b.1 regression (OASIS BL-M-1/4/14: a freshly
+    // Registered AES key vanished from its own Locate). Gating on
+    // `key_material.is_none()` keeps the orphan guard sound for the
+    // engine-resident case it was written for while leaving store-backed
+    // objects locatable.
     if let Some(session) = deps.engine_session {
         matches.retain(|r| {
+            if r.key_material.is_some() {
+                // Store-backed: locatable regardless of engine state.
+                return true;
+            }
             matches!(
                 super::helpers::find_handle_for_object(session, &r.pkcs11_cka_id, r.object_type),
                 Ok(Some(_))
@@ -366,6 +390,54 @@ mod tests {
         // Absent → spec default is On-line-only → results.
         let r = locate(&d, LocateRequest::default(), "c").unwrap();
         assert_eq!(r.uids, vec!["a"]);
+    }
+
+    /// Regression guard (Phase 7b.1 orphan-filter): a store-backed
+    /// object — one that carries its own `key_material` (e.g. a Register
+    /// of a Raw AES SymmetricKey, as in OASIS BL-M-1/4/14) — must remain
+    /// locatable even when an engine session is present and the engine
+    /// holds no handle for it. The orphan filter (added by 9176662)
+    /// dropped EVERY record whose PKCS#11 handle was absent, wrongly
+    /// removing legitimately store-only objects and regressing
+    /// conformance 92→89. The `key_material.is_some()` short-circuit
+    /// keeps such records present without ever probing the (here-bogus)
+    /// engine session.
+    #[test]
+    fn locate_keeps_store_backed_object_with_engine_session_present() {
+        let mut d = deps_with();
+        // Simulate a real engine being wired (the conformance/default
+        // server path). The session id is never dereferenced because the
+        // record below carries `key_material`, so the filter short-circuits.
+        d.engine_session = Some(1);
+
+        // A Registered Raw AES key: store-backed, no engine import.
+        d.store
+            .put(ObjectRecord {
+                uid: "store-only".into(),
+                object_type: ObjectType::SymmetricKey,
+                algorithm: KmipAlgorithm::Aes,
+                state: State::Active,
+                pkcs11_cka_id: vec![9, 9, 9],
+                key_material: Some(vec![0u8; 32]),
+                initial_date: OffsetDateTime::UNIX_EPOCH,
+                ..ObjectRecord::default()
+            })
+            .unwrap();
+
+        let r = locate(
+            &d,
+            LocateRequest {
+                attributes: vec![Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes)],
+                ..Default::default()
+            },
+            "c",
+        )
+        .unwrap();
+        assert_eq!(
+            r.uids,
+            vec!["store-only"],
+            "a store-backed object must survive Locate even with an engine session present"
+        );
     }
 
     /// K22 — §6.1.32: "The server SHALL NOT return unique identifiers


### PR DESCRIPTION
## Summary

A KMIP conformance-harness **accuracy + completeness audit** (prompted by "do we pass all official KMIP 3.0 KAT?") found that `main` was actually at **89 PASS / 3 FAIL**, not the claimed 92/0 — a regression hidden by a stale `conformance/REPLAY_REPORT.md` (a 1-test partial run that never iterated the full corpus).

### Root cause
The Phase 7b.1 "Locate orphan filter" (`9176662`) drops every Locate result whose PKCS#11 handle is absent from the engine. Intent: in a persistent-SQLite + volatile-engine restart, hide records whose engine token died. Bug: it also dropped legitimately **store-only** objects — Raw AES / certificate / secret-data Registers that are never engine-imported (they hit the `_ => {}` no-op in the Register engine-import block). So a freshly Registered AES key vanished from its own Locate → empty payload where the corpus expects a UniqueIdentifier (BL-M-1/4/14, `child count 1 != 0`).

### Fix
The filter now keys on `ObjectRecord.key_material` — the exact engine-residency distinguisher:
- `Some(..)` → store-backed; `Get` serves from the store without the engine, so it stays locatable.
- `None` → engine-only; a missing handle is a true orphan (unservable), so it's still hidden.

This preserves the orphan guard for the case it was written for (verified: the existing `locate_drops_orphans_when_engine_handle_is_gone` e2e still passes) while restoring conformance. New regression test `locate_keeps_store_backed_object_with_engine_session_present`.

## Audit findings (recorded; no code change)
- **Harness accuracy: sound.** Drives the real compiled server over TLS, exact tree-wise comparison, ResultStatus + ResultReason both checked, no error-as-PASS path. All 10 SKIPs legitimate (5 deprecated DES/3DES/DSA, 2 cross-transcript precondition, 3 mutually-exclusive RNG policy variants).
- **Corpus completeness: complete.** The checked-in corpus is the verbatim official OASIS KMIP 3.0 package — 102/102 transcripts, 1234/1234 messages, byte-identical.
- **Two honest scope limits:** (1) crypto outputs (signature/ciphertext/MAC/digest) are placeholder-bound, not KAT-verified — the claim is protocol/structural/status conformance, not cryptographic correctness; (2) **the replay is not CI-gated**, which is how this regression slipped in — recommended follow-up.

## Test plan
- Full replay: **92 PASS / 0 FAIL / 10 SKIP** (102 total); `REPLAY_REPORT.{md,json}` regenerated from the full run (was stale at 1 test).
- `cargo test`: 421 lib + all e2e/integration green.

**Do not merge yet — review requested.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
