### PR TITLE
feat(policy): W2 — policy completeness (Encrypt forcing, Hash gating, CKM map) + gaps plan

### DIFF
--- a/kmip/docs/REMAINING_GAPS_IMPLEMENTATION_PLAN.md
+++ b/kmip/docs/REMAINING_GAPS_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,124 @@
+# Remaining Gaps — Implementation Plan
+
+Covers the gaps open after: engine reproduces all 1452 OASIS PQC interop KATs
+byte-exact (PR #102); KMIP server-side PQC ops — keygen-seed (#104), Sign/Verify
+flags (#102), Encapsulate/Decapsulate (#105); crypto-policy mechanism dimension
+(PR #106). **Date**: 2026-06-14.
+
+> **Source-of-truth rule (unchanged):** every KMIP tag/enum from
+> `spec/oasis-kmip-3.0/…` (+ WD19 PDF for PQC); every `CK*` from
+> `src/lib/pkcs11/pkcs11t.h` (mirror: `rust/src/constants.rs`). No guessed values.
+
+Priority order: **W1** (the real interop claim) > **W2** (policy completeness,
+mostly quick) > **W4** (operability) > **W3** (alternate backend, large/optional).
+
+---
+
+## W1 — Full KMIP transcript replay of the 1452 set  *(highest value, largest)*
+
+**Goal:** drive the 1452 OASIS transcripts as live KMIP request/response
+exchanges through the TLS server and pass them — turning "every component
+produces the right bytes" into "the server passes the OASIS 1452 protocol set."
+
+**Why it's big:** the comparison is tree-wise with placeholder binding
+(`conformance/harness/dispatcher_replay.py`), and the transcripts carry *literal*
+expected crypto. A transcript passes only when (a) the crypto bytes match —
+**proven** — and (b) the server's **response structure** matches. (b) is the
+open-ended bulk.
+
+- **R1 — Python codec: teach `oasis_codec.py` the WD19 codepoints.** Add the PQC
+  tags (`0x4201C3–CA`) to the tag table and the op enums (`Encapsulate 0x41`,
+  `Decapsulate 0x42`) via the existing `_SPEC_EXTRACT_PATCHES`/tag-table seam
+  (values already in `kmip-spec-v3.0-wd19-clean.pdf`, vendored, + this repo's
+  memory). *Small.*
+- **R2 — Corpus wiring.** Point a replay run at the PQC corpus
+  (re-downloadable: kmip-interop.org → `…/72593/kmip-3-0-pqc-tests-03.zip`),
+  strip leading `#` annotation lines, and bind the PQC placeholders
+  (`$UNIQUE_IDENTIFIER_n`, `$NOW`, `$KEY_MATERIAL`, …) the same way the 3.0
+  corpus does. *Small–medium.*
+- **R3 — keygen/encap full-sequence support.** keygen `Seed` is wired (#104);
+  ensure the keygen response emits the `SeedPrivateKey` KeyBlock the transcript
+  expects; thread encap `InputKeyMaterial` through the real Encapsulate op
+  (depends on R-of-W2 passthrough/Encapsulate maturity). *Medium.*
+- **R4 — Per-category response-structure alignment (the bulk).** For each of
+  keygen/siggen/sigver/encap/decap, make the server's `ResponsePayload` shape
+  match the transcript (tags, nesting, KeyBlock format) so the tree comparator
+  passes with placeholders bound. Drive this empirically: replay one transcript
+  per category, diff, fix, repeat. *Large, iterative.*
+- **R5 — CI gate + report.** Add a small PQC replay subset to CI (mirror the
+  existing `dispatcher_replay` gate at 92/0/10); regenerate the full report on
+  demand. Keep the slow SLH-"s" cases out of per-push CI (as today).
+
+**Verify:** `dispatcher_replay.py` over the PQC corpus → PASS/FAIL per transcript;
+target 0 FAIL on the actionable set. **Sizing:** R1–R3 days; R4 the long pole
+(structure alignment across 5 categories).
+
+---
+
+## W2 — Crypto-policy completeness  *(mostly quick wins; on top of PR #106)*
+
+- **W2.1 — Encrypt mechanism-param forcing.** Apply `Decision.cp_override` in
+  `ops/encrypt.rs` (mirror `ops/sign.rs`): capture `forced_cp` at the decision,
+  `merge_cp_override` into the effective CP before `aes_mechanism_for` /
+  `encrypt_ml_kem`. Thread it into `encrypt_classical`/`encrypt_ml_kem`
+  (the sub-functions compute their own CP today). *Small–medium.* Test: a
+  policy forcing AES-GCM makes an app-requested CBC run as GCM.
+- **W2.2 — Standalone `Hash` op gating.** Populate `PolicyRequest.mechanism`
+  in `ops/mac_and_hash.rs::hash` (the keyless Hash op) so
+  `hash_algorithm_allowlist` gates it. *Small.*
+- **W2.3 — Expand `ckm_name_to_code`.** Grow the curated map in
+  `policy/rule.rs` toward the full PKCS#11 v3.2 mechanism set the engine
+  supports (AES-KWP, ChaCha20-Poly1305, prehash sig variants, the KDFs), each
+  value referenced from `constants.rs`. *Small, mechanical.*
+- **W2.4 — Verify the `CKM_KMAC` codepoint upstream.** Local `pkcs11t.h` +
+  `constants.rs` agree (`0x80000100`, vendor-defined) — self-consistent. Check
+  the canonical OASIS PKCS#11 v3.2 header
+  (`docs.oasis-open.org/pkcs11/.../pkcs11t.h`): if v3.2 standardizes KMAC at a
+  non-vendor codepoint, re-sync `pkcs11t.h` + `constants.rs` (and the JS/TS
+  mirror per the cross-layer-constants memory). *Small; verification-first.*
+- **W2.5 — Phase-gated (track, don't force now):**
+  - `MaxKeyAgeDays` rule — needs the Phase-6 object store to expose
+    `activated_at`; un-stub then.
+  - Full `RekeyAndProceed` transaction (state→Deprecated, supersedes-link,
+    re-issue) — Phase 6 store + lifecycle FSM.
+  - Composite/hybrid signature **wire format** (`HybridDualSignRequirement`
+    enforces; encoding deferred) — Phase 7 / LAMPS draft-19.
+  - `ComplianceProfileGate` — keep documentational until the Phase-8
+    compliance tool consumes it.
+
+**Verify:** policy unit + integration suites stay green; new tests per item.
+
+---
+
+## W4 — Policy management facade  *(operability; unblocks the Hub UI)*
+
+The enforcement plane is KMIP (done); the management plane is the Rust
+`PolicyStore` API + YAML files only. Add a thin HTTP and/or WASM facade over the
+existing `PolicyStore` primitives (`list/load/validate_draft/dry_run/save/
+activate_with_engine/resume_active`) so the Hub UI can author, dry-run, and
+activate policies. **No new KMIP surface** — policy admin stays out-of-band
+(separation of duties). *Medium; design + a thin transport, no new logic.*
+
+---
+
+## W3 — Option C: C++ SoftHSM + OpenSSL 3.6 as an alternate KMIP backend  *(large, optional)*
+
+Per the earlier `CRYPTO_BACKEND_ARCHITECTURE.md`: a `trait CryptoBackend`
+abstraction with `SofthsmRustV3Backend` (current) and a `Pkcs11Backend`
+(KMIP → C++ SoftHSM → OpenSSL 3.6 via the PKCS#11 C ABI), then dual-backend
+1452 cross-validation (native only; WASM stays Rust). Shared blocker noted
+there — encaps-with-coins — is now resolved on the Rust side
+(`encapsulate_deterministic`); the C++/OpenSSL path exposes it via
+`CKH_*`/`C_EncapsulateKey`. *Large, multi-week; start only if a second backend
+is a product requirement.*
+
+---
+
+## Cross-cutting
+- **CI economy:** one CI run per logical PR (not per commit); local `cargo test`
+  + the policy/interop suites are the gate. Keep slow SLH-"s" vectors out of
+  per-push CI; full 1452 runs on demand / nightly.
+- **Suggested PR cuts:** [W2.1+W2.2+W2.3+W2.4] (one "policy completeness" PR) →
+  [W1 R1–R3] → [W1 R4] (likely several) → [W4] → [W3] (its own track).
+- **Recommended next:** W2 quick wins (fast, closes the policy asymmetries),
+  then W1 (the real interop claim).

--- a/kmip/src/ops/encrypt.rs
+++ b/kmip/src/ops/encrypt.rs
@@ -37,7 +37,7 @@ use super::helpers::{
     state_name,
 };
 
-pub fn encrypt(deps: &Deps, req: EncryptRequest, correlation_id: &str) -> Result<EncryptResponse> {
+pub fn encrypt(deps: &Deps, mut req: EncryptRequest, correlation_id: &str) -> Result<EncryptResponse> {
     let started = OffsetDateTime::now_utc();
     emit_request(
         deps,
@@ -136,7 +136,12 @@ pub fn encrypt(deps: &Deps, req: EncryptRequest, correlation_id: &str) -> Result
             .as_ref()
             .or(obj.cryptographic_parameters.as_ref()),
     );
-    match deps.engine.evaluate(&p_req) {
+    let decision = deps.engine.evaluate(&p_req);
+    // W2.1 — a forcing rule (mechanism_parameter_default) may mandate the mode /
+    // padding; merge it into req.cryptographic_parameters so every downstream
+    // path (classical / ML-KEM / streaming) honors it.
+    let forced_cp = decision.cp_override().cloned();
+    match decision {
         Decision::Allow { .. } => {}
         Decision::Deny { human, .. } => {
             return Err(fail_err(
@@ -159,6 +164,12 @@ pub fn encrypt(deps: &Deps, req: EncryptRequest, correlation_id: &str) -> Result
                 ),
             ));
         }
+    }
+    if let Some(ov) = forced_cp.as_ref() {
+        req.cryptographic_parameters = Some(super::helpers::merge_cp_override(
+            req.cryptographic_parameters.as_ref(),
+            ov,
+        ));
     }
 
     // KMIP 3.0 §6.1.21 multi-part streaming — `Init Indicator` opens a

--- a/kmip/src/ops/helpers.rs
+++ b/kmip/src/ops/helpers.rs
@@ -1196,6 +1196,30 @@ mod tests {
     }
 
     #[test]
+    fn merge_cp_override_applies_forced_fields() {
+        use crate::kmip30::HashingAlgorithm;
+        use crate::policy::CpOverride;
+        // Base mode = CBC (0x01); a forcing rule mandates GCM (0x09).
+        let base = cp(Some(0x01), None, None);
+        let merged = merge_cp_override(
+            Some(&base),
+            &CpOverride { block_cipher_mode: Some(0x09), ..Default::default() },
+        );
+        assert_eq!(merged.block_cipher_mode, Some(0x09));
+        // Force deterministic + hash onto an empty base.
+        let merged2 = merge_cp_override(
+            None,
+            &CpOverride {
+                deterministic: Some(true),
+                hashing_algorithm: Some(0x06), // KMIP SHA-256
+                ..Default::default()
+            },
+        );
+        assert_eq!(merged2.deterministic, Some(true));
+        assert_eq!(merged2.hashing_algorithm, Some(HashingAlgorithm::Sha256));
+    }
+
+    #[test]
     fn mechanism_params_projects_cp_and_resolves_canonical_mech() {
         use crate::kmip30::{HashingAlgorithm, KmipAlgorithm, PkcsOp};
         let c0 = crate::kmip30::CryptographicParameters {

--- a/kmip/src/ops/mac_and_hash.rs
+++ b/kmip/src/ops/mac_and_hash.rs
@@ -189,6 +189,24 @@ pub fn hash(deps: &Deps, req: HashRequest, correlation_id: &str) -> Result<HashR
         ))
     })?;
 
+    // W2.2 — Plane-1 gate for the keyless Hash op: surface the requested
+    // Hashing Algorithm so `hash_algorithm_allowlist` can restrict it (e.g.
+    // deny SHA-1). No managed object, so the request carries no algorithm/key.
+    {
+        let empty: HashMap<String, String> = HashMap::new();
+        let mut p_req = PolicyRequest::minimal(
+            "Hash",
+            None,
+            OffsetDateTime::now_utc(),
+            correlation_id,
+            &empty,
+        );
+        p_req.mechanism.hashing_algorithm = Some(algo as u32);
+        if let Decision::Deny { human, .. } = deps.engine.evaluate(&p_req) {
+            return Err(fail_err(deps, correlation_id, "Hash", KmipError::permission_denied(human)));
+        }
+    }
+
     let bytes = compute_hash(algo, &req.data).map_err(|e| {
         fail_err(deps, correlation_id, "Hash", e)
     })?;

--- a/kmip/src/policy/rule.rs
+++ b/kmip/src/policy/rule.rs
@@ -852,8 +852,10 @@ fn padding_method_name_to_code(name: &str) -> Option<u32> {
 /// the source of truth per CLAUDE.md) — never hardcoded here. Curated to the
 /// mechanisms relevant to policy gating: AES modes, RSA/ECDSA sign variants,
 /// PQC, HMAC/KMAC, KDFs. Unknown → `None` (loader rejects unknown up-front).
-/// NOTE: `CKM_KMAC_*` are in the vendor-defined range in constants.rs; re-verify
-/// against pkcs11t.h if relied upon for a hard gate.
+/// NOTE: `CKM_KMAC_*` use the vendor-defined codepoint (`CKM_VENDOR_DEFINED |
+/// 0x100`). Verified: KMIP/PKCS#11 v3.2 does NOT standardize KMAC (absent from
+/// the canonical OASIS v3.2 `pkcs11t.h`), so vendor-defined is correct, and it
+/// is consistent across `src/lib/pkcs11/pkcs11t.h` + `rust/src/constants.rs`.
 fn ckm_name_to_code(name: &str) -> Option<u32> {
     use softhsmrustv3::constants as c;
     Some(match name {
@@ -881,7 +883,33 @@ fn ckm_name_to_code(name: &str) -> Option<u32> {
         "CKM_SHA512_HMAC" => c::CKM_SHA512_HMAC,
         "CKM_KMAC_128" => c::CKM_KMAC_128,
         "CKM_KMAC_256" => c::CKM_KMAC_256,
+        // W2.3 — broaden toward the full PKCS#11 v3.2 surface the engine
+        // supports. Hashes:
+        "CKM_SHA256" => c::CKM_SHA256,
+        "CKM_SHA384" => c::CKM_SHA384,
+        "CKM_SHA512" => c::CKM_SHA512,
+        "CKM_SHA3_256" => c::CKM_SHA3_256,
+        "CKM_SHA3_512" => c::CKM_SHA3_512,
+        "CKM_SHA3_256_HMAC" => c::CKM_SHA3_256_HMAC,
+        "CKM_SHA3_512_HMAC" => c::CKM_SHA3_512_HMAC,
+        // ECDSA pre-hash SHA-3 variants + EdDSA (pure / pre-hash):
+        "CKM_ECDSA_SHA3_224" => c::CKM_ECDSA_SHA3_224,
+        "CKM_ECDSA_SHA3_256" => c::CKM_ECDSA_SHA3_256,
+        "CKM_ECDSA_SHA3_384" => c::CKM_ECDSA_SHA3_384,
+        "CKM_ECDSA_SHA3_512" => c::CKM_ECDSA_SHA3_512,
+        "CKM_EDDSA" => c::CKM_EDDSA,
+        "CKM_EDDSA_PH" => c::CKM_EDDSA_PH,
+        // ChaCha20 family + AES key-wrap modes:
+        "CKM_CHACHA20" => c::CKM_CHACHA20,
+        "CKM_CHACHA20_POLY1305" => c::CKM_CHACHA20_POLY1305,
+        "CKM_AES_KEY_WRAP" => c::CKM_AES_KEY_WRAP,
+        "CKM_AES_KEY_WRAP_PAD" => c::CKM_AES_KEY_WRAP_PAD,
+        "CKM_AES_KEY_WRAP_KWP" => c::CKM_AES_KEY_WRAP_KWP,
+        // KDFs:
         "CKM_HKDF_DERIVE" => c::CKM_HKDF_DERIVE,
+        "CKM_PKCS5_PBKD2" => c::CKM_PKCS5_PBKD2,
+        "CKM_SP800_108_COUNTER_KDF" => c::CKM_SP800_108_COUNTER_KDF,
+        "CKM_SP800_108_FEEDBACK_KDF" => c::CKM_SP800_108_FEEDBACK_KDF,
         _ => return None,
     })
 }


### PR DESCRIPTION
Executes **W2** of the remaining-gaps plan (also included as a doc), closing the policy-completeness asymmetries left after PR #106.

- **W2.1 — Encrypt mechanism-param forcing.** `ops/encrypt.rs` merges `Decision.cp_override` into `req.cryptographic_parameters` before dispatch, so classical / ML-KEM / streaming all honor a forced mode (policy can mandate AES-GCM). Sign already did this; Encrypt now matches.
- **W2.2 — Hash-op gating.** The keyless `Hash` op now consults the engine (op=`Hash` + requested Hashing Algorithm), so `hash_algorithm_allowlist` can restrict it (e.g. deny SHA-1) — consistent with Sign/Encrypt.
- **W2.3 — CKM map broadened** toward the full PKCS#11 v3.2 surface: SHA-2/3 + HMACs, ECDSA-SHA3, EdDSA(+PH), ChaCha20(+Poly1305), AES key-wrap, KDFs. Values from `constants.rs`.
- **W2.4 — `CKM_KMAC` verified** against the canonical OASIS PKCS#11 v3.2 `pkcs11t.h`: v3.2 doesn't standardize KMAC, so the vendor-defined codepoint is correct + consistent (no code change; comment updated).

Also commits `REMAINING_GAPS_IMPLEMENTATION_PLAN.md` (W1 replay / W2 policy / W3 backend / W4 mgmt).

Regression clean: lib **472/472**, policy suites 9/6/9. Spec-sourced values throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)