### PR TITLE
feat(kmip): cryptopolicy-manager GET /audit — three-plane log inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — cryptopolicy-manager `GET /audit` (three-plane log inspection) (2026-06-14)
+
+The admin facade gains `GET /audit?limit=N`, returning the in-memory `RingSink`
+snapshot (the p1 policy / p2 KMIP / p3 PKCS#11 audit trail, newest last) as
+JSON over the same mTLS interface. This is the "inspect logs" data source for
+the dev-sandbox UI: a `pykmip`-driven op shows up as p1 `PolicyDecided` +
+p2 `KmipRequestReceived`/`KmipResponseSent` + p3 `Pkcs11Call`, all correlated
+by `correlation_id`. `serve_admin` now takes the `RingSink`; unit test added.
+
 ### Added — cryptopolicy-manager: quantum-safe-mTLS HTTP policy-admin facade (2026-06-14)
 
 The W4 server-side admin facade for the crypto-agility plane (`kmip/cryptopolicy-manager/`),

--- a/kmip/bin/pqctoday-kmip.rs
+++ b/kmip/bin/pqctoday-kmip.rs
@@ -217,10 +217,17 @@ async fn main() -> anyhow::Result<()> {
         )
         .map_err(|e| anyhow::anyhow!("admin mTLS config: {e}"))?;
         let admin_engine = engine.clone();
+        let admin_ring = ring.clone();
         tracing::info!("cryptopolicy-manager admin facade enabled on {addr} (mTLS, X25519MLKEM768)");
         tokio::spawn(async move {
-            if let Err(e) =
-                pqctoday_kmip::cryptopolicy_manager::serve_admin(addr, policy_dir, admin_engine, tls).await
+            if let Err(e) = pqctoday_kmip::cryptopolicy_manager::serve_admin(
+                addr,
+                policy_dir,
+                admin_engine,
+                admin_ring,
+                tls,
+            )
+            .await
             {
                 tracing::error!("admin facade exited: {e}");
             }

--- a/kmip/cryptopolicy-manager/README.md
+++ b/kmip/cryptopolicy-manager/README.md
@@ -21,12 +21,13 @@ restarting it.
 | HTTP (proposed) | `PolicyStore` primitive | Effect |
 |---|---|---|
 | `GET /policies` | `list()` | enumerate policies |
-| `GET /policies/{name}` | `load()` | read one |
-| `POST /policies/validate` | `validate_draft(yaml)` | parse + validate, no disk |
-| `POST /policies/dry-run` | `dry_run(yaml, req)` | evaluate a sample request, no side effects |
+| `GET /policies/{name}` | `load()` + raw YAML | read one (for an editor) |
+| `GET /active` | `read_active()` | what's active now |
+| `GET /audit?limit=N` | `RingSink.snapshot()` | the three-plane audit trail (p1/p2/p3), newest last — the "inspect logs" source |
+| `POST /validate` | `validate_draft(yaml)` | parse + validate, no disk (live lint) |
+| `POST /dry-run` | `dry_run(yaml, {op,algorithm})` | evaluate a sample request, no side effects |
 | `PUT /policies/{name}` | `save(name, yaml)` | persist (atomic) |
 | `POST /policies/{name}/activate` | `activate_with_engine(name, engine)` | **swap the live enforcement policy** |
-| `GET /active` | `read_active()` | what's active now |
 
 ## Consumers
 
@@ -108,6 +109,9 @@ printf 'POST /policies/pqc/activate HTTP/1.1\r\nConnection: close\r\n\r\n' | \
 - `GET /policies`, `GET /active`, `POST /validate` (clean line/col error),
   `POST /dry-run` (`{"decision":{"outcome":"allow"}}`), `PUT /policies/{name}`,
   and **`POST /policies/{name}/activate`** all return correct JSON.
+- **`GET /audit`** returns the live three-plane trail — a pykmip-driven
+  CreateKeyPair shows up as p1 PolicyDecided + p2 KmipRequestReceived/Sent +
+  p3 Pkcs11Call, consumed via the same mTLS admin interface.
 - Live activation flips the running engine (`/active` reflects it immediately)
   and is audited with the client-cert CN:
   `admin: LIVE policy activated name="pqc" fp=… by cn="policy-admin-alice"`.

--- a/kmip/cryptopolicy-manager/manager.rs
+++ b/kmip/cryptopolicy-manager/manager.rs
@@ -103,6 +103,7 @@ pub async fn serve_admin(
     addr: SocketAddr,
     store_root: PathBuf,
     engine: Engine,
+    ring: Arc<crate::auditlog::RingSink>,
     tls: Arc<ServerConfig>,
 ) -> Result<(), AdminError> {
     let listener = TcpListener::bind(addr).await?;
@@ -121,8 +122,9 @@ pub async fn serve_admin(
         let acceptor = acceptor.clone();
         let store_root = store_root.clone();
         let engine = engine.clone();
+        let ring = ring.clone();
         tokio::spawn(async move {
-            if let Err(e) = handle_conn(tcp, acceptor, store_root, engine).await {
+            if let Err(e) = handle_conn(tcp, acceptor, store_root, engine, ring).await {
                 tracing::warn!("admin conn from {peer} ended: {e}");
             }
         });
@@ -134,6 +136,7 @@ async fn handle_conn(
     acceptor: TlsAcceptor,
     store_root: PathBuf,
     engine: Engine,
+    ring: Arc<crate::auditlog::RingSink>,
 ) -> Result<(), AdminError> {
     let mut tls = acceptor.accept(tcp).await?;
     // mTLS already enforced the client cert in the handshake; capture its CN
@@ -150,7 +153,8 @@ async fn handle_conn(
     };
 
     let store = PolicyStore::new(&store_root);
-    let (status, value) = route(&store, &store_root, &engine, &method, &path, &body, client_cn.as_deref());
+    let (status, value) =
+        route(&store, &store_root, &engine, &ring, &method, &path, &body, client_cn.as_deref());
     let resp = http_json(status, &value);
     tls.write_all(&resp).await?;
     tls.shutdown().await.ok();
@@ -163,6 +167,7 @@ fn route(
     store: &PolicyStore,
     store_root: &std::path::Path,
     engine: &Engine,
+    ring: &crate::auditlog::RingSink,
     method: &str,
     path: &str,
     body: &[u8],
@@ -173,6 +178,24 @@ fn route(
             Ok(names) => (200, json!({ "policies": names })),
             Err(e) => store_err(e),
         },
+        // Inspect logs — the three-plane audit trail (p1 policy / p2 KMIP /
+        // p3 PKCS#11) from the in-memory ring, newest events last. The UI's
+        // "inspect logs" section consumes this (correlate by correlation_id).
+        // Optional `?limit=N` caps the tail (default 200).
+        ("GET", p) if p == "/audit" || p.starts_with("/audit?") => {
+            let limit = p
+                .split_once("limit=")
+                .and_then(|(_, v)| v.split('&').next())
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(200)
+                .min(2000);
+            let all = ring.snapshot();
+            let tail = &all[all.len().saturating_sub(limit)..];
+            match serde_json::to_value(tail) {
+                Ok(events) => (200, json!({ "events": events, "total": all.len() })),
+                Err(e) => (500, json!({ "error": e.to_string() })),
+            }
+        }
         ("GET", "/active") => match store.read_active() {
             Ok(Some(m)) => (200, json!({ "name": m.name, "fingerprint": m.fingerprint })),
             Ok(None) => (200, Value::Null),
@@ -389,7 +412,8 @@ mod tests {
     #[test]
     fn route_list_includes_policy() {
         let (dir, store) = store_with("list");
-        let (status, body) = route(&store, &dir, &Engine::deny_all(), "GET", "/policies", b"", None);
+        let ring = crate::auditlog::RingSink::new(8);
+        let (status, body) = route(&store, &dir, &Engine::deny_all(), &ring, "GET", "/policies", b"", None);
         assert_eq!(status, 200);
         assert!(body["policies"].as_array().unwrap().iter().any(|v| v == "p"));
         let _ = std::fs::remove_dir_all(&dir);
@@ -398,7 +422,8 @@ mod tests {
     #[test]
     fn route_unknown_path_404() {
         let (dir, store) = store_with("404");
-        let (status, _) = route(&store, &dir, &Engine::deny_all(), "GET", "/nope", b"", None);
+        let ring = crate::auditlog::RingSink::new(8);
+        let (status, _) = route(&store, &dir, &Engine::deny_all(), &ring, "GET", "/nope", b"", None);
         assert_eq!(status, 404);
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -406,8 +431,9 @@ mod tests {
     #[test]
     fn route_validate_rejects_bad_yaml_400() {
         let (dir, store) = store_with("validate");
+        let ring = crate::auditlog::RingSink::new(8);
         let (status, body) =
-            route(&store, &dir, &Engine::deny_all(), "POST", "/validate", b"not: a policy", None);
+            route(&store, &dir, &Engine::deny_all(), &ring, "POST", "/validate", b"not: a policy", None);
         assert_eq!(status, 400);
         assert!(body["error"].is_string());
         let _ = std::fs::remove_dir_all(&dir);
@@ -416,9 +442,21 @@ mod tests {
     #[test]
     fn route_active_none_is_null() {
         let (dir, store) = store_with("active");
-        let (status, body) = route(&store, &dir, &Engine::deny_all(), "GET", "/active", b"", None);
+        let ring = crate::auditlog::RingSink::new(8);
+        let (status, body) = route(&store, &dir, &Engine::deny_all(), &ring, "GET", "/active", b"", None);
         assert_eq!(status, 200);
         assert!(body.is_null());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn route_audit_empty_ring() {
+        let (dir, store) = store_with("audit");
+        let ring = crate::auditlog::RingSink::new(8);
+        let (status, body) = route(&store, &dir, &Engine::deny_all(), &ring, "GET", "/audit", b"", None);
+        assert_eq!(status, 200);
+        assert_eq!(body["total"], 0);
+        assert!(body["events"].as_array().unwrap().is_empty());
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
Adds **`GET /audit?limit=N`** to the `cryptopolicy-manager` admin facade — the
"inspect logs" data source for the dev-sandbox UI.

Returns the in-memory `RingSink` snapshot (the **p1 policy / p2 KMIP / p3
PKCS#11** audit events, newest last) as JSON over the same mTLS interface. A
`pykmip`-driven op shows up as `PolicyDecided` (p1) + `KmipRequestReceived` /
`KmipResponseSent` (p2) + `Pkcs11Call` (p3), all sharing a `correlation_id`
(`pykmip.audit` groups them into per-request trails).

- `serve_admin` now takes the `RingSink` (threaded from the server's audit sink).
- Router unit tests now 6 (added empty-ring `/audit` case).

**Verified live:** a `pykmip` CreateKeyPair followed by `GET /audit` (brew
Python 3.13, mTLS + `X25519MLKEM768`) returned 5 events `{p1:2, p2:2, p3:1}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)