### PR TITLE
feat(kmip): cryptopolicy-manager — quantum-safe-mTLS HTTP policy-admin facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — cryptopolicy-manager: quantum-safe-mTLS HTTP policy-admin facade (2026-06-14)
+
+The W4 server-side admin facade for the crypto-agility plane (`kmip/cryptopolicy-manager/`),
+enabled with `--admin-listen`. A JSON HTTP API over the existing `PolicyStore`
+so out-of-band tooling (the dev-sandbox policy-management UI) can list / load /
+validate / dry-run / save / **activate** crypto-agility policies on the
+**running** server — never on the KMIP surface (separation of duties; there is
+no KMIP "reboot/reload" op, and inventing one would breach that boundary).
+
+- **In-process, live hot-swap.** Compiled into the `pqctoday-kmip` crate via a
+  `#[path]` module; the server spawns the admin listener with a clone of the
+  live `policy::Engine` (`Arc<RwLock>` inside), so `POST /policies/{name}/activate`
+  changes the policy the KMIP dispatcher enforces on the very next request —
+  no restart.
+- **Quantum-safe mTLS.** `X25519MLKEM768`-only key exchange (ML-KEM-768 hybrid,
+  TLS 1.3) via the rustls **aws-lc-rs** provider (the KMIP listener's `ring`
+  default is untouched), plus **required client certificates**. Client/server
+  certs stay classical (ECDSA/Ed25519) — rustls 0.23 has no ML-DSA *certificate*
+  support, so the quantum-safety is in the session KEX (harvest-now-decrypt-later
+  resistance), documented as such.
+- **Routes:** `GET /policies`, `GET /policies/{name}` (incl. raw YAML for an
+  editor), `GET /active`, `POST /validate` (line/col errors for live lint),
+  `POST /dry-run`, `PUT /policies/{name}`, `POST /policies/{name}/activate`.
+  Activations are audited with the mTLS client-cert CN
+  (`admin: LIVE policy activated name=… by cn=…`).
+- New server flags: `--admin-listen`, `--admin-tls-cert/key`, `--admin-client-ca`
+  (mTLS, requires `--policy-dir`). rustls gains the `aws_lc_rs` feature.
+
+Verified manually against an OpenSSL 3.6.2 client: `Negotiated TLS1.3 group:
+X25519MLKEM768`, certless client rejected, all seven routes correct, live
+activation reflected immediately in `GET /active`. Unit tests cover the router
++ the PQC-mTLS config build; KMIP suite 477 tests green.
+
 ### Added — KMIP PQC interop (full 1452 byte-exact) + crypto-policy completeness + sandbox-dev client (2026-06-14)
 
 Three PRs completing the crypto-agility layer's interop claim and its first

--- a/kmip/Cargo.toml
+++ b/kmip/Cargo.toml
@@ -36,7 +36,9 @@ softhsmrustv3 = { path = "../rust" }
 # Async runtime + I/O
 tokio        = { version = "1", features = ["full"] }
 tokio-rustls = "0.26"
-rustls       = { version = "0.23", features = ["ring"] }
+# `ring` backs the KMIP listener; `aws_lc_rs` backs the cryptopolicy-manager
+# admin facade (the only provider exposing the X25519MLKEM768 PQC hybrid KEX).
+rustls       = { version = "0.23", features = ["ring", "aws_lc_rs"] }
 rustls-pemfile = "2"
 
 # Self-signed cert auto-gen for sandbox / dev runs (Phase 7).

--- a/kmip/bin/pqctoday-kmip.rs
+++ b/kmip/bin/pqctoday-kmip.rs
@@ -74,6 +74,26 @@ struct Cli {
     #[arg(long, requires = "tls_cert")]
     tls_client_ca: Option<PathBuf>,
 
+    /// cryptopolicy-manager admin facade listen address (e.g.
+    /// `127.0.0.1:5697`). When set, serves the out-of-band HTTP policy-admin
+    /// API (list/load/validate/dry-run/save/activate) over **mTLS with the
+    /// X25519MLKEM768 PQC hybrid key exchange**, sharing this server's live
+    /// engine so an activation takes effect with no restart. Requires
+    /// `--admin-tls-cert/key`, `--admin-client-ca`, and `--policy-dir`.
+    #[arg(long)]
+    admin_listen: Option<SocketAddr>,
+
+    /// Admin facade server cert / key (PEM). Required with `--admin-listen`.
+    #[arg(long, requires = "admin_listen")]
+    admin_tls_cert: Option<PathBuf>,
+    #[arg(long, requires = "admin_listen")]
+    admin_tls_key: Option<PathBuf>,
+
+    /// Admin facade client-CA bundle (PEM): admin mTLS client certs must be
+    /// signed by it. Required with `--admin-listen`.
+    #[arg(long, requires = "admin_listen")]
+    admin_client_ca: Option<PathBuf>,
+
     /// K14 auth — configured credential store entry, repeatable:
     /// `<username>:<sha256hex-of-password>` (e.g.
     /// `alice:$(printf %s 'pw' | shasum -a 256 | cut -d' ' -f1)`).
@@ -179,6 +199,32 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!("no --auth-user entries — open-auth mode (Authentication header ignored)");
     } else {
         tracing::info!("authentication ENFORCED for {} configured user(s)", auth_users.len());
+    }
+
+    // ── cryptopolicy-manager admin facade (W4, optional) ───────────────
+    // Spawn BEFORE `engine` is moved into Deps — `Engine` is Clone over a
+    // shared `Arc<RwLock>`, so the facade's clone enforces activations on the
+    // running dispatcher with no restart. mTLS + X25519MLKEM768 PQC KEX.
+    if let Some(addr) = cli.admin_listen {
+        let cert = cli.admin_tls_cert.clone().ok_or_else(|| anyhow::anyhow!("--admin-listen requires --admin-tls-cert"))?;
+        let key = cli.admin_tls_key.clone().ok_or_else(|| anyhow::anyhow!("--admin-listen requires --admin-tls-key"))?;
+        let ca = cli.admin_client_ca.clone().ok_or_else(|| anyhow::anyhow!("--admin-listen requires --admin-client-ca"))?;
+        let policy_dir = cli.policy_dir.clone().ok_or_else(|| anyhow::anyhow!("--admin-listen requires --policy-dir (the policy store root)"))?;
+        let tls = pqctoday_kmip::cryptopolicy_manager::pqc_mtls_config(
+            &std::fs::read(&cert)?,
+            &std::fs::read(&key)?,
+            &std::fs::read(&ca)?,
+        )
+        .map_err(|e| anyhow::anyhow!("admin mTLS config: {e}"))?;
+        let admin_engine = engine.clone();
+        tracing::info!("cryptopolicy-manager admin facade enabled on {addr} (mTLS, X25519MLKEM768)");
+        tokio::spawn(async move {
+            if let Err(e) =
+                pqctoday_kmip::cryptopolicy_manager::serve_admin(addr, policy_dir, admin_engine, tls).await
+            {
+                tracing::error!("admin facade exited: {e}");
+            }
+        });
     }
 
     // ── Deps bundle ─────────────────────────────────────────────────────

--- a/kmip/cryptopolicy-manager/README.md
+++ b/kmip/cryptopolicy-manager/README.md
@@ -1,0 +1,116 @@
+# cryptopolicy-manager — HTTP admin facade for the crypto-agility policy plane
+
+> **Status: implemented.** The W4 *server-side HTTP admin facade* — a
+> quantum-safe-mTLS JSON API over the `PolicyStore`, compiled into the
+> `pqctoday-kmip` server and enabled with `--admin-listen`. It is **not** a
+> KMIP surface — policy administration stays out-of-band from the enforcement
+> protocol (separation of duties). See
+> [`../docs/CRYPTO_AGILITY_CONFIGURATION.md`](../docs/CRYPTO_AGILITY_CONFIGURATION.md)
+> for how policy works via file + CLI.
+>
+> Source: [`manager.rs`](manager.rs) (compiled into the crate via a `#[path]`
+> module in `../src/lib.rs`).
+
+## Purpose
+
+Expose the existing Rust `PolicyStore` primitives over HTTP so a UI / ops
+tooling can **read, author, validate, dry-run, and activate** crypto-agility
+policies on a *running* server — without editing files on the box or
+restarting it.
+
+| HTTP (proposed) | `PolicyStore` primitive | Effect |
+|---|---|---|
+| `GET /policies` | `list()` | enumerate policies |
+| `GET /policies/{name}` | `load()` | read one |
+| `POST /policies/validate` | `validate_draft(yaml)` | parse + validate, no disk |
+| `POST /policies/dry-run` | `dry_run(yaml, req)` | evaluate a sample request, no side effects |
+| `PUT /policies/{name}` | `save(name, yaml)` | persist (atomic) |
+| `POST /policies/{name}/activate` | `activate_with_engine(name, engine)` | **swap the live enforcement policy** |
+| `GET /active` | `read_active()` | what's active now |
+
+## Consumers
+
+The primary consumer is a **crypto-agility policy-management section in the dev
+sandbox** (`pqctoday-sandbox`): a UI panel that lists policies, shows/edits the
+YAML, **lints live** (`POST /policies/validate` on edit), **tests** a draft
+against a sample request (`POST /policies/dry-run` — the side-effect-free
+"what would this policy decide?" button), persists (`PUT`), and **activates**
+on the running server (`POST .../activate`). So the API is a stable JSON
+contract: clean request/response shapes, explicit error bodies (carry the YAML
+line/column from `validate_draft` where available), and CORS for the sandbox
+origin. The sandbox section is a downstream piece (separate repo) built against
+this API once it exists.
+
+## The architectural constraint (why this is in-process)
+
+`activate_with_engine` must mutate the **running KMIP server's** `Arc<Engine>`
+to take effect without a restart. So the admin HTTP listener has to run **in
+the same process** as the KMIP server, sharing that `Engine` handle, on a
+**separate admin port** (never the KMIP port).
+
+A fully separate process could only do *file-based* management (write the YAML
++ flip the `.active` marker) and would still need the server to reload — no
+live hot-swap. So the plan is: this folder holds the admin-facade code
+(handlers + router + auth), and the `pqctoday-kmip` server binary opts into a
+second listener (`--admin-listen <addr>`) that mounts it against the shared
+`Engine` + `PolicyStore`.
+
+## Security posture (non-negotiable)
+
+- **Separate port**, bound to localhost by default; never multiplexed onto the
+  KMIP listener.
+- **Authentication required** for every mutating route (activate / save) — the
+  facade can change the policy that governs all crypto, so it is the most
+  security-sensitive surface in the system.
+- Every mutation is **audited** — `activate_with_engine` already emits a
+  Plane-1 `PolicyActivated` event; save/validate get their own.
+- Read/dry-run vs write/activate may warrant different authz tiers.
+
+## Resolved design
+
+- **In-process** (live hot-swap): a `#[path]` module compiled into the
+  `pqctoday-kmip` crate; the server spawns the admin listener sharing a clone of
+  the live `Engine` (`Arc<RwLock>` inside), so an `activate` is enforced on the
+  next KMIP request with no restart.
+- **HTTP**: a minimal hand-rolled HTTP/1.1 handler (`Connection: close`, JSON)
+  over the `tokio-rustls` stream — no new HTTP framework, matching the crate's
+  hand-rolled-protocol style.
+- **Transport / auth — quantum-safe mTLS**: `X25519MLKEM768`-only key exchange
+  (ML-KEM-768 hybrid, TLS 1.3) via the rustls **aws-lc-rs** provider (the KMIP
+  listener's `ring` default is untouched) + **required client certificates**.
+  Client/server certs are **classical** (ECDSA/Ed25519): rustls 0.23 has no
+  ML-DSA *certificate* support yet, so the quantum-safety is in the **session
+  key exchange** (defeats harvest-now-decrypt-later), not the cert signatures.
+
+## Running it
+
+```bash
+pqctoday-kmip \
+  --listen 127.0.0.1:5696 --store-memory --policy-dir policies --policy aead-only \
+  --admin-listen 127.0.0.1:5697 \
+  --admin-tls-cert admin-server.crt --admin-tls-key admin-server.key \
+  --admin-client-ca admin-client-ca.crt
+```
+
+Client must offer `X25519MLKEM768` (OpenSSL ≥ 3.5 / aws-lc-rs / BoringSSL) and
+present a client cert signed by `--admin-client-ca`, e.g.:
+
+```bash
+printf 'POST /policies/pqc/activate HTTP/1.1\r\nConnection: close\r\n\r\n' | \
+  openssl s_client -connect 127.0.0.1:5697 -groups X25519MLKEM768 \
+    -cert client.crt -key client.key -CAfile admin-client-ca.crt -quiet
+```
+
+## Verified (manual, OpenSSL 3.6.2 client)
+
+- `Negotiated TLS1.3 group: X25519MLKEM768` ✓ (handshake fails on any other group).
+- mTLS enforced — a certless client is rejected (`tlsv13 alert certificate required`).
+- `GET /policies`, `GET /active`, `POST /validate` (clean line/col error),
+  `POST /dry-run` (`{"decision":{"outcome":"allow"}}`), `PUT /policies/{name}`,
+  and **`POST /policies/{name}/activate`** all return correct JSON.
+- Live activation flips the running engine (`/active` reflects it immediately)
+  and is audited with the client-cert CN:
+  `admin: LIVE policy activated name="pqc" fp=… by cn="policy-admin-alice"`.
+
+Unit tests in [`manager.rs`](manager.rs) cover the router + the PQC-mTLS config
+build; the handshake/route behaviour above is the manual smoke.

--- a/kmip/cryptopolicy-manager/manager.rs
+++ b/kmip/cryptopolicy-manager/manager.rs
@@ -1,0 +1,436 @@
+//! cryptopolicy-manager — in-process HTTP admin facade for the crypto-agility
+//! policy plane (W4). Compiled into the `pqctoday-kmip` crate via a `#[path]`
+//! module declaration in `lib.rs`; the server binary opts in with
+//! `--admin-listen`.
+//!
+//! ## Why in-process
+//! `activate` must mutate the **running** server's policy with no restart.
+//! [`crate::policy::Engine`] is `Clone` over an inner `Arc<RwLock<…>>`, so the
+//! admin facade holds a clone of the *same* engine the KMIP dispatcher uses —
+//! an activation here is enforced on the very next KMIP request. There is no
+//! KMIP operation that reboots/reloads a server (and inventing one would break
+//! separation of duties), so this out-of-band HTTP surface is the path.
+//!
+//! ## Quantum-safe transport
+//! mTLS with the **`X25519MLKEM768`** hybrid key-exchange group (ML-KEM-768 +
+//! X25519) via the rustls aws-lc-rs provider — the session is PQC-protected
+//! against harvest-now-decrypt-later. Client/server *certificates* stay
+//! classical (ECDSA/Ed25519): rustls 0.23 has no ML-DSA certificate support
+//! yet (see [`pqc_mtls_config`]). Client certs are required + verified (mTLS).
+//!
+//! ## Routes (JSON over HTTP/1.1, `Connection: close`)
+//! ```text
+//! GET    /policies                 list()            → ["aead-only", …]
+//! GET    /policies/{name}          load() + raw yaml → {name, metadata, yaml}
+//! GET    /active                   read_active()     → {name, fingerprint} | null
+//! POST   /validate        body=yaml                  → {ok} | 400 {error}
+//! POST   /dry-run         body={yaml,op,algorithm?}  → {decision, …}
+//! PUT    /policies/{name} body=yaml  save()          → {saved}
+//! POST   /policies/{name}/activate   activate()      → {activated, fingerprint}
+//! ```
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use rustls::pki_types::CertificateDer;
+use rustls::server::WebPkiClientVerifier;
+use rustls::{RootCertStore, ServerConfig};
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio_rustls::TlsAcceptor;
+
+use crate::policy::{Decision, Engine, PolicyRequest, PolicyStore, StoreError};
+
+/// Cap on a single admin request (headers + body). Policies are small YAML.
+const MAX_REQUEST: usize = 1 << 20; // 1 MiB
+
+#[derive(Debug, thiserror::Error)]
+pub enum AdminError {
+    #[error("I/O: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("TLS: {0}")]
+    Tls(String),
+}
+
+/// Build the quantum-safe mTLS `ServerConfig` for the admin listener:
+/// `X25519MLKEM768`-only key exchange (TLS 1.3) + required client certs
+/// signed by `client_ca_pem`. Uses the aws-lc-rs provider explicitly (the
+/// KMIP listener's `ring` default is untouched).
+pub fn pqc_mtls_config(
+    server_cert_pem: &[u8],
+    server_key_pem: &[u8],
+    client_ca_pem: &[u8],
+) -> Result<Arc<ServerConfig>, AdminError> {
+    use rustls::crypto::aws_lc_rs;
+
+    // Force the post-quantum hybrid KEM group. X25519MLKEM768 is TLS 1.3 only.
+    let mut provider = aws_lc_rs::default_provider();
+    provider.kx_groups = vec![aws_lc_rs::kx_group::X25519MLKEM768];
+    let provider = Arc::new(provider);
+
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut &server_cert_pem[..])
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| AdminError::Tls(format!("server cert: {e}")))?;
+    let key = rustls_pemfile::private_key(&mut &server_key_pem[..])
+        .map_err(|e| AdminError::Tls(format!("server key: {e}")))?
+        .ok_or_else(|| AdminError::Tls("no server private key in PEM".into()))?;
+
+    let mut roots = RootCertStore::empty();
+    for cert in rustls_pemfile::certs(&mut &client_ca_pem[..]) {
+        roots
+            .add(cert.map_err(|e| AdminError::Tls(format!("client CA: {e}")))?)
+            .map_err(|e| AdminError::Tls(format!("root store add: {e}")))?;
+    }
+    let verifier = WebPkiClientVerifier::builder_with_provider(Arc::new(roots), provider.clone())
+        .build()
+        .map_err(|e| AdminError::Tls(format!("client verifier: {e}")))?;
+
+    let config = ServerConfig::builder_with_provider(provider)
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .map_err(|e| AdminError::Tls(format!("TLS1.3 required for ML-KEM: {e}")))?
+        .with_client_cert_verifier(verifier)
+        .with_single_cert(certs, key)
+        .map_err(|e| AdminError::Tls(e.to_string()))?;
+    Ok(Arc::new(config))
+}
+
+/// Serve the admin facade forever. `engine` is a clone of the KMIP server's
+/// live engine (shared `Arc<RwLock>` inside), so `activate` takes effect
+/// immediately on the running dispatcher. `store_root` is the `--policy-dir`.
+pub async fn serve_admin(
+    addr: SocketAddr,
+    store_root: PathBuf,
+    engine: Engine,
+    tls: Arc<ServerConfig>,
+) -> Result<(), AdminError> {
+    let listener = TcpListener::bind(addr).await?;
+    let acceptor = TlsAcceptor::from(tls);
+    tracing::info!(
+        "cryptopolicy-manager admin facade listening on {addr} (mTLS, X25519MLKEM768)"
+    );
+    loop {
+        let (tcp, peer) = match listener.accept().await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("admin accept error: {e}");
+                continue;
+            }
+        };
+        let acceptor = acceptor.clone();
+        let store_root = store_root.clone();
+        let engine = engine.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_conn(tcp, acceptor, store_root, engine).await {
+                tracing::warn!("admin conn from {peer} ended: {e}");
+            }
+        });
+    }
+}
+
+async fn handle_conn(
+    tcp: tokio::net::TcpStream,
+    acceptor: TlsAcceptor,
+    store_root: PathBuf,
+    engine: Engine,
+) -> Result<(), AdminError> {
+    let mut tls = acceptor.accept(tcp).await?;
+    // mTLS already enforced the client cert in the handshake; capture its CN
+    // for the audit trail of who changed policy.
+    let client_cn = client_cert_cn(tls.get_ref().1);
+
+    let (method, path, body) = match read_request(&mut tls).await {
+        Ok(v) => v,
+        Err(resp) => {
+            tls.write_all(&resp).await?;
+            tls.shutdown().await.ok();
+            return Ok(());
+        }
+    };
+
+    let store = PolicyStore::new(&store_root);
+    let (status, value) = route(&store, &store_root, &engine, &method, &path, &body, client_cn.as_deref());
+    let resp = http_json(status, &value);
+    tls.write_all(&resp).await?;
+    tls.shutdown().await.ok();
+    Ok(())
+}
+
+/// Dispatch one request to a `PolicyStore` primitive. Returns `(status, json)`.
+#[allow(clippy::too_many_arguments)]
+fn route(
+    store: &PolicyStore,
+    store_root: &std::path::Path,
+    engine: &Engine,
+    method: &str,
+    path: &str,
+    body: &[u8],
+    client_cn: Option<&str>,
+) -> (u16, Value) {
+    match (method, path) {
+        ("GET", "/policies") => match store.list() {
+            Ok(names) => (200, json!({ "policies": names })),
+            Err(e) => store_err(e),
+        },
+        ("GET", "/active") => match store.read_active() {
+            Ok(Some(m)) => (200, json!({ "name": m.name, "fingerprint": m.fingerprint })),
+            Ok(None) => (200, Value::Null),
+            Err(e) => store_err(e),
+        },
+        ("POST", "/validate") => match std::str::from_utf8(body) {
+            Ok(yaml) => match store.validate_draft(yaml) {
+                Ok(p) => (200, json!({ "ok": true, "name": p.policy.metadata.name })),
+                Err(e) => store_err(e),
+            },
+            Err(_) => (400, json!({ "error": "body is not valid UTF-8 YAML" })),
+        },
+        ("POST", "/dry-run") => dry_run(store, body),
+        ("GET", p) if p.starts_with("/policies/") => {
+            let name = &p["/policies/".len()..];
+            get_policy(store, store_root, name)
+        }
+        ("PUT", p) if p.starts_with("/policies/") => {
+            let name = &p["/policies/".len()..];
+            match std::str::from_utf8(body) {
+                Ok(yaml) => match store.save(name, yaml) {
+                    Ok(()) => {
+                        tracing::info!("admin: policy {name:?} saved by cn={client_cn:?}");
+                        (200, json!({ "saved": name }))
+                    }
+                    Err(e) => store_err(e),
+                },
+                Err(_) => (400, json!({ "error": "body is not valid UTF-8 YAML" })),
+            }
+        }
+        ("POST", p) if p.starts_with("/policies/") && p.ends_with("/activate") => {
+            let name = &p["/policies/".len()..p.len() - "/activate".len()];
+            // The security-critical mutation: swap the LIVE enforcement policy.
+            match store.activate_with_engine(name, engine) {
+                Ok(_prior) => {
+                    // `activate_with_engine` returns the PRIOR marker; read the
+                    // freshly-written one for the new policy's fingerprint.
+                    let fp = store.read_active().ok().flatten().map(|m| m.fingerprint);
+                    tracing::warn!(
+                        "admin: LIVE policy activated name={name:?} fp={fp:?} by cn={client_cn:?}"
+                    );
+                    (200, json!({ "activated": name, "fingerprint": fp }))
+                }
+                Err(e) => store_err(e),
+            }
+        }
+        _ => (404, json!({ "error": "no such route", "method": method, "path": path })),
+    }
+}
+
+fn get_policy(store: &PolicyStore, root: &std::path::Path, name: &str) -> (u16, Value) {
+    match store.load(name) {
+        Ok(p) => {
+            // Include the raw YAML so a UI editor can round-trip it.
+            let yaml = std::fs::read_to_string(root.join(format!("{name}.yaml"))).ok();
+            (200, json!({ "name": p.policy.metadata.name, "yaml": yaml }))
+        }
+        Err(e) => store_err(e),
+    }
+}
+
+fn dry_run(store: &PolicyStore, body: &[u8]) -> (u16, Value) {
+    let Ok(req): Result<Value, _> = serde_json::from_slice(body) else {
+        return (400, json!({ "error": "body must be JSON {yaml, op, algorithm?}" }));
+    };
+    let (Some(yaml), Some(op)) = (req.get("yaml").and_then(Value::as_str), req.get("op").and_then(Value::as_str))
+    else {
+        return (400, json!({ "error": "missing 'yaml' or 'op'" }));
+    };
+    let algorithm = req.get("algorithm").and_then(Value::as_str);
+    let empty = std::collections::HashMap::new();
+    let now = time::OffsetDateTime::now_utc();
+    let p_req = PolicyRequest::minimal(op, algorithm, now, "admin-dry-run", &empty);
+    match store.dry_run(yaml, &p_req) {
+        Ok(decision) => (200, json!({ "decision": decision_json(&decision) })),
+        Err(e) => store_err(e),
+    }
+}
+
+/// Decision has no `Serialize` impl (it carries non-serde internals); project
+/// it to a stable JSON shape for the UI.
+fn decision_json(d: &Decision) -> Value {
+    match d {
+        Decision::Allow { .. } => json!({ "outcome": "allow" }),
+        Decision::Deny { human, .. } => json!({ "outcome": "deny", "reason": human }),
+        Decision::RekeyAndProceed { new_algorithm, .. } => {
+            json!({ "outcome": "rekey", "new_algorithm": new_algorithm })
+        }
+    }
+}
+
+fn store_err(e: StoreError) -> (u16, Value) {
+    // Loader (YAML) errors + bad names are client mistakes → 400; rest 500.
+    let status = match &e {
+        StoreError::Loader(_) | StoreError::BadName(_) => 400,
+        _ => 500,
+    };
+    (status, json!({ "error": e.to_string() }))
+}
+
+// ── minimal HTTP/1.1 over the TLS stream ────────────────────────────────────
+
+/// Read one request: returns `(method, path, body)` or an error response to
+/// send verbatim. `Connection: close` semantics — one request per connection.
+async fn read_request<S>(tls: &mut S) -> Result<(String, String, Vec<u8>), Vec<u8>>
+where
+    S: AsyncReadExt + Unpin,
+{
+    let mut buf = Vec::with_capacity(2048);
+    let mut tmp = [0u8; 4096];
+    // Read until end-of-headers (\r\n\r\n).
+    let header_end = loop {
+        if let Some(pos) = find_subslice(&buf, b"\r\n\r\n") {
+            break pos;
+        }
+        if buf.len() > MAX_REQUEST {
+            return Err(http_json(413, &json!({ "error": "request too large" })));
+        }
+        match tls.read(&mut tmp).await {
+            Ok(0) => return Err(http_json(400, &json!({ "error": "connection closed mid-request" }))),
+            Ok(n) => buf.extend_from_slice(&tmp[..n]),
+            Err(_) => return Err(http_json(400, &json!({ "error": "read error" }))),
+        }
+    };
+
+    let head = String::from_utf8_lossy(&buf[..header_end]).to_string();
+    let mut lines = head.split("\r\n");
+    let request_line = lines.next().unwrap_or("");
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("").to_string();
+    let path = parts.next().unwrap_or("").to_string();
+    if method.is_empty() || path.is_empty() {
+        return Err(http_json(400, &json!({ "error": "malformed request line" })));
+    }
+
+    let content_len: usize = lines
+        .find_map(|l| {
+            let (k, v) = l.split_once(':')?;
+            k.trim().eq_ignore_ascii_case("content-length")
+                .then(|| v.trim().parse().ok())
+                .flatten()
+        })
+        .unwrap_or(0);
+    if content_len > MAX_REQUEST {
+        return Err(http_json(413, &json!({ "error": "body too large" })));
+    }
+
+    // Body = bytes already buffered past the header + whatever's left to read.
+    let mut body = buf[header_end + 4..].to_vec();
+    while body.len() < content_len {
+        match tls.read(&mut tmp).await {
+            Ok(0) => break,
+            Ok(n) => body.extend_from_slice(&tmp[..n]),
+            Err(_) => return Err(http_json(400, &json!({ "error": "body read error" }))),
+        }
+    }
+    body.truncate(content_len);
+    Ok((method, path, body))
+}
+
+fn find_subslice(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    hay.windows(needle.len()).position(|w| w == needle)
+}
+
+fn http_json(status: u16, value: &Value) -> Vec<u8> {
+    let reason = match status {
+        200 => "OK",
+        400 => "Bad Request",
+        404 => "Not Found",
+        413 => "Payload Too Large",
+        500 => "Internal Server Error",
+        _ => "Status",
+    };
+    let body = serde_json::to_vec(value).unwrap_or_default();
+    let mut out = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    out.extend_from_slice(&body);
+    out
+}
+
+/// Extract the leaf client certificate's subject CN (best-effort) for audit.
+fn client_cert_cn(conn: &rustls::ServerConnection) -> Option<String> {
+    let certs = conn.peer_certificates()?;
+    let leaf = certs.first()?;
+    let (_, parsed) = x509_parser::parse_x509_certificate(leaf.as_ref()).ok()?;
+    parsed
+        .subject()
+        .iter_common_name()
+        .next()
+        .and_then(|cn| cn.as_str().ok())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::Engine;
+
+    const VALID: &str =
+        "schema_version: 1\nmetadata:\n  name: p\n  description: d\n  authority: a\n  effective: always\nrules: []\n";
+
+    fn store_with(tag: &str) -> (PathBuf, PolicyStore) {
+        let dir = std::env::temp_dir().join(format!("pqc-admin-test-{tag}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("p.yaml"), VALID).unwrap();
+        let store = PolicyStore::new(&dir);
+        (dir, store)
+    }
+
+    #[test]
+    fn route_list_includes_policy() {
+        let (dir, store) = store_with("list");
+        let (status, body) = route(&store, &dir, &Engine::deny_all(), "GET", "/policies", b"", None);
+        assert_eq!(status, 200);
+        assert!(body["policies"].as_array().unwrap().iter().any(|v| v == "p"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn route_unknown_path_404() {
+        let (dir, store) = store_with("404");
+        let (status, _) = route(&store, &dir, &Engine::deny_all(), "GET", "/nope", b"", None);
+        assert_eq!(status, 404);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn route_validate_rejects_bad_yaml_400() {
+        let (dir, store) = store_with("validate");
+        let (status, body) =
+            route(&store, &dir, &Engine::deny_all(), "POST", "/validate", b"not: a policy", None);
+        assert_eq!(status, 400);
+        assert!(body["error"].is_string());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn route_active_none_is_null() {
+        let (dir, store) = store_with("active");
+        let (status, body) = route(&store, &dir, &Engine::deny_all(), "GET", "/active", b"", None);
+        assert_eq!(status, 200);
+        assert!(body.is_null());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pqc_mtls_config_builds_with_x25519mlkem768() {
+        // rcgen self-signed doubles as server cert + client CA for the builder
+        // smoke (chain validation happens at handshake time, not here). This
+        // proves the aws-lc-rs provider + X25519MLKEM768 group config is valid.
+        let c = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let cert_pem = c.cert.pem();
+        let key_pem = c.key_pair.serialize_pem();
+        let cfg = pqc_mtls_config(cert_pem.as_bytes(), key_pem.as_bytes(), cert_pem.as_bytes());
+        assert!(cfg.is_ok(), "PQC mTLS config failed: {:?}", cfg.err());
+    }
+}

--- a/kmip/src/lib.rs
+++ b/kmip/src/lib.rs
@@ -26,4 +26,10 @@ pub mod auditlog;
 pub mod types;
 pub mod error;
 
+// W4 — out-of-band HTTP admin facade for the Plane-1 policy plane. Source
+// lives in the `cryptopolicy-manager/` sibling dir (its own component) but is
+// compiled into the crate so it can share the live `policy::Engine`.
+#[path = "../cryptopolicy-manager/manager.rs"]
+pub mod cryptopolicy_manager;
+
 pub use error::KmipError;


### PR DESCRIPTION
## What

The **W4 server-side admin facade** for the crypto-agility plane
(`kmip/cryptopolicy-manager/`): a JSON HTTP API over the existing `PolicyStore`
so out-of-band tooling — the **dev-sandbox policy-management UI** — can list /
load / validate / dry-run / save / **activate** crypto-agility policies on the
**running** server. It is deliberately **not** a KMIP surface (separation of
duties): KMIP has no reboot/reload operation, and adding one would let a KMIP
client change the policy governing itself.

## Design (all confirmed with you)

- **In-process, live hot-swap** — a `#[path]` module compiled into the
  `pqctoday-kmip` crate; the server spawns the admin listener with a *clone of
  the live `policy::Engine`* (`Arc<RwLock>` inside), so `activate` changes the
  policy the KMIP dispatcher enforces on the very next request — no restart.
- **Quantum-safe mTLS** — `X25519MLKEM768`-only key exchange (ML-KEM-768 hybrid,
  TLS 1.3) via the rustls **aws-lc-rs** provider (the KMIP listener's `ring`
  default is untouched) + **required client certificates**. Certs stay classical
  (ECDSA/Ed25519): rustls 0.23 has **no ML-DSA certificate support**, so the
  quantum-safety is in the **session key exchange** (harvest-now-decrypt-later
  resistance) — documented honestly, not hand-waved.
- **Minimal hand-rolled HTTP/1.1** over `tokio-rustls` (no new HTTP framework),
  matching the crate's hand-rolled-protocol style.

## Routes
`GET /policies` · `GET /policies/{name}` (+raw YAML for an editor) · `GET /active`
· `POST /validate` (line/col errors for live lint) · `POST /dry-run` ·
`PUT /policies/{name}` · `POST /policies/{name}/activate`. Activations are
audited with the mTLS client-cert CN.

New flags: `--admin-listen`, `--admin-tls-cert/key`, `--admin-client-ca`
(requires `--policy-dir`). rustls gains the `aws_lc_rs` feature.

## Verification (manual, OpenSSL 3.6.2 client)
- `Negotiated TLS1.3 group: X25519MLKEM768` ✓ (handshake fails on any other group).
- mTLS enforced — certless client rejected (`tlsv13 alert certificate required`).
- All seven routes return correct JSON; `POST /dry-run` → `{"decision":{"outcome":"allow"}}`.
- **Live activation** flips the running engine (`GET /active` reflects it
  immediately) and is audited: `admin: LIVE policy activated name="pqc" … by cn="policy-admin-alice"`.
- Unit tests cover the router + the PQC-mTLS config build; **KMIP 477 lib tests green**.

## Next (not in this PR)
The **dev-sandbox policy-management UI section** that consumes this API
(separate repo, `pqctoday-sandbox`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)