### PR TITLE
fix(wasm): set EMSCRIPTEN=1 in emscripten toolchain so build-wasm.sh emits .js

### DIFF
--- a/cmake/toolchain/emscripten.cmake
+++ b/cmake/toolchain/emscripten.cmake
@@ -10,6 +10,7 @@
 
 set(CMAKE_SYSTEM_NAME Emscripten)
 set(CMAKE_SYSTEM_VERSION 1)
+set(EMSCRIPTEN 1)
 
 # Locate emcc — must be in PATH (provided by emcmake wrapper or manual source)
 find_program(EMCC emcc REQUIRED)


### PR DESCRIPTION
The custom emscripten toolchain (`cmake/toolchain/emscripten.cmake`) is passed via `-DCMAKE_TOOLCHAIN_FILE`, which overrides emscripten's own toolchain — the only thing that sets the legacy `EMSCRIPTEN` CMake variable (`Platform/Emscripten.cmake:296`). Newer bundled CMake (3.28, in emsdk 5.0.7/6.x) doesn't set it either.

Without `EMSCRIPTEN`, the `if(EMSCRIPTEN)` guard at `src/lib/CMakeLists.txt:95` (which sets `SUFFIX .js` + `MODULARIZE=1`) is skipped, so `build-wasm.sh` links a `libsofthsmv3.so` side-module instead of the `libsofthsmv3.js` main module it then looks for — and aborts with "Expected output not found".

**Fix:** one line — `set(EMSCRIPTEN 1)` in the toolchain file, restoring the value emscripten's own toolchain would provide.

**Verified:** on a clean `emscripten/emsdk:5.0.7`, `bash scripts/build-wasm.sh` now produces `wasm/softhsm.js` (88K) + `wasm/softhsm.wasm` (2.3M). No build-logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)