### PR TITLE
feat(pykmip): locate() + get_attributes() for object enumeration

### DIFF
--- a/kmip/pykmip/client.py
+++ b/kmip/pykmip/client.py
@@ -176,6 +176,21 @@ class KmipClient:
             payload.append(leaf("KeyFormatType", "Enumeration", key_format_type))
         return self.request("Get", *payload)
 
+    def locate(self, *, maximum_items: Optional[int] = None) -> KmipResult:
+        """Locate managed objects. With no filters the server returns every
+        on-line object's UniqueIdentifier (KMIP 3.0 §6.1.32). Pull them with
+        `codec.find_all(result.payload, "UniqueIdentifier")`."""
+        payload = []
+        if maximum_items is not None:
+            payload.append(leaf("MaximumItems", "Integer", maximum_items))
+        return self.request("Locate", *payload)
+
+    def get_attributes(self, uid: str) -> KmipResult:
+        """GetAttributes for `uid` (KMIP 3.0 §6.1.21). No AttributeReference
+        children → the server returns every attribute it knows, wrapped in an
+        `Attributes` structure under the ResponsePayload."""
+        return self.request("GetAttributes", leaf("UniqueIdentifier", "TextString", uid))
+
     def encrypt(
         self,
         uid: str,


### PR DESCRIPTION
## What

Adds two methods to the `pykmip` client so callers can enumerate managed
objects on the agile `pqctoday-kmip` server:

- **`locate()`** — KMIP 3.0 §6.1.32. With no filters, returns every on-line
  object's `UniqueIdentifier` (read via `codec.find_all` on the response).
- **`get_attributes(uid)`** — §6.1.21. With no `AttributeReference` children,
  the server returns every attribute, wrapped in an `Attributes` structure.

Both build on the existing `request()` path. **Client-only** — no change to
the Rust server or `softhsmrustv3`.

## Why

The dev-sandbox **Agility console** (object explorer) needs the KMIP
managed-object view (`Locate` + `GetAttributes`). This is the client half.

## Coupling

Consumed by **pqctoday-sandbox PR #13** (`feat/crypto-agile-kmip-integration`)
via `agile_kms.list_objects()` → `GET /api/v1/kmip/objects`. The `pqc-kmip` /
`kms-proxy` images bake this `pykmip`, so the two PRs should land together.

## Test

Verified live against the running `pqc-kmip`: `GET /api/v1/kmip/objects`
returns managed objects (ML-DSA-44/65 keypairs) with attributes decoded to
names (`ObjectType`, `CryptographicAlgorithm`, `State`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)