### PR TITLE
feat(kmip): pykmip sandbox-dev client + route ML-KEM ops through the policy engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — KMIP PQC interop (full 1452 byte-exact) + crypto-policy completeness + sandbox-dev client (2026-06-14)
+
+Three PRs completing the crypto-agility layer's interop claim and its first
+integration. KMIP suite 472 tests green throughout; OASIS replay held at 92/0/10.
+
+- **Crypto-policy completeness** (`3dc86e1`, PR #107). W2: Encrypt now applies a
+  policy-forced `Decision.cp_override` (mechanism-parameter *forcing*, not just
+  gating); the keyless Hash op is policy-gated (`hash_algorithm_allowlist`); the
+  canonical `CKM_*` map expanded (SHA-2/3 hashes, ECDSA-SHA3, EdDSA, ChaCha20,
+  KWP, KDFs); confirmed `CKM_KMAC_*` is vendor-defined (OASIS v3.2 standardises
+  no codepoint). Closes W2 of `CRYPTO_POLICY_GAPS_IMPLEMENTATION_PLAN.md`.
+- **OASIS KMIP 3.0 PQC interop — 1452/1452 byte-exact through the live server**
+  (`9626e6a`, `46e2f8c`, `c7c907f`, PR #108). W1/I4: the full OASIS PQC interop
+  set (keygen, encapsulate/decapsulate, sign/verify across ML-DSA 44/65/87,
+  ML-KEM 512/768/1024, all 12 SLH-DSA parameter sets) now replays **byte-exact**
+  through the real `pqctoday-kmip` server over TLS. Taught the replay codec the
+  KMIP 3.0 WD19 PQC tags + `SeedPrivateKey` KeyFormatType (`0x18`) +
+  Encapsulate/Decapsulate ops, with per-test port cycling for large local
+  sweeps. Server side: the ML-KEM shared secret is served as
+  `SecretDataType=Seed` in a 2-child KeyBlock, born `PreActive`; keygen serves
+  `Get` of `SeedPrivateKey` (`{Seed, Key}`) + `Raw` via born-extractable seeded
+  keygen (`generate_{ml_dsa,ml_kem,slh_dsa}_keypair_from_seed_extractable`) gated
+  by the KMIP `Extractable` attribute; `Get` resolves the engine handle by
+  PKCS#11 class. New `KMIP PQC Interop Replay` CI job over a vendored
+  42-transcript subset (`kmip/conformance/pqc_corpus/`); the full 1452-case set
+  stays unvendored (`KMIP_REPLAY_CORPUS=<dir>`).
+- **pykmip sandbox-dev client + ML-KEM ops through the policy engine** (PR #109).
+  First sandbox-dev integration: a Python KMIP client (`kmip/pykmip/`) that
+  drives the agile server and a correlator that renders the `--audit-log` as
+  per-request three-plane trails (p1 policy / p2 KMIP / p3 PKCS#11). Building it
+  surfaced + fixed two findings in the WD19 ML-KEM ops: Encapsulate/Decapsulate
+  now resolve the engine handle by PKCS#11 class (a `CreateKeyPair` pair shares
+  one CKA_ID → the bare lookup hit the wrong half →
+  `CKR_KEY_FUNCTION_NOT_PERMITTED`), and they now route through the Plane-1
+  policy engine (emit a p1 decision + enforce allow/deny) instead of bypassing
+  it — closing a crypto-agility blind spot for KEM operations.
+
 ### Added — KMIP 3.0 coverage Phase 2: implementable spec-surface gaps (2026-06-13)
 
 Closes the implementable spec-surface gaps from `kmip/docs/COVERAGE_GAP_PLAN.md`,

--- a/kmip/.gitignore
+++ b/kmip/.gitignore
@@ -1,0 +1,6 @@
+
+# Server runtime: active-policy marker written by --policy/activate
+policies/.active
+# Python bytecode (pykmip)
+__pycache__/
+*.pyc

--- a/kmip/docs/CRYPTO_AGILITY_CONFIGURATION.md
+++ b/kmip/docs/CRYPTO_AGILITY_CONFIGURATION.md
@@ -1,0 +1,206 @@
+# Crypto-Agility Configuration Guide — pqctoday-kmip
+
+How to configure, apply, and observe the crypto-agility layer of the
+`pqctoday-kmip` server. This is the consolidated operator/integrator guide;
+the deeper design rationale lives in
+[THREE_PLANE_ARCHITECTURE.md](THREE_PLANE_ARCHITECTURE.md), the policy YAML
+library in [../policies/README.md](../policies/README.md), and the client/
+observability tooling in [../pykmip/README.md](../pykmip/README.md).
+
+---
+
+## 1. What it is
+
+The server has three planes:
+
+| Plane | Role | Surface |
+|-------|------|---------|
+| **Plane 1 — Crypto Agility** | Decides *whether* an operation is allowed and *which* algorithm / mechanism parameters it must use, from the **active policy**. | YAML policy files (this guide) |
+| **Plane 2 — KMIP 3.0** | The protocol applications speak. Unchanged by policy. | KMIP over TLS (`--listen`) |
+| **Plane 3 — PKCS#11** | The `softhsmrustv3` engine that does the crypto. | in-process bridge |
+
+**Enforcement is the KMIP protocol itself** — there is no separate
+enforcement API. Every Encrypt / Sign / CreateKeyPair / Encapsulate /
+Decapsulate / Hash / MAC request is evaluated against the active policy
+*before* it reaches the engine. The application's code never changes; flip
+the active policy and the same requests are allowed, denied, or transparently
+re-keyed.
+
+**Management is out-of-band** (separation of duties): a KMIP client cannot
+read or change the policy that governs it. Policies are authored as files and
+selected when the server starts (see §3). There is intentionally **no KMIP
+operation** to read/write/update a policy.
+
+---
+
+## 2. How an application talks to it
+
+Applications issue ordinary KMIP 3.0 requests over TLS. They do **not** name a
+policy, a rule, or an algorithm-override — the agility layer supplies those.
+A typical agile pattern is to omit the algorithm entirely:
+
+```
+CreateKeyPair { CommonAttributes: { CryptographicUsageMask: Sign|Verify } }
+```
+
+Under a classical policy this resolves to ECDSA; flip to a PQC policy and the
+identical call returns an ML-DSA key (`algorithm_default` rule, §4). For
+driving the server + reading back the decision trail from Python, see
+[`pykmip`](../pykmip/README.md).
+
+---
+
+## 3. Configuring & applying a policy
+
+A policy is one YAML file. Library of ready-made ones:
+[`../policies/`](../policies/) (`training-permissive`, `classical`, `pqc`,
+`fips-only`, `cnsa-2.0`, `aead-only`, `fips-hashing`,
+`deterministic-signing`, `pqc-migration-2030`, `hybrid-migration-window`).
+
+### File shape
+
+```yaml
+schema_version: 1
+metadata:
+  name: my-policy
+  description: |
+    Human-readable intent.
+  authority: my-org
+  effective: always                 # or a time window
+  compliance_mapping:               # optional, informational
+    - { framework: "FIPS 140-3", status: aligned }
+rules:
+  - type: <rule_type>               # see §4
+    # … rule-specific fields …
+```
+
+An **empty `rules: []` allows everything** at Plane 1 (that is what
+`training-permissive` is). Rules then *gate* (deny), *force* (rewrite a
+parameter), or *migrate* (substitute / rekey). Rule order matters: Pass-1
+algorithm resolution is **last-match-wins**; Pass-2 gates all apply.
+
+> **Fail-safe default:** if the server has *no* active policy at all, every
+> request is **denied**. A loaded policy with no rules allows everything; the
+> two are different states.
+
+### Apply it
+
+```bash
+pqctoday-kmip \
+  --listen 127.0.0.1:5696 --store-memory \
+  --policy-dir policies \        # directory of *.yaml policies
+  --policy aead-only \           # which one to activate at boot
+  --audit-log /tmp/agility.jsonl # three-plane decision log (see §6)
+```
+
+- `--policy-dir` — the policy library directory.
+- `--policy <name>` — activate `<name>.yaml` at boot and write the
+  `.active` marker.
+- Omit `--policy` and the server resumes the `.active` marker if present,
+  else loads the built-in permissive fallback (with a warning).
+- The `PolicyStore` Rust API (`list / load / validate_draft / dry_run / save /
+  activate_with_engine / resume_active`) backs all of this; there is no network
+  management surface (a server-side HTTP admin facade is a separate, parked
+  decision).
+
+**Changing the active policy today requires a (re)launch** — there is no live
+hot-swap over the wire.
+
+---
+
+## 4. Rule-type reference
+
+Every rule is `{ type: <snake_case>, … }`. The authoritative source is the
+`Rule` enum in [`../src/policy/rule.rs`](../src/policy/rule.rs); names below are
+the exact YAML `type:` values.
+
+### Algorithm selection (Pass-1, last-match-wins)
+| `type` | Effect |
+|--------|--------|
+| `algorithm_default` | When the request omits the algorithm and `op ∈ ops`, supply `default_algorithm`. The agility backbone — same app call, policy picks the algorithm. |
+| `algorithm_substitution` | When the request asks for `from` and `op ∈ ops`, rewrite to `to`. Hard-cutover migration; if the stored key differs, the engine emits **RekeyAndProceed**. |
+
+### Algorithm gating (Pass-2, deny)
+| `type` | Denies when |
+|--------|-------------|
+| `algorithm_allowlist` | `op ∈ ops` and `algorithm ∉ algorithms` |
+| `algorithm_denylist` | `op ∈ ops` and `algorithm ∈ algorithms` (optional `unless` custom-attribute escape hatch) |
+| `min_key_length` | `algorithm` matches and `key_length < min_bits` |
+| `require_usage_mask` | creating `algorithm` without all `flags` set |
+| `require_custom_attribute` | creating any of `algorithms` without `x-<attribute_name>` set |
+| `lifecycle_state_gate` | `op == op` and object `state ∉ allowed_states` |
+
+### Mechanism-level gating & forcing (the "how", not just "which")
+| `type` | Effect |
+|--------|--------|
+| `hash_algorithm_allowlist` | gate the `Hashing Algorithm` (KMIP enum names, e.g. `SHA-256`, `SHA3-256`) for the listed ops; deny others. |
+| `mechanism_parameter_constraint` | gate `Block Cipher Mode` / `Padding Method` (e.g. AES → `[GCM, CCM]`, RSA → `[OAEP]`). Governs *how* a cipher is used. |
+| `mechanism_parameter_default` | **force** a hash / mode / padding / deterministic flag when the request leaves it unset (`Decision.cp_override`). |
+| `mac_mechanism_policy` | gate the MAC mechanism family. |
+| `mechanism_allowlist` / `mechanism_denylist` | gate on the canonical **`CKM_*`** mechanism codepoint — the full PKCS#11 v3.2 surface (incl. vendor `CKM_KMAC_*`), bypass-proof by construction. |
+
+### Migration & temporal
+| `type` | Effect |
+|--------|--------|
+| `temporal_cutoff` | after `after`, deny `op` for an `algorithm_class` (`classical`/`pqc`) — optionally narrowed to `algorithms`. |
+| `max_key_age_days` | deny `op` when the key is older than `days`. *(Stub: needs object-store timestamps; logs a warning, never fires today.)* |
+| `hybrid_dual_sign_requirement` | during `effective`, require a composite `primary + secondary` algorithm. |
+| `compliance_profile_gate` | informational profile marker (`FIPS-140-3` / `CNSA-2.0` / …); actual enforcement is composed from the allow/deny rules above. |
+
+---
+
+## 5. Decision outcomes
+
+`engine.evaluate(request)` returns one of:
+
+- **Allow** — proceed (optionally with a forced `cp_override` merged into the
+  effective Cryptographic Parameters).
+- **Deny** — the op fails with KMIP `PermissionDenied` and the rule's reason;
+  **no engine call happens**.
+- **RekeyAndProceed** — policy substituted the algorithm and the stored key
+  doesn't match; surfaced as a typed rekey-required error (the inline op
+  handlers do not execute the multi-op rekey transaction).
+
+**Operations routed through Plane 1:** Create, CreateKeyPair, Encrypt, Decrypt,
+Sign, SignatureVerify, Hash, MAC, **Encapsulate, Decapsulate**, Derive, and the
+lifecycle/attribute ops. (Encapsulate/Decapsulate were brought under the policy
+plane in the 2026-06-14 work — previously a KEM blind spot.)
+
+---
+
+## 6. Observing enforcement
+
+Run the server with `--audit-log <path>`. Every event carries a `plane`
+(`p1`/`p2`/`p3`) and a `correlation_id` shared across all three planes for one
+request:
+
+```
+p1 — PolicyDecided   { op, algorithm, outcome: Allow|Deny|Rekey }
+p2 — KmipResponseSent{ op, result: Success|OperationFailed }
+p3 — Pkcs11Call      { function, mechanism: CKM_*, rv_name }
+```
+
+[`pykmip.audit`](../pykmip/audit.py) groups the log into per-request trails.
+A **denied** request shows a p1 Deny and **no** p3 call — visible proof the
+agility layer stopped it before the engine.
+
+### Worked example — `aead-only`
+
+```
+ALLOW  Encrypt   p1: Allow             p2: Success          p3: native::encrypt [AES-GCM]
+DENY   Encrypt   p1: Deny "AES must    p2: OperationFailed  p3: (no engine call)
+                    use GCM or CCM"
+```
+
+Identical client code; the policy alone decides. Swap `--policy aead-only` for
+`--policy training-permissive` and both Encrypts are allowed. That is the
+agility story end-to-end. See [`pykmip/demo.py`](../pykmip/demo.py).
+
+---
+
+## 7. See also
+
+- [THREE_PLANE_ARCHITECTURE.md](THREE_PLANE_ARCHITECTURE.md) — design rationale.
+- [../policies/README.md](../policies/README.md) — the policy library.
+- [CRYPTO_POLICY_STATUS.md](CRYPTO_POLICY_STATUS.md) — capabilities & limits.
+- [../pykmip/README.md](../pykmip/README.md) — drive it + read the trail.

--- a/kmip/docs/CRYPTO_POLICY_STATUS.md
+++ b/kmip/docs/CRYPTO_POLICY_STATUS.md
@@ -18,6 +18,19 @@
 > a v0.1 stub — Phase 7). The §3 gap list below is retained as the historical
 > assessment that motivated the work.
 
+> **UPDATE 2026-06-14 (post-W2 / PR #107 + #109).** Two items above advanced:
+> - **Encrypt mechanism-param *forcing*** is now implemented (W2.1, PR #107):
+>   Encrypt applies `Decision.cp_override`, so a policy can *force* the block
+>   cipher mode / padding, not only gate it. The "remaining/deferred" note above
+>   is superseded.
+> - **KEM was not actually policy-gated until PR #109.** Encapsulate/Decapsulate
+>   previously bypassed `engine.evaluate()` entirely (no p1 decision) — the
+>   "KEM ✅" above was aspirational. They are now routed through the Plane-1
+>   engine (emit a p1 `PolicyDecided`, enforce allow/deny) **and** resolve the
+>   engine handle by PKCS#11 class, so **KEM ✅ is now literally true**.
+>
+> Operator guide: [CRYPTO_AGILITY_CONFIGURATION.md](CRYPTO_AGILITY_CONFIGURATION.md).
+
 ## Goal (target state)
 
 > Enable crypto-agility through **crypto-policy definitions**, such that

--- a/kmip/docs/REMAINING_GAPS_IMPLEMENTATION_PLAN.md
+++ b/kmip/docs/REMAINING_GAPS_IMPLEMENTATION_PLAN.md
@@ -14,6 +14,23 @@ mostly quick) > **W4** (operability) > **W3** (alternate backend, large/optional
 
 ---
 
+## Status — updated 2026-06-14
+
+| Track | State | Where |
+| --- | --- | --- |
+| **W1 — full 1452 transcript replay** | ✅ **DONE** | PR #108. All 1452 OASIS PQC interop transcripts replay **byte-exact** through the live `pqctoday-kmip` TLS server (keygen `SeedPrivateKey`+`Raw` export, ML-KEM encap/decap, ML-DSA/SLH-DSA sign/verify). New `KMIP PQC Interop Replay` CI gate over a vendored 42-transcript subset (`conformance/pqc_corpus/`); full set via `KMIP_REPLAY_CORPUS`. |
+| **W2 — crypto-policy completeness** | ✅ **DONE** | PR #107. Encrypt mechanism-param forcing (`cp_override`), Hash-op gating, `CKM_*` map expansion, `CKM_KMAC_*` vendor-defined confirmed. |
+| **W4 — operability** | ↪️ **REDIRECTED + partially done** | Re-scoped from a wasm/HTTP policy-mgmt facade to a **sandbox-dev integration**: `pykmip` Python KMIP client + audit-log three-plane correlator + demo (PR #109, *observe-only*). A **live HTTP admin facade** (read/write/activate policies over the network) remains **parked** — separate, security-sensitive decision. WASM was dropped (the sandbox runs the server natively). |
+| **KEM policy blind spot** | ✅ **CLOSED** | PR #109. Encapsulate/Decapsulate now resolve the engine handle by PKCS#11 class (`find_handle_for_object`) and route through the Plane-1 policy engine (p1 decision + allow/deny). |
+| **W3 — alternate C++/OpenSSL backend** | ⏸️ **PARKED** | Large/optional; start only if a second backend becomes a product requirement. |
+
+The per-track detail below is the original plan; W1/W2 are retained as the
+historical record of what was built. See
+[CRYPTO_AGILITY_CONFIGURATION.md](CRYPTO_AGILITY_CONFIGURATION.md) for the
+current operator guide.
+
+---
+
 ## W1 — Full KMIP transcript replay of the 1452 set  *(highest value, largest)*
 
 **Goal:** drive the 1452 OASIS transcripts as live KMIP request/response

--- a/kmip/pykmip/README.md
+++ b/kmip/pykmip/README.md
@@ -1,0 +1,86 @@
+# pykmip — sandbox-dev integration client for the agile KMIP server
+
+A small Python toolkit to **drive** the `pqctoday-kmip` server with real
+crypto operations and **observe** how the crypto-agility layer governs them,
+by reading the server's three-plane audit log.
+
+It is the "format the KMIP calls + check the KMIP/PKCS#11 logs" layer for the
+first sandbox-dev integration. It targets an **already-running** server and
+is **policy-agnostic**: it issues operations and reports the results; *which*
+policy is in force is configured on the server and observed in the audit log,
+never managed from here (separation of duties).
+
+## Pieces
+
+| Module | What |
+|--------|------|
+| `pykmip.client.KmipClient` | Build + send KMIP calls over TLS (Create, CreateKeyPair, Encrypt, Sign, Encapsulate, Decapsulate, Get, Activate, Destroy). PQC-aware. Reuses the conformance harness's TTLV codec (knows the KMIP 3.0 WD19 PQC tags). |
+| `pykmip.audit` | Correlate the server's `--audit-log` JSONL by `correlation_id` into per-request **p1 policy / p2 KMIP / p3 PKCS#11** trails. |
+| `pykmip.demo` | Runs a PQC happy-path + an Encrypt allow-vs-deny contrast, then prints the correlated trail. |
+
+## 1. Start the server (with audit log + a policy)
+
+```bash
+cd kmip
+cargo build --release --bin pqctoday-kmip
+./target/release/pqctoday-kmip \
+    --listen 127.0.0.1:5696 --store-memory \
+    --policy-dir policies --policy aead-only \
+    --audit-log /tmp/agility-audit.jsonl
+```
+
+`--policy aead-only` makes the contrast visible: AES Encrypt must use an
+authenticated mode. Swap in any policy from [`../policies/`](../policies/)
+(`training-permissive`, `fips-hashing`, `pqc`, …) and re-run — the **same**
+client code produces different p1 decisions. That is the agility story.
+
+## 2. Drive it + read the trail
+
+```bash
+cd kmip
+python3 -m pykmip.demo --audit-log /tmp/agility-audit.jsonl
+```
+
+Example output (under `aead-only`):
+
+```
+ALLOW  Sign            p1 policy : Allow
+                       p2 kmip   : Success
+                       p3 pkcs11 : native::sign [CKM_0x001D]
+
+ALLOW  Encrypt         p1 policy : Allow
+                       p2 kmip   : Success
+                       p3 pkcs11 : native::encrypt [CKM_0x1087]      ← AES-GCM ran
+
+DENY   Encrypt         p1 policy : Deny  AES must use an authenticated mode (GCM or CCM)
+                       p2 kmip   : OperationFailed: PermissionDenied
+                       p3 pkcs11 : (no engine call)                  ← AES-CBC stopped before the engine
+```
+
+The **absence** of a p3 line on the DENY proves the policy stopped the
+request at Plane 1, before any key material was touched.
+
+## 3. Use the client directly
+
+```python
+from pykmip import KmipClient, audit
+
+c = KmipClient("127.0.0.1", 5696)
+kp = c.create_key_pair("ML_DSA_44", "Sign Verify")
+priv = kp.get("PrivateKeyUniqueIdentifier")
+c.activate(priv)
+sig = c.sign(priv, b"hello", "ML_DSA_44")
+print(sig.ok, sig.get("SignatureData"))
+
+# inspect the three-plane trail the server logged
+print(audit.format_log("/tmp/agility-audit.jsonl"))
+```
+
+## Notes / known findings
+
+- The client accepts the server's self-signed TLS cert without verification
+  (`insecure=True`) — sandbox dev posture. Pass real CA trust for production.
+- This integration surfaced two server-side findings in the WD19 ML-KEM ops
+  (Encapsulate/Decapsulate): handle resolution is not PKCS#11-class-aware
+  (breaks on `CreateKeyPair`-generated keys that share a CKA_ID), and the ops
+  are not yet routed through the Plane-1 policy engine. Tracked separately.

--- a/kmip/pykmip/__init__.py
+++ b/kmip/pykmip/__init__.py
@@ -1,0 +1,17 @@
+"""pykmip — a small Python KMIP 3.0 client for the agile pqctoday-kmip server.
+
+Sandbox-dev integration toolkit:
+
+  * `KmipClient` — format + send KMIP calls (Create / CreateKeyPair / Encrypt /
+    Sign / Encapsulate / Decapsulate / Get / Activate / Destroy), PQC-aware.
+  * `pykmip.audit` — correlate the server's `--audit-log` JSONL into per-request
+    three-plane trails (p1 policy / p2 KMIP / p3 PKCS#11).
+
+The client is policy-agnostic: it drives operations; *which* crypto policy is
+in force is configured on the server (`--policy <name>`) and observed in the
+audit log, never managed from here (separation of duties).
+"""
+from .client import KmipClient, KmipResult, RESULT_SUCCESS, RESULT_OP_FAILED
+from . import audit
+
+__all__ = ["KmipClient", "KmipResult", "RESULT_SUCCESS", "RESULT_OP_FAILED", "audit"]

--- a/kmip/pykmip/audit.py
+++ b/kmip/pykmip/audit.py
@@ -1,0 +1,149 @@
+"""Correlate the agile KMIP server's audit log into per-request trails.
+
+The server (run with `--audit-log <path>`) appends one JSON object per
+line, each tagged with a `plane` and a `correlation_id` that is shared by
+every event for one inbound request:
+
+    p1 — Crypto-Agility engine  (PolicyDecided: allow / deny / rekey)
+    p2 — KMIP dispatcher        (KmipResponseSent: op + result)
+    p3 — PKCS#11 bridge         (Pkcs11Call: C_Sign / C_EncapsulateKey / …)
+
+Grouping by `correlation_id` reconstructs, for each request, the full
+three-plane story: what the policy decided, what KMIP did, and which
+PKCS#11 engine calls (if any) actually ran. A *denied* request shows a p1
+Deny and **no** p3 call — visible proof the agility layer stopped it before
+the engine.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Optional
+
+PLANE_LABEL = {"p1": "policy", "p2": "kmip", "p3": "pkcs11"}
+
+
+@dataclass
+class RequestTrail:
+    correlation_id: str
+    op: Optional[str] = None
+    decision: Optional[str] = None  # "Allow" | "Deny" | "Rekey"
+    decision_detail: str = ""
+    kmip_result: Optional[str] = None  # "Success" | "OperationFailed: …"
+    pkcs11_calls: list = field(default_factory=list)  # (function, mechanism, rv_name)
+    policy_loaded: Optional[str] = None  # set for a PolicyActivated (startup) event
+    events: list = field(default_factory=list)  # raw events in arrival order
+
+    @property
+    def is_request(self) -> bool:
+        """True for a real KMIP request (has an op / decision / engine call);
+        False for envelope events like the startup PolicyActivated."""
+        return bool(self.op or self.decision or self.pkcs11_calls)
+
+
+def load_events(path: str) -> list[dict]:
+    """Read a JSONL audit log into a list of event dicts (order preserved)."""
+    events = []
+    with open(path, "r") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
+    return events
+
+
+def group(events: list[dict]) -> list[RequestTrail]:
+    """Group events by correlation_id into ordered RequestTrails (first-seen
+    correlation order). Each trail summarises the p1/p2/p3 story."""
+    trails: dict[str, RequestTrail] = {}
+    order: list[str] = []
+    for ev in events:
+        cid = ev.get("correlation_id", "?")
+        if cid not in trails:
+            trails[cid] = RequestTrail(correlation_id=cid)
+            order.append(cid)
+        t = trails[cid]
+        t.events.append(ev)
+        payload = ev.get("event", {})
+        etype = payload.get("type")
+        if etype == "PolicyActivated":
+            t.policy_loaded = payload.get("policy_name")
+        elif etype == "PolicyDecided":
+            t.op = t.op or payload.get("op")
+            outcome = payload.get("outcome", {})
+            t.decision = outcome.get("type")
+            if t.decision == "Deny":
+                t.decision_detail = outcome.get("reason", "")
+            elif t.decision == "Rekey":
+                t.decision_detail = f"-> {outcome.get('new_algorithm', '?')}"
+            elif t.decision == "Allow" and outcome.get("algorithm_override"):
+                t.decision_detail = f"override -> {outcome['algorithm_override']}"
+        elif etype == "KmipResponseSent":
+            t.op = payload.get("op", t.op)
+            res = payload.get("result", {})
+            if res.get("type") == "Success":
+                t.kmip_result = "Success"
+            else:
+                t.kmip_result = f"OperationFailed: {res.get('reason', '')}"
+        elif etype == "KmipRequestReceived":
+            t.op = t.op or payload.get("op")
+        elif etype == "Pkcs11Call":
+            t.pkcs11_calls.append(
+                (payload.get("function"), payload.get("mechanism"), payload.get("rv_name"))
+            )
+    return [trails[c] for c in order]
+
+
+def format_trail(t: RequestTrail, *, color: bool = True) -> str:
+    """One human-readable block for a single request trail."""
+    def c(code: str, s: str) -> str:
+        return f"\033[{code}m{s}\033[0m" if color else s
+
+    if t.decision == "Allow":
+        mark = c("32", "ALLOW")
+    elif t.decision == "Deny":
+        mark = c("31", "DENY")
+    elif t.decision == "Rekey":
+        mark = c("33", "REKEY")
+    else:
+        mark = c("90", "?")
+
+    lines = [f"{mark}  {t.op or '?'}  ({t.correlation_id[:8]})"]
+    detail = t.decision_detail
+    lines.append(f"    p1 policy : {t.decision or '—'}" + (f"  {detail}" if detail else ""))
+    lines.append(f"    p2 kmip   : {t.kmip_result or '—'}")
+    if t.pkcs11_calls:
+        for fn, mech, rv in t.pkcs11_calls:
+            mech_s = f" [{mech}]" if mech else ""
+            rv_s = "" if rv in (None, "CKR_OK") else c("31", f" {rv}")
+            lines.append(f"    p3 pkcs11 : {fn}{mech_s}{rv_s}")
+    else:
+        none = c("90", "(no engine call)")
+        lines.append(f"    p3 pkcs11 : {none}")
+    return "\n".join(lines)
+
+
+def format_log(path: str, *, color: bool = True) -> str:
+    """Load, group, and format an entire audit log as correlated trails.
+
+    Startup `PolicyActivated` envelope events render as a one-line banner;
+    every real KMIP request renders as a three-plane block."""
+    def c(code: str, s: str) -> str:
+        return f"\033[{code}m{s}\033[0m" if color else s
+
+    blocks = []
+    for t in group(load_events(path)):
+        if t.policy_loaded and not t.is_request:
+            blocks.append(c("36", f"● policy active: {t.policy_loaded}"))
+        elif t.is_request:
+            blocks.append(format_trail(t, color=color))
+    return "\n\n".join(blocks)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        print("usage: python -m pykmip.audit <audit-log.jsonl>", file=sys.stderr)
+        raise SystemExit(2)
+    print(format_log(sys.argv[1]))

--- a/kmip/pykmip/client.py
+++ b/kmip/pykmip/client.py
@@ -1,0 +1,224 @@
+"""A small KMIP 3.0 client for driving the agile `pqctoday-kmip` server.
+
+Builds TTLV `RequestMessage`s, sends one per TLS connection (the server
+speaks one request/response per connection per KMIP 3.0 §6), and decodes
+the response. PQC-aware: ML-DSA / SLH-DSA sign, ML-KEM encapsulate /
+decapsulate, plus the classical Create / Encrypt / Sign path.
+
+This is the "format the KMIP calls" layer for the sandbox-dev integration.
+It is policy-agnostic: it issues operations and reports what came back; the
+agile layer's allow / deny / rekey decision is observed out-of-band in the
+server's audit log (see `pykmip.audit`), not here.
+
+Targets an already-running server (host/port). Self-signed TLS is accepted
+without verification by default (`insecure=True`) — sandbox dev posture.
+"""
+from __future__ import annotations
+
+import socket
+import ssl
+from dataclasses import dataclass, field
+from typing import Optional
+
+from . import codec
+from .codec import find, find_all, leaf, struct
+
+# ── KMIP ResultStatus enum (decoded as integers by the codec) ───────────────
+RESULT_SUCCESS = 0
+RESULT_OP_FAILED = 1
+RESULT_OP_PENDING = 2
+RESULT_OP_UNDONE = 3
+
+
+def _proto() -> codec.TtlvNode:
+    return struct(
+        "ProtocolVersion",
+        leaf("ProtocolVersionMajor", "Integer", 3),
+        leaf("ProtocolVersionMinor", "Integer", 0),
+    )
+
+
+@dataclass
+class KmipResult:
+    """Decoded outcome of one KMIP batch item."""
+
+    operation: str
+    status: int
+    reason: Optional[int] = None
+    message: Optional[str] = None
+    payload: Optional[codec.TtlvNode] = None
+    raw: Optional[codec.TtlvNode] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status == RESULT_SUCCESS
+
+    def get(self, tag: str):
+        """First value under the ResponsePayload matching `tag` (or None)."""
+        if self.payload is None:
+            return None
+        n = find(self.payload, tag)
+        return n.value if n is not None else None
+
+    def __str__(self) -> str:
+        if self.ok:
+            return f"{self.operation}: SUCCESS"
+        extra = self.message or (f"reason={self.reason}" if self.reason is not None else "")
+        return f"{self.operation}: FAILED ({extra})"
+
+
+class KmipClient:
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 5696,
+        *,
+        timeout: float = 5.0,
+        insecure: bool = True,
+    ):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self._ctx = ssl.create_default_context()
+        if insecure:
+            self._ctx.check_hostname = False
+            self._ctx.verify_mode = ssl.CERT_NONE
+
+    # ── transport ───────────────────────────────────────────────────────────
+    def _send(self, request: codec.TtlvNode) -> codec.TtlvNode:
+        req_bytes = codec.encode_node(request)
+        raw = socket.create_connection((self.host, self.port), timeout=self.timeout)
+        sock = self._ctx.wrap_socket(raw, server_hostname=self.host)
+        try:
+            sock.sendall(req_bytes)
+            sock.settimeout(self.timeout)
+            chunks: list[bytes] = []
+            while True:
+                chunk = sock.recv(65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+        finally:
+            sock.close()
+        resp_bytes = b"".join(chunks)
+        if not resp_bytes:
+            raise ConnectionError("server returned 0 bytes (request rejected at TLS/parse layer)")
+        node, _ = codec.decode_one(resp_bytes)
+        return node
+
+    def request(self, operation: str, *payload: codec.TtlvNode) -> KmipResult:
+        """Send a single-batch-item request for `operation` and decode it."""
+        msg = struct(
+            "RequestMessage",
+            struct("RequestHeader", _proto()),
+            struct(
+                "BatchItem",
+                leaf("Operation", "Enumeration", operation),
+                struct("RequestPayload", *payload),
+            ),
+        )
+        resp = self._send(msg)
+        batch = find(resp, "BatchItem")
+        status_node = find(batch, "ResultStatus") if batch else None
+        reason_node = find(batch, "ResultReason") if batch else None
+        msg_node = find(batch, "ResultMessage") if batch else None
+        payload_node = find(batch, "ResponsePayload") if batch else None
+        status = int(status_node.value) if status_node and status_node.value is not None else -1
+        return KmipResult(
+            operation=operation,
+            status=status,
+            reason=int(reason_node.value) if reason_node and reason_node.value is not None else None,
+            message=str(msg_node.value) if msg_node and msg_node.value is not None else None,
+            payload=payload_node,
+            raw=resp,
+        )
+
+    # ── operations ────────────────────────────────────────────────────────────
+    def create_symmetric(
+        self,
+        algorithm: str = "AES",
+        length: int = 256,
+        name: Optional[str] = None,
+        usage: str = "Encrypt Decrypt",
+    ) -> KmipResult:
+        attrs = [
+            leaf("CryptographicAlgorithm", "Enumeration", algorithm),
+            leaf("CryptographicLength", "Integer", length),
+            leaf("CryptographicUsageMask", "Integer", usage),
+        ]
+        if name:
+            attrs.append(leaf("Name", "TextString", name))
+        return self.request(
+            "Create",
+            leaf("ObjectType", "Enumeration", "SymmetricKey"),
+            struct("Attributes", *attrs),
+        )
+
+    def create_key_pair(self, algorithm: str, usage: str) -> KmipResult:
+        """ML-DSA / ML-KEM / SLH-DSA / RSA / ECDSA keypair. `usage` is a
+        space-separated CryptographicUsageMask (e.g. "Sign Verify" or
+        "KeyAgreement"). Returns priv/pub UIDs via .get("PrivateKeyUniqueIdentifier")."""
+        return self.request(
+            "CreateKeyPair",
+            struct(
+                "CommonAttributes",
+                leaf("CryptographicAlgorithm", "Enumeration", algorithm),
+                leaf("CryptographicUsageMask", "Integer", usage),
+            ),
+        )
+
+    def activate(self, uid: str) -> KmipResult:
+        return self.request("Activate", leaf("UniqueIdentifier", "TextString", uid))
+
+    def get(self, uid: str, key_format_type: Optional[str] = None) -> KmipResult:
+        payload = [leaf("UniqueIdentifier", "TextString", uid)]
+        if key_format_type:
+            payload.append(leaf("KeyFormatType", "Enumeration", key_format_type))
+        return self.request("Get", *payload)
+
+    def encrypt(
+        self,
+        uid: str,
+        data: bytes,
+        *,
+        block_cipher_mode: Optional[str] = None,
+        iv: Optional[bytes] = None,
+    ) -> KmipResult:
+        cp_children = []
+        if block_cipher_mode:
+            cp_children.append(leaf("BlockCipherMode", "Enumeration", block_cipher_mode))
+        payload = [
+            leaf("UniqueIdentifier", "TextString", uid),
+            struct("CryptographicParameters", *cp_children),
+            leaf("Data", "ByteString", data.hex()),
+        ]
+        if iv is not None:
+            payload.append(leaf("IVCounterNonce", "ByteString", iv.hex()))
+        return self.request("Encrypt", *payload)
+
+    def sign(self, uid: str, data: bytes, algorithm: str) -> KmipResult:
+        return self.request(
+            "Sign",
+            leaf("UniqueIdentifier", "TextString", uid),
+            struct(
+                "CryptographicParameters",
+                leaf("CryptographicAlgorithm", "Enumeration", algorithm),
+            ),
+            leaf("Data", "ByteString", data.hex()),
+        )
+
+    def encapsulate(self, uid: str) -> KmipResult:
+        """ML-KEM encapsulate against a public key UID. Returns the shared-secret
+        object UID (.get("UniqueIdentifier")) and ciphertext (.get("Data"))."""
+        return self.request("Encapsulate", leaf("UniqueIdentifier", "TextString", uid))
+
+    def decapsulate(self, uid: str, ciphertext: bytes) -> KmipResult:
+        """ML-KEM decapsulate `ciphertext` against a private key UID."""
+        return self.request(
+            "Decapsulate",
+            leaf("UniqueIdentifier", "TextString", uid),
+            leaf("Data", "ByteString", ciphertext.hex()),
+        )
+
+    def destroy(self, uid: str) -> KmipResult:
+        return self.request("Destroy", leaf("UniqueIdentifier", "TextString", uid))

--- a/kmip/pykmip/codec.py
+++ b/kmip/pykmip/codec.py
@@ -1,0 +1,74 @@
+"""TTLV codec shim.
+
+`pykmip` reuses the single canonical TTLV codec that lives with the
+conformance harness (`conformance/harness/oasis_codec.py`) rather than
+carrying a second copy — that codec already knows every KMIP 3.0 tag/enum
+codepoint *and* the KMIP 3.0 WD19 PQC extensions (ML-KEM Encapsulate /
+Decapsulate, SeedPrivateKey, the PQC `CryptographicParameters` fields).
+
+Importing it requires putting the harness directory on `sys.path`; we do
+that here once so the rest of `pykmip` can just `from . import codec`.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+_HARNESS = pathlib.Path(__file__).resolve().parent.parent / "conformance" / "harness"
+if str(_HARNESS) not in sys.path:
+    sys.path.insert(0, str(_HARNESS))
+
+import oasis_codec as _oc  # noqa: E402  (path injected above)
+
+TtlvNode = _oc.TtlvNode
+encode_node = _oc.encode_node
+decode_one = _oc.decode_one
+table = _oc.table
+EncodeError = _oc.EncodeError
+DecodeError = _oc.DecodeError
+
+
+def norm(name: str) -> str:
+    """Alphanumerics-only tag-name normaliser (matches the codec)."""
+    return "".join(c for c in name if c.isalnum())
+
+
+def struct(tag: str, *children: TtlvNode) -> TtlvNode:
+    """Build a TTLV Structure node."""
+    return TtlvNode(tag_name=tag, ttlv_type="Structure", children=list(children))
+
+
+def leaf(tag: str, ttlv_type: str, value) -> TtlvNode:
+    """Build a TTLV leaf node (Integer / Enumeration / ByteString / …)."""
+    return TtlvNode(tag_name=tag, ttlv_type=ttlv_type, value=value)
+
+
+def find(node: TtlvNode, tag: str):
+    """Breadth-first search for the first descendant whose (normalised) tag
+    matches `tag`. Returns the node or None. Tolerant of the decoder's
+    space-separated tag names ("Result Status" ~ "ResultStatus")."""
+    from collections import deque
+
+    want = norm(tag)
+    dq = deque([node])
+    while dq:
+        n = dq.popleft()
+        if norm(n.tag_name) == want:
+            return n
+        dq.extend(n.children)
+    return None
+
+
+def find_all(node: TtlvNode, tag: str) -> list:
+    """All descendants whose (normalised) tag matches `tag`, in BFS order."""
+    from collections import deque
+
+    want = norm(tag)
+    out = []
+    dq = deque([node])
+    while dq:
+        n = dq.popleft()
+        if norm(n.tag_name) == want:
+            out.append(n)
+        dq.extend(n.children)
+    return out

--- a/kmip/pykmip/demo.py
+++ b/kmip/pykmip/demo.py
@@ -1,0 +1,112 @@
+"""Sandbox-dev integration demo for the agile pqctoday-kmip server.
+
+Drives a fixed sequence of KMIP operations against a RUNNING server, then
+reads the server's audit log and prints the correlated three-plane trail
+(p1 policy / p2 KMIP / p3 PKCS#11) for every request.
+
+Two halves, exercised by identical client code:
+
+  1. PQC happy-path — ML-DSA keygen + sign, ML-KEM keygen + encapsulate +
+     decapsulate. Under any policy that allows them, each shows
+     ALLOW -> KMIP Success -> the PKCS#11 engine call that ran.
+
+  2. Encryption allow-vs-deny contrast — one AES key, encrypted once with
+     GCM and once with CBC. Under the `aead-only` policy the GCM call is
+     ALLOWED (full p1->p2->p3 trail) while the CBC call is DENIED at p1 with
+     NO p3 engine call — the agility layer stopping it before the engine.
+
+Run the server first, e.g.:
+
+    cargo build --release --bin pqctoday-kmip
+    ./target/release/pqctoday-kmip \
+        --listen 127.0.0.1:5696 --store-memory \
+        --policy-dir policies --policy aead-only \
+        --audit-log /tmp/agility-audit.jsonl
+
+then:
+
+    python -m pykmip.demo --audit-log /tmp/agility-audit.jsonl
+
+The client targets the running server; it does not launch or configure it.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import time
+
+from . import audit
+from .client import KmipClient
+
+
+def _step(label: str, result) -> None:
+    status = "ok" if result.ok else f"DENIED/FAILED (reason={result.reason})"
+    print(f"  · {label:<34} -> {status}")
+
+
+def run_operations(c: KmipClient) -> None:
+    print("\n=== 1. PQC happy-path ===")
+
+    # ML-DSA: keygen -> activate -> sign
+    kp = c.create_key_pair("ML_DSA_44", "Sign Verify")
+    _step("CreateKeyPair ML-DSA-44", kp)
+    priv = kp.get("PrivateKeyUniqueIdentifier")
+    if kp.ok and priv:
+        c.activate(priv)
+        _step("Sign (ML-DSA-44)", c.sign(priv, b"agility demo message", "ML_DSA_44"))
+
+    # ML-KEM: keygen -> activate -> encapsulate -> decapsulate
+    kem = c.create_key_pair("ML_KEM_512", "KeyAgreement")
+    _step("CreateKeyPair ML-KEM-512", kem)
+    kpriv = kem.get("PrivateKeyUniqueIdentifier")
+    kpub = kem.get("PublicKeyUniqueIdentifier")
+    if kem.ok and kpub:
+        c.activate(kpub)
+        if kpriv:
+            c.activate(kpriv)
+        enc = c.encapsulate(kpub)
+        _step("Encapsulate (ML-KEM-512)", enc)
+        ct = enc.get("Data")
+        if enc.ok and ct and kpriv:
+            _step("Decapsulate (ML-KEM-512)", c.decapsulate(kpriv, bytes.fromhex(ct)))
+
+    print("\n=== 2. Encryption allow-vs-deny contrast ===")
+    aes = c.create_symmetric("AES", 256, name="agility-demo-aes")
+    _step("Create AES-256", aes)
+    aes_uid = aes.get("UniqueIdentifier")
+    if aes.ok and aes_uid:
+        c.activate(aes_uid)
+        block = b"\x00" * 16
+        _step("Encrypt AES-GCM (expect ALLOW)",
+              c.encrypt(aes_uid, block, block_cipher_mode="GCM", iv=b"\x00" * 12))
+        _step("Encrypt AES-CBC (expect DENY under aead-only)",
+              c.encrypt(aes_uid, block, block_cipher_mode="CBC", iv=b"\x00" * 16))
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Agile KMIP server sandbox-dev demo")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=5696)
+    ap.add_argument("--audit-log", help="server's --audit-log path; printed as a correlated 3-plane trail after the run")
+    ap.add_argument("--no-color", action="store_true")
+    args = ap.parse_args(argv)
+
+    c = KmipClient(args.host, args.port)
+    print(f"agile KMIP server @ {args.host}:{args.port}")
+    run_operations(c)
+
+    if args.audit_log:
+        # Give the JSONL sink a moment to flush the last lines.
+        time.sleep(0.2)
+        print("\n=== three-plane audit trail (p1 policy / p2 kmip / p3 pkcs11) ===\n")
+        if os.path.exists(args.audit_log):
+            print(audit.format_log(args.audit_log, color=not args.no_color))
+        else:
+            print(f"  (audit log not found at {args.audit_log})")
+    else:
+        print("\n(pass --audit-log <path> to print the correlated three-plane trail)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kmip/src/ops/decapsulate.rs
+++ b/kmip/src/ops/decapsulate.rs
@@ -69,6 +69,47 @@ pub fn decapsulate(
         ));
     }
 
+    // ── Plane 1: policy gate ────────────────────────────────────────────
+    // Route Decapsulate through the agility engine (see encapsulate.rs) so the
+    // policy plane governs ML-KEM operations — emits the p1 PolicyDecided
+    // audit event and enforces allow / deny.
+    let started = time::OffsetDateTime::now_utc();
+    let empty: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let stored_algo = super::helpers::canonical_name(obj.algorithm);
+    let mut p_req = crate::policy::PolicyRequest::minimal(
+        "Decapsulate",
+        Some(&stored_algo),
+        started,
+        correlation_id,
+        &empty,
+    );
+    p_req.usage_mask = Some(obj.usage_mask);
+    p_req.state = Some("Active");
+    p_req.current_object_algorithm = Some(&stored_algo);
+    p_req.target_uid = Some(&req.uid);
+    match deps.engine.evaluate(&p_req) {
+        crate::policy::Decision::Allow { .. } => {}
+        crate::policy::Decision::Deny { human, .. } => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Decapsulate",
+                KmipError::permission_denied(human),
+            ));
+        }
+        crate::policy::Decision::RekeyAndProceed { .. } => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Decapsulate",
+                KmipError::failed(
+                    ResultReason::OperationNotSupported,
+                    "Decapsulate: policy requires rekey, which is not supported inline".to_string(),
+                ),
+            ));
+        }
+    }
+
     let mech = obj.algorithm.to_pkcs11_mech(PkcsOp::Decrypt).ok_or_else(|| {
         KmipError::failed(
             ResultReason::OperationNotSupported,
@@ -78,9 +119,17 @@ pub fn decapsulate(
 
     let shared_secret = match deps.engine_session {
         Some(session) => {
-            let handle = softhsmrustv3::native::find_by_cka_id(session, &obj.pkcs11_cka_id)
-                .map_err(|rv| super::helpers::ck_rv_to_kmip_error(rv, "Decap:find"))?
-                .ok_or_else(|| KmipError::object_not_found(&req.uid))?;
+            // Resolve by PKCS#11 class: Decapsulate needs the PRIVATE key, but
+            // a CreateKeyPair pair shares one CKA_ID across both halves, so a
+            // bare `find_by_cka_id` may return the public half (CKA_DECAPSULATE
+            // =false → CKR_KEY_FUNCTION_NOT_PERMITTED). (Same fix as Get/Sign.)
+            let handle = super::helpers::find_handle_for_object(
+                session,
+                &obj.pkcs11_cka_id,
+                crate::kmip30::ObjectType::PrivateKey,
+            )
+            .map_err(|rv| super::helpers::ck_rv_to_kmip_error(rv, "Decap:find"))?
+            .ok_or_else(|| KmipError::object_not_found(&req.uid))?;
             let native_mech = super::helpers::native_kem_mech(obj.algorithm).ok_or_else(|| {
                 KmipError::failed(
                     ResultReason::OperationNotSupported,

--- a/kmip/src/ops/encapsulate.rs
+++ b/kmip/src/ops/encapsulate.rs
@@ -90,6 +90,48 @@ pub fn encapsulate(
         ));
     }
 
+    // ── Plane 1: policy gate ────────────────────────────────────────────
+    // Route Encapsulate through the agility engine like Sign / Encrypt so the
+    // policy plane governs ML-KEM operations too — `engine.evaluate` emits the
+    // p1 `PolicyDecided` audit event and enforces allow / deny. Without this,
+    // KEM ops were a blind spot in the crypto-agility layer.
+    let started = OffsetDateTime::now_utc();
+    let empty: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let stored_algo = super::helpers::canonical_name(obj.algorithm);
+    let mut p_req = crate::policy::PolicyRequest::minimal(
+        "Encapsulate",
+        Some(&stored_algo),
+        started,
+        correlation_id,
+        &empty,
+    );
+    p_req.usage_mask = Some(obj.usage_mask);
+    p_req.state = Some("Active");
+    p_req.current_object_algorithm = Some(&stored_algo);
+    p_req.target_uid = Some(&req.uid);
+    match deps.engine.evaluate(&p_req) {
+        crate::policy::Decision::Allow { .. } => {}
+        crate::policy::Decision::Deny { human, .. } => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Encapsulate",
+                KmipError::permission_denied(human),
+            ));
+        }
+        crate::policy::Decision::RekeyAndProceed { .. } => {
+            return Err(fail_err(
+                deps,
+                correlation_id,
+                "Encapsulate",
+                KmipError::failed(
+                    ResultReason::OperationNotSupported,
+                    "Encapsulate: policy requires rekey, which is not supported inline".to_string(),
+                ),
+            ));
+        }
+    }
+
     let mech = obj.algorithm.to_pkcs11_mech(PkcsOp::Encrypt).ok_or_else(|| {
         KmipError::failed(
             ResultReason::OperationNotSupported,
@@ -103,9 +145,18 @@ pub fn encapsulate(
 
     let (ciphertext, shared_secret) = match deps.engine_session {
         Some(session) => {
-            let handle = softhsmrustv3::native::find_by_cka_id(session, &obj.pkcs11_cka_id)
-                .map_err(|rv| super::helpers::ck_rv_to_kmip_error(rv, "Encap:find"))?
-                .ok_or_else(|| KmipError::object_not_found(&req.uid))?;
+            // Resolve the handle by PKCS#11 class: a CreateKeyPair-generated
+            // ML-KEM pair stores BOTH halves under one shared CKA_ID, so a
+            // bare `find_by_cka_id` can return the private half (which has
+            // CKA_ENCAPSULATE=false → CKR_KEY_FUNCTION_NOT_PERMITTED).
+            // Encapsulate needs the PUBLIC key. (Same fix as Get/Sign.)
+            let handle = super::helpers::find_handle_for_object(
+                session,
+                &obj.pkcs11_cka_id,
+                ObjectType::PublicKey,
+            )
+            .map_err(|rv| super::helpers::ck_rv_to_kmip_error(rv, "Encap:find"))?
+            .ok_or_else(|| KmipError::object_not_found(&req.uid))?;
             let native_mech = super::helpers::native_kem_mech(obj.algorithm).ok_or_else(|| {
                 KmipError::failed(
                     ResultReason::OperationNotSupported,


### PR DESCRIPTION
## What

The first **sandbox-dev integration** for the agile KMIP server: a small
Python client (`kmip/pykmip/`) that drives the server with real crypto
operations and a correlator that reads the `--audit-log` into per-request
**three-plane trails** (p1 policy / p2 KMIP / p3 PKCS#11). Building it
surfaced — and this PR fixes — two real findings in the WD19 ML-KEM ops.

## `kmip/pykmip/`
- **`client.py`** — `KmipClient`: format + send KMIP calls over TLS (Create, CreateKeyPair, Encrypt, Sign, Encapsulate, Decapsulate, Get, Activate, Destroy). PQC-aware; reuses the conformance harness's TTLV codec. Targets a running server; policy-agnostic.
- **`audit.py`** — correlate the audit JSONL by `correlation_id` into p1/p2/p3 trails.
- **`demo.py`** — PQC happy-path + Encrypt allow-vs-deny contrast.
- **`README.md`** — launch the server with a policy + `--audit-log`, run the client, read the trail.

The agility story renders directly in the log (same client code, the policy decides):
```
ALLOW  Encrypt   p1: Allow             p2: Success          p3: native::encrypt [AES-GCM]
DENY   Encrypt   p1: Deny "AES must    p2: OperationFailed  p3: (no engine call)   ← stopped at p1
                    use GCM or CCM"
```

## Two server-side fixes (found by the integration)
1. **Class-aware handle resolution for Encapsulate/Decapsulate.** They used the bare `find_by_cka_id`; a `CreateKeyPair` ML-KEM pair shares one CKA_ID across both halves, so the lookup could return the wrong half (`CKA_ENCAPSULATE/DECAPSULATE=false`) → `CKR_KEY_FUNCTION_NOT_PERMITTED`. Now resolves by PKCS#11 class via `find_handle_for_object` (PublicKey for encap, PrivateKey for decap) — the same fix Get/Sign already use. The 1452 KATs missed it because they `Register` separate keys with distinct CKA_IDs.
2. **KEM ops now go through the Plane-1 policy engine.** Encapsulate/Decapsulate never called `engine.evaluate()`, so the crypto-agility layer didn't govern them (no p1 decision). Now routed like Sign/Encrypt: emits the p1 `PolicyDecided` audit event and enforces allow/deny.

## Verification
- KMIP **472/472** lib tests green.
- PQC interop replay **unchanged**: vendored subset **42/42**, full encap+decap **105/105** byte-exact (KATs run under built-in-permissive and Register distinct CKA_IDs, so neither fix changes their wire behaviour).
- Live demo: Encapsulate + Decapsulate now show **p1 Allow** and succeed with the correct engine call; AES-CBC still denied at p1 with no p3 call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)