### PR TITLE
fix(softhsm): prevent pkcs11-provider host crash at process exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed — pkcs11-provider no longer crashes the host at process exit (2026-06-17)
+
+A program that loads softhsmv3 as an OpenSSL provider (our pkcs11-provider) could
+**segfault at process exit** — intermittently, about two in three `openssl req`
+ML-DSA signing runs. The signing itself always succeeded and the certificate was
+written; the crash came afterwards, during OpenSSL's `atexit` cleanup, so it
+showed up as a non-zero exit code on an otherwise-good operation.
+
+Root cause was a C++ **static-destruction-order** problem, not the crypto.
+OpenSSL's `OPENSSL_cleanup` tears the provider down and calls back into the
+module (`C_CloseSession`, `C_Finalize`) *after* softhsm's global singletons had
+already been destroyed by C++ static destruction — dereferencing freed memory
+(`HandleManager::getSessionShared`), and later a NULL OpenSSL RAND lock.
+
+- **`LeakingPtr`** (new — `src/lib/common/LeakingPtr.h`) replaces the
+  `std::unique_ptr` singletons (`SoftHSM`, `MutexFactory`, `OSSLCryptoFactory`,
+  `SecureMemoryRegistry`). Its destructor does not free, so the module outlives
+  C++ static destruction and stays valid for OpenSSL's late callbacks; `reset()`
+  still frees, so `C_Finalize`/fork do **not** leak during normal operation.
+- **`C_Finalize` process-exit guard** (`SoftHSM_slots.cpp`): an `atexit` sentinel
+  registered in `C_Initialize` (which runs before OpenSSL's cleanup) lets
+  `C_Finalize` skip OpenSSL-touching teardown (RAND / EVP / provider unload)
+  during exit, where those globals are already gone.
+
+Verified: **20/20 clean** `openssl req` ML-DSA certificate generations, was 4/6
+crashing. Long-running servers (`s_server`) were never affected.
+
 ### Added — PQC tooling forks: step-ca, cosign, osslsigncode (ML-DSA, HSM-backed) (2026-06-15)
 
 Three strongSwan-style fork patches (each `<tool>-pqc.patch` + a

--- a/src/bin/util/softhsm2-util.cpp
+++ b/src/bin/util/softhsm2-util.cpp
@@ -68,26 +68,13 @@
 
 // Initialise the one-and-only instance
 
-#ifdef HAVE_CXX11
-
-std::unique_ptr<MutexFactory> MutexFactory::instance(nullptr);
-std::unique_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(nullptr);
+// Leaked at process exit — see LeakingPtr.h (singletons must outlive static destruction)
+LeakingPtr<MutexFactory> MutexFactory::instance(NULL);
+LeakingPtr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
 #if defined(WITH_OPENSSL)
-std::unique_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(nullptr);
+LeakingPtr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
 #else
-std::unique_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(nullptr);
-#endif
-
-#else
-
-std::auto_ptr<MutexFactory> MutexFactory::instance(NULL);
-std::auto_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
-#if defined(WITH_OPENSSL)
-std::auto_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
-#else
-std::auto_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
-#endif
-
+LeakingPtr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
 #endif
 
 // Display the usage

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -223,29 +223,18 @@ void SoftHSM::cleanupKeyPair(AsymmetricAlgorithm* algo,
 
 // Initialise the one-and-only instance
 
-#ifdef HAVE_CXX11
-
-std::unique_ptr<MutexFactory> MutexFactory::instance(nullptr);
-std::unique_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(nullptr);
+// Intentionally leaked at process exit (LeakingPtr) so the PKCS#11 module
+// survives C++ static-destruction ordering and stays valid for late atexit
+// callbacks from OpenSSL provider teardown (C_CloseSession / C_Finalize).
+// reset() still frees, so explicit teardown (C_Finalize, fork) does not leak.
+LeakingPtr<MutexFactory> MutexFactory::instance(NULL);
+LeakingPtr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
 #if defined(WITH_OPENSSL)
-std::unique_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(nullptr);
+LeakingPtr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
 #else
-std::unique_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(nullptr);
+LeakingPtr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
 #endif
-std::unique_ptr<SoftHSM> SoftHSM::instance(nullptr);
-
-#else
-
-std::auto_ptr<MutexFactory> MutexFactory::instance(NULL);
-std::auto_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
-#if defined(WITH_OPENSSL)
-std::auto_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
-#else
-std::auto_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
-#endif
-std::auto_ptr<SoftHSM> SoftHSM::instance(NULL);
-
-#endif
+LeakingPtr<SoftHSM> SoftHSM::instance(NULL);
 
 
 /*****************************************************************************

--- a/src/lib/SoftHSM.h
+++ b/src/lib/SoftHSM.h
@@ -33,6 +33,7 @@
  *****************************************************************************/
 
 #include "config.h"
+#include "LeakingPtr.h"
 #include "log.h"
 #include "cryptoki.h"
 #include "SessionObjectStore.h"
@@ -245,12 +246,8 @@ private:
 	// Constructor
 	SoftHSM();
 
-	// The one-and-only instance
-#ifdef HAVE_CXX11
-	static std::unique_ptr<SoftHSM> instance;
-#else
-	static std::auto_ptr<SoftHSM> instance;
-#endif
+	// The one-and-only instance (leaked at process exit — see LeakingPtr.h)
+	static LeakingPtr<SoftHSM> instance;
 
 	// Is the SoftHSM PKCS #11 library initialised?
 	bool isInitialised;

--- a/src/lib/SoftHSM_slots.cpp
+++ b/src/lib/SoftHSM_slots.cpp
@@ -58,6 +58,23 @@
 #include "BotanCryptoFactory.h"
 #endif
 
+#include <cstdlib>
+
+// Set by an atexit() handler so C_Finalize can tell it is being called during
+// process teardown. The pkcs11-provider unloads us from OpenSSL's OPENSSL_cleanup
+// (an atexit handler), which calls C_Finalize. By then OpenSSL's own globals
+// (RAND method locks, EVP fetch tables) are already being freed, so any teardown
+// that reaches back into OpenSSL — RAND_set_rand_method, EVP_MD_free, provider
+// unload via CryptoFactory::reset — dereferences freed state and crashes.
+//
+// SoftHSM is initialised AFTER OpenSSL, so this handler is registered after
+// OpenSSL's cleanup and therefore runs BEFORE it (atexit is LIFO). When the
+// provider's C_Finalize then runs, the flag is already set and we skip the
+// OpenSSL-touching teardown — the OS reclaims everything at exit. This is the
+// companion to the LeakingPtr singleton-lifetime fix (see LeakingPtr.h).
+static bool g_processExiting = false;
+static void softhsm_mark_exiting() { g_processExiting = true; }
+
 /*****************************************************************************
  Implementation of PKCS #11 functions
  *****************************************************************************/
@@ -66,6 +83,15 @@
 CK_RV SoftHSM::C_Initialize(CK_VOID_PTR pInitArgs)
 {
 	CK_C_INITIALIZE_ARGS_PTR args;
+
+	// Register the process-teardown sentinel once. Done here (after OpenSSL is
+	// up) so it runs before OpenSSL's atexit cleanup — see g_processExiting.
+	static bool exitHandlerRegistered = false;
+	if (!exitHandlerRegistered)
+	{
+		atexit(softhsm_mark_exiting);
+		exitHandlerRegistered = true;
+	}
 
 	// Check if PKCS#11 is already initialized
 	if (isInitialised)
@@ -262,6 +288,17 @@ CK_RV SoftHSM::C_Finalize(CK_VOID_PTR pReserved)
 
 	// Must be set to NULL_PTR in this version of PKCS#11
 	if (pReserved != NULL_PTR) return CKR_ARGUMENTS_BAD;
+
+	// During process teardown (OpenSSL's atexit cleanup unloading the provider),
+	// OpenSSL's globals are already being freed. The cleanup below reaches back
+	// into OpenSSL (RAND_set_rand_method, EVP_MD_free, provider unload), which
+	// would dereference freed state and crash. Skip it — the OS reclaims all of
+	// it at exit. See g_processExiting and LeakingPtr.h.
+	if (g_processExiting)
+	{
+		isInitialised = false;
+		return CKR_OK;
+	}
 
 	if (handleManager != NULL) delete handleManager;
 	handleManager = NULL;

--- a/src/lib/common/LeakingPtr.h
+++ b/src/lib/common/LeakingPtr.h
@@ -1,0 +1,78 @@
+/*
+ * LeakingPtr.h
+ *
+ * A minimal owning smart pointer for PROCESS-LIFETIME singletons.
+ *
+ * It exposes the same {get, reset, operator->, operator*} surface as
+ * std::unique_ptr for the subset SoftHSM's singletons use, with ONE
+ * deliberate difference: its destructor does NOT delete the managed object.
+ * This intentionally "leaks" the singleton at process exit so it survives
+ * C++ static-destruction ordering.
+ *
+ * Why this exists
+ * ---------------
+ * OpenSSL registers OPENSSL_cleanup via atexit(). When a PKCS#11 consumer
+ * (e.g. our pkcs11-provider) is torn down inside that atexit handler, it can
+ * call back into this module (C_CloseSession / C_Finalize). C++ static
+ * destructors run before atexit handlers that were registered earlier, so by
+ * the time OPENSSL_cleanup runs the SoftHSM/MutexFactory/crypto-factory
+ * singletons may already be destroyed. Those late callbacks then dereference
+ * freed memory -> intermittent SIGSEGV (e.g. HandleManager::getSessionShared
+ * via SoftHSM::C_CloseSession during ossl_provider_free).
+ *
+ * Leaking the singletons keeps the module valid until the process is fully
+ * gone; the OS reclaims the memory. A module that crashes the host process at
+ * cleanup is far worse than one that leaks a handful of objects at exit.
+ *
+ * reset() STILL deletes the previous object, so explicit teardown
+ * (C_Finalize -> SoftHSM::reset(), fork handling) does not leak.
+ */
+
+#ifndef _SOFTHSM_V2_LEAKINGPTR_H
+#define _SOFTHSM_V2_LEAKINGPTR_H
+
+#include <cstddef>
+
+template <typename T>
+class LeakingPtr
+{
+public:
+	explicit LeakingPtr(T* ptr = NULL) : p(ptr) { }
+
+	// Intentionally does NOT delete p: the singleton must outlive
+	// C++ static destruction so late atexit callbacks stay valid.
+	~LeakingPtr() { }
+
+	T* get() const { return p; }
+	T* operator->() const { return p; }
+	T& operator*() const { return *p; }
+
+	// Mirror std::unique_ptr's explicit bool conversion so existing call
+	// sites like `if (!instance)` / `if (instance)` keep working unchanged.
+	explicit operator bool() const { return p != NULL; }
+
+	// Explicit lifetime management DOES free, so C_Finalize/fork do not leak.
+	void reset(T* ptr = NULL)
+	{
+		if (p != ptr)
+		{
+			delete p;
+			p = ptr;
+		}
+	}
+
+	T* release()
+	{
+		T* old = p;
+		p = NULL;
+		return old;
+	}
+
+private:
+	LeakingPtr(const LeakingPtr&);
+	LeakingPtr& operator=(const LeakingPtr&);
+
+	T* p;
+};
+
+#endif // !_SOFTHSM_V2_LEAKINGPTR_H

--- a/src/lib/common/MutexFactory.h
+++ b/src/lib/common/MutexFactory.h
@@ -36,6 +36,7 @@
 #include "config.h"
 #include "osmutex.h"
 #include "cryptoki.h"
+#include "LeakingPtr.h"
 #include <memory>
 
 class Mutex
@@ -112,12 +113,8 @@ private:
 	CK_RV LockMutex(CK_VOID_PTR mutex);
 	CK_RV UnlockMutex(CK_VOID_PTR mutex);
 
-	// The one-and-only instance
-#ifdef HAVE_CXX11
-	static std::unique_ptr<MutexFactory> instance;
-#else
-	static std::auto_ptr<MutexFactory> instance;
-#endif
+	// The one-and-only instance (leaked at process exit — see LeakingPtr.h)
+	static LeakingPtr<MutexFactory> instance;
 
 	// The function pointers
 	CK_CREATEMUTEX createMutex;

--- a/src/lib/crypto/OSSLCryptoFactory.h
+++ b/src/lib/crypto/OSSLCryptoFactory.h
@@ -37,6 +37,7 @@
 #define _SOFTHSM_V2_OSSLCRYPTOFACTORY_H
 
 #include "config.h"
+#include "LeakingPtr.h"
 #include "CryptoFactory.h"
 #include "SymmetricAlgorithm.h"
 #include "AsymmetricAlgorithm.h"
@@ -76,8 +77,8 @@ private:
 	// Constructor
 	OSSLCryptoFactory();
 
-	// The one-and-only instance
-	static std::unique_ptr<OSSLCryptoFactory> instance;
+	// The one-and-only instance (leaked at process exit — see LeakingPtr.h)
+	static LeakingPtr<OSSLCryptoFactory> instance;
 
 	// The one-and-only RNG instance
 	RNG* rng;

--- a/src/lib/crypto/test/cryptotest.cpp
+++ b/src/lib/crypto/test/cryptotest.cpp
@@ -56,22 +56,22 @@
 // Initialise the one-and-only instance
 #ifdef HAVE_CXX11
 
-std::unique_ptr<MutexFactory> MutexFactory::instance(nullptr);
-std::unique_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(nullptr);
+LeakingPtr<MutexFactory> MutexFactory::instance(nullptr);
+LeakingPtr<SecureMemoryRegistry> SecureMemoryRegistry::instance(nullptr);
 #if defined(WITH_OPENSSL)
-std::unique_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(nullptr);
+LeakingPtr<OSSLCryptoFactory> OSSLCryptoFactory::instance(nullptr);
 #else
-std::unique_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(nullptr);
+LeakingPtr<BotanCryptoFactory> BotanCryptoFactory::instance(nullptr);
 #endif
 
 #else
 
-std::auto_ptr<MutexFactory> MutexFactory::instance(NULL);
-std::auto_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
+LeakingPtr<MutexFactory> MutexFactory::instance(NULL);
+LeakingPtr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
 #if defined(WITH_OPENSSL)
-std::auto_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
+LeakingPtr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
 #else
-std::auto_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
+LeakingPtr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
 #endif
 
 #endif

--- a/src/lib/data_mgr/SecureMemoryRegistry.h
+++ b/src/lib/data_mgr/SecureMemoryRegistry.h
@@ -39,6 +39,7 @@
 #include <map>
 #include <memory>
 #include "MutexFactory.h"
+#include "LeakingPtr.h"
 
 class SecureMemoryRegistry
 {
@@ -58,11 +59,8 @@ public:
 	void wipe();
 
 private:
-#ifdef HAVE_CXX11
-	static std::unique_ptr<SecureMemoryRegistry> instance;
-#else
-	static std::auto_ptr<SecureMemoryRegistry> instance;
-#endif
+	// Leaked at process exit — see LeakingPtr.h
+	static LeakingPtr<SecureMemoryRegistry> instance;
 
 	std::map<void*, size_t> registry;
 

--- a/src/lib/data_mgr/test/datamgrtest.cpp
+++ b/src/lib/data_mgr/test/datamgrtest.cpp
@@ -53,22 +53,22 @@
 // Initialise the one-and-only instance
 #ifdef HAVE_CXX11
 
-std::unique_ptr<MutexFactory> MutexFactory::instance(nullptr);
-std::unique_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(nullptr);
+LeakingPtr<MutexFactory> MutexFactory::instance(nullptr);
+LeakingPtr<SecureMemoryRegistry> SecureMemoryRegistry::instance(nullptr);
 #if defined(WITH_OPENSSL)
-std::unique_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(nullptr);
+LeakingPtr<OSSLCryptoFactory> OSSLCryptoFactory::instance(nullptr);
 #else
-std::unique_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(nullptr);
+LeakingPtr<BotanCryptoFactory> BotanCryptoFactory::instance(nullptr);
 #endif
 
 #else
 
-std::auto_ptr<MutexFactory> MutexFactory::instance(NULL);
-std::auto_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
+LeakingPtr<MutexFactory> MutexFactory::instance(NULL);
+LeakingPtr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
 #if defined(WITH_OPENSSL)
-std::auto_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
+LeakingPtr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
 #else
-std::auto_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
+LeakingPtr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
 #endif
 
 #endif

--- a/src/lib/handle_mgr/test/handlemgrtest.cpp
+++ b/src/lib/handle_mgr/test/handlemgrtest.cpp
@@ -49,9 +49,9 @@
 #include "MutexFactory.h"
 
 #ifdef HAVE_CXX11
-std::unique_ptr<MutexFactory> MutexFactory::instance(nullptr);
+LeakingPtr<MutexFactory> MutexFactory::instance(nullptr);
 #else
-std::auto_ptr<MutexFactory> MutexFactory::instance(NULL);
+LeakingPtr<MutexFactory> MutexFactory::instance(NULL);
 #endif
 
 class MyProgressListener : public CppUnit::TextTestProgressListener

--- a/src/lib/object_store/test/objstoretest.cpp
+++ b/src/lib/object_store/test/objstoretest.cpp
@@ -53,22 +53,22 @@
 // Initialise the one-and-only instance
 #ifdef HAVE_CXX11
 
-std::unique_ptr<MutexFactory> MutexFactory::instance(nullptr);
-std::unique_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(nullptr);
+LeakingPtr<MutexFactory> MutexFactory::instance(nullptr);
+LeakingPtr<SecureMemoryRegistry> SecureMemoryRegistry::instance(nullptr);
 #if defined(WITH_OPENSSL)
-std::unique_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(nullptr);
+LeakingPtr<OSSLCryptoFactory> OSSLCryptoFactory::instance(nullptr);
 #else
-std::unique_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(nullptr);
+LeakingPtr<BotanCryptoFactory> BotanCryptoFactory::instance(nullptr);
 #endif
 
 #else
 
-std::auto_ptr<MutexFactory> MutexFactory::instance(NULL);
-std::auto_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
+LeakingPtr<MutexFactory> MutexFactory::instance(NULL);
+LeakingPtr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
 #if defined(WITH_OPENSSL)
-std::auto_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
+LeakingPtr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
 #else
-std::auto_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
+LeakingPtr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
 #endif
 
 #endif

--- a/src/lib/session_mgr/test/sessionmgrtest.cpp
+++ b/src/lib/session_mgr/test/sessionmgrtest.cpp
@@ -59,22 +59,22 @@
 // Initialise the one-and-only instance
 #ifdef HAVE_CXX11
 
-std::unique_ptr<MutexFactory> MutexFactory::instance(nullptr);
-std::unique_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(nullptr);
+LeakingPtr<MutexFactory> MutexFactory::instance(nullptr);
+LeakingPtr<SecureMemoryRegistry> SecureMemoryRegistry::instance(nullptr);
 #if defined(WITH_OPENSSL)
-std::unique_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(nullptr);
+LeakingPtr<OSSLCryptoFactory> OSSLCryptoFactory::instance(nullptr);
 #else
-std::unique_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(nullptr);
+LeakingPtr<BotanCryptoFactory> BotanCryptoFactory::instance(nullptr);
 #endif
 
 #else
 
-std::auto_ptr<MutexFactory> MutexFactory::instance(NULL);
-std::auto_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
+LeakingPtr<MutexFactory> MutexFactory::instance(NULL);
+LeakingPtr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
 #if defined(WITH_OPENSSL)
-std::auto_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
+LeakingPtr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
 #else
-std::auto_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
+LeakingPtr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
 #endif
 
 #endif

--- a/src/lib/slot_mgr/test/slotmgrtest.cpp
+++ b/src/lib/slot_mgr/test/slotmgrtest.cpp
@@ -53,22 +53,22 @@
 // Initialise the one-and-only instance
 #ifdef HAVE_CXX11
 
-std::unique_ptr<MutexFactory> MutexFactory::instance(nullptr);
-std::unique_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(nullptr);
+LeakingPtr<MutexFactory> MutexFactory::instance(nullptr);
+LeakingPtr<SecureMemoryRegistry> SecureMemoryRegistry::instance(nullptr);
 #if defined(WITH_OPENSSL)
-std::unique_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(nullptr);
+LeakingPtr<OSSLCryptoFactory> OSSLCryptoFactory::instance(nullptr);
 #else
-std::unique_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(nullptr);
+LeakingPtr<BotanCryptoFactory> BotanCryptoFactory::instance(nullptr);
 #endif
 
 #else
 
-std::auto_ptr<MutexFactory> MutexFactory::instance(NULL);
-std::auto_ptr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
+LeakingPtr<MutexFactory> MutexFactory::instance(NULL);
+LeakingPtr<SecureMemoryRegistry> SecureMemoryRegistry::instance(NULL);
 #if defined(WITH_OPENSSL)
-std::auto_ptr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
+LeakingPtr<OSSLCryptoFactory> OSSLCryptoFactory::instance(NULL);
 #else
-std::auto_ptr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
+LeakingPtr<BotanCryptoFactory> BotanCryptoFactory::instance(NULL);
 #endif
 
 #endif


### PR DESCRIPTION
## What

A program loading softhsmv3 as an OpenSSL provider (our pkcs11-provider) could **segfault at process exit** — intermittently (~67% of `openssl req` ML-DSA signing runs). The crypto always succeeded and the cert was written; the crash came afterward during OpenSSL's `atexit` cleanup, surfacing as a non-zero exit on a good op.

## Root cause

C++ **static-destruction-order**, not crypto. `OPENSSL_cleanup` tears the provider down and calls back into the module (`C_CloseSession`, `C_Finalize`) *after* softhsm's global `unique_ptr` singletons were already destroyed → use-after-free in `HandleManager::getSessionShared`, then a NULL OpenSSL RAND lock in `C_Finalize`.

## Fix

- **`LeakingPtr`** (new, `src/lib/common/LeakingPtr.h`) replaces the `std::unique_ptr` singletons (`SoftHSM`, `MutexFactory`, `OSSLCryptoFactory`, `SecureMemoryRegistry`). Its destructor does **not** free (module survives static destruction, stays valid for OpenSSL's late callbacks); `reset()` **still** frees, so `C_Finalize`/fork do not leak in normal operation.
- **`C_Finalize` process-exit guard** (`SoftHSM_slots.cpp`): an `atexit` sentinel registered in `C_Initialize` (runs before `OPENSSL_cleanup`) lets `C_Finalize` skip OpenSSL-touching teardown (RAND/EVP/provider) during exit.

## Verification

**20/20 clean** `openssl req` ML-DSA cert-generations (was 4/6 crashing); re-validated on the current `main` base (compiles + 12/12 clean). Long-running `s_server` was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)