### PR TITLE
feat(openssh-wasm): PKCS#11 trace-tap + selectable KEX/host-key profile

### DIFF
--- a/kmip/Cargo.lock
+++ b/kmip/Cargo.lock
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "asn1-rs"
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -852,7 +852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "102d3643d30dd8b559613c5cced68317199597fffb278cdc88daa2ef7fafc935"
 dependencies = [
  "base16ct 1.0.0",
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.5",
  "crypto-common 0.2.2",
  "ff 0.14.0",
  "group 0.14.0",

--- a/openssh-pkcs11/CHANGELOG.md
+++ b/openssh-pkcs11/CHANGELOG.md
@@ -7,6 +7,23 @@ file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
+### Added — selectable KEX + host-key profile and an in-WASM PKCS#11 trace tap (2026-06-27)
+
+For the hub playground integration:
+
+- **`set_handshake_config(kex, hostalg)`** — the driver now runs a selectable
+  profile instead of the hardcoded combo. Two host-key types provision on the
+  token and sign via the real provider path: `ssh-mldsa-65` (ML-DSA-65,
+  `CKM_ML_DSA`) and `ecdsa-sha2-nistp256` (ECDSA P-256, `CKM_ECDSA`); KEX is any
+  compiled algorithm (`mlkem768x25519-sha256`, `curve25519-sha256`,
+  `ecdh-sha2-nistp*`). Enables a real-vs-real classical/PQC comparison in the UI.
+- **PKCS#11 trace tap** — `pkcs11_static.c` hands OpenSSH's provider a wrapped
+  function list that emits a `pkcs11` event per `C_Login` / `C_FindObjects` /
+  `C_GetAttributeValue` / `C_SignInit` / `C_Sign` before delegating to softhsm,
+  so the hub can render the genuine call sequence (including the two `C_Sign`
+  operations) without touching the generated OpenSSH source. The provisioning
+  `C_GenerateKeyPair` is emitted from the shim.
+
 ### Added — the WASM bundle now runs a real, end-to-end post-quantum SSH handshake (2026-06-27)
 
 The OpenSSH WASM build is no longer a scaffold: it links cleanly and runs a

--- a/openssh-pkcs11/scripts/build-wasm.sh
+++ b/openssh-pkcs11/scripts/build-wasm.sh
@@ -251,7 +251,7 @@ SSHD_SHIM_OBJS="$ROOT/build/sshd-wasm/sshd_wasm_main.o $ROOT/build/sshd-wasm/ssh
         -L. -Lopenbsd-compat/ -L${OPENSSL_WASM}/lib \
         ${SSHD_SHIM_OBJS} \
         -Wl,--wrap,lib_contains_symbol \
-        -s EXPORTED_FUNCTIONS=['___wrap_main','_C_GetFunctionList'] \
+        -s EXPORTED_FUNCTIONS=['___wrap_main','_set_handshake_config','_C_GetFunctionList'] \
         ${COMMON_LIBS}")
 
 echo "[openssh-pkcs11] Building ssh WASM with ${NCPU} jobs..."

--- a/openssh-pkcs11/wasm-shims/pkcs11_static.c
+++ b/openssh-pkcs11/wasm-shims/pkcs11_static.c
@@ -16,10 +16,89 @@
 #include "includes.h"
 #include <dlfcn.h>
 #include <string.h>
+#include <stdio.h>
 #include "pkcs11.h"   /* CK_RV, CK_FUNCTION_LIST_PTR_PTR (softhsm headers, on the build -I path) */
 
 /* Forward-declare softhsmv3's function-list entry point. */
 extern CK_RV C_GetFunctionList(CK_FUNCTION_LIST_PTR_PTR ppFunctionList);
+
+/* ── PKCS#11 trace tap ────────────────────────────────────────────────────────
+ * OpenSSH's provider gets its CK_FUNCTION_LIST through dlsym("C_GetFunctionList")
+ * below. We hand back a WRAPPED list: a copy of softhsm's real list with the
+ * provider-path entries (login, object lookup, signing) replaced by thin wrappers
+ * that emit a "pkcs11" UI event, then delegate to the real function. This makes
+ * the playground's PKCS#11 panel show the genuine calls — including the C_Sign
+ * that proves the private key never leaves the token — without touching the
+ * generated OpenSSH source. wasm_emit_event is the same EM_JS hook the handshake
+ * driver uses (defined in sshd_wasm_main.c, linked into this binary). */
+extern void wasm_emit_event(const char *type, const char *payload);
+
+static CK_FUNCTION_LIST *p11_real = NULL;   /* softhsm's real list */
+static CK_FUNCTION_LIST  p11_wrapped;       /* copy with tapped entries */
+
+static void trace_emit(const char *json) { wasm_emit_event("pkcs11", json); }
+
+static CK_RV tap_C_Login(CK_SESSION_HANDLE s, CK_USER_TYPE ut, CK_UTF8CHAR_PTR pin, CK_ULONG plen) {
+    char j[96];
+    snprintf(j, sizeof j, "{\"op\":\"C_Login\",\"userType\":%lu}", (unsigned long)ut);
+    trace_emit(j);
+    return p11_real->C_Login(s, ut, pin, plen);
+}
+static CK_RV tap_C_FindObjectsInit(CK_SESSION_HANDLE s, CK_ATTRIBUTE_PTR t, CK_ULONG n) {
+    char j[96];
+    snprintf(j, sizeof j, "{\"op\":\"C_FindObjectsInit\",\"attrs\":%lu}", (unsigned long)n);
+    trace_emit(j);
+    return p11_real->C_FindObjectsInit(s, t, n);
+}
+static CK_RV tap_C_FindObjects(CK_SESSION_HANDLE s, CK_OBJECT_HANDLE_PTR o, CK_ULONG max, CK_ULONG_PTR n) {
+    CK_RV rv = p11_real->C_FindObjects(s, o, max, n);
+    char j[96];
+    snprintf(j, sizeof j, "{\"op\":\"C_FindObjects\",\"found\":%lu,\"rv\":%lu}",
+             (unsigned long)(n ? *n : 0), (unsigned long)rv);
+    trace_emit(j);
+    return rv;
+}
+static CK_RV tap_C_GetAttributeValue(CK_SESSION_HANDLE s, CK_OBJECT_HANDLE o, CK_ATTRIBUTE_PTR t, CK_ULONG n) {
+    CK_RV rv = p11_real->C_GetAttributeValue(s, o, t, n);
+    char j[112];
+    snprintf(j, sizeof j, "{\"op\":\"C_GetAttributeValue\",\"attrs\":%lu,\"rv\":%lu}",
+             (unsigned long)n, (unsigned long)rv);
+    trace_emit(j);
+    return rv;
+}
+static CK_RV tap_C_SignInit(CK_SESSION_HANDLE s, CK_MECHANISM_PTR m, CK_OBJECT_HANDLE k) {
+    char j[112];
+    snprintf(j, sizeof j, "{\"op\":\"C_SignInit\",\"mech\":%lu,\"key\":%lu}",
+             (unsigned long)(m ? m->mechanism : 0), (unsigned long)k);
+    trace_emit(j);
+    return p11_real->C_SignInit(s, m, k);
+}
+static CK_RV tap_C_Sign(CK_SESSION_HANDLE s, CK_BYTE_PTR d, CK_ULONG dlen, CK_BYTE_PTR sig, CK_ULONG_PTR slen) {
+    CK_RV rv = p11_real->C_Sign(s, d, dlen, sig, slen);
+    char j[144];
+    /* pSignature == NULL is the length-query call; otherwise the real signing. */
+    snprintf(j, sizeof j, "{\"op\":\"C_Sign\",\"dataLen\":%lu,\"sigLen\":%lu,\"query\":%d,\"rv\":%lu}",
+             (unsigned long)dlen, (unsigned long)(slen ? *slen : 0), sig ? 0 : 1, (unsigned long)rv);
+    trace_emit(j);
+    return rv;
+}
+
+/* Build (once) and return the wrapped function list. */
+static CK_RV wrapped_GetFunctionList(CK_FUNCTION_LIST_PTR_PTR pp) {
+    if (p11_real == NULL) {
+        CK_RV rv = C_GetFunctionList(&p11_real);
+        if (rv != CKR_OK) return rv;
+        p11_wrapped = *p11_real;                 /* copy all real entries */
+        p11_wrapped.C_Login            = tap_C_Login;
+        p11_wrapped.C_FindObjectsInit  = tap_C_FindObjectsInit;
+        p11_wrapped.C_FindObjects      = tap_C_FindObjects;
+        p11_wrapped.C_GetAttributeValue= tap_C_GetAttributeValue;
+        p11_wrapped.C_SignInit         = tap_C_SignInit;
+        p11_wrapped.C_Sign             = tap_C_Sign;
+    }
+    if (pp) *pp = &p11_wrapped;
+    return CKR_OK;
+}
 
 /* There is no .so to load in WASM (softhsm is statically linked), and softhsm has
  * no involvement in the dynamic-linker "handle" that dlopen() normally returns.
@@ -29,10 +108,12 @@ extern CK_RV C_GetFunctionList(CK_FUNCTION_LIST_PTR_PTR ppFunctionList);
  * same real entry point — so the caller gets softhsm's actual C_GetFunctionList. */
 void *dlopen(const char *filename, int flags) {
     (void)flags;
-    /* Accept any name that looks like softhsmv3 */
+    /* Accept any name that looks like softhsmv3. Hand back the WRAPPED entry
+     * point as the opaque handle so the provider's calls flow through the trace
+     * tap (and on to softhsm's real functions). */
     if (filename &&
         (strstr(filename, "softhsm") || strstr(filename, "libpkcs11"))) {
-        return (void *)C_GetFunctionList;
+        return (void *)wrapped_GetFunctionList;
     }
     /* For anything else (e.g. OpenSSL providers loaded by pkcs11-provider)
      * return NULL — they are not needed in the WASM build. */
@@ -40,9 +121,9 @@ void *dlopen(const char *filename, int flags) {
 }
 
 void *dlsym(void *handle, const char *symbol) {
-    if (handle == (void *)C_GetFunctionList &&
+    if (handle == (void *)wrapped_GetFunctionList &&
         symbol && strcmp(symbol, "C_GetFunctionList") == 0) {
-        return (void *)C_GetFunctionList;
+        return (void *)wrapped_GetFunctionList;
     }
     return NULL;
 }

--- a/openssh-pkcs11/wasm-shims/sshd_wasm_main.c
+++ b/openssh-pkcs11/wasm-shims/sshd_wasm_main.c
@@ -97,6 +97,40 @@ static CK_OBJECT_HANDLE   g_host_key = CK_INVALID_HANDLE;
 #define SM1_SO_PIN   "12345678"
 #define SM1_USER_PIN "1234"
 
+/* EC / ECDSA constants (classical host-key profile). Values from PKCS#11 v3.2
+ * pkcs11t.h; guards are belt-and-suspenders for header drift. */
+#ifndef CKK_EC
+#define CKK_EC 0x00000003UL
+#endif
+#ifndef CKM_EC_KEY_PAIR_GEN
+#define CKM_EC_KEY_PAIR_GEN 0x00001040UL
+#endif
+#ifndef CKM_ECDSA
+#define CKM_ECDSA 0x00001041UL
+#endif
+/* DER OID for prime256v1 / NIST P-256 (1.2.840.10045.3.1.7). */
+static const CK_BYTE EC_PARAMS_P256[] = {
+    0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07
+};
+
+/* ── Handshake config (set from JS via set_handshake_config before __wrap_main) ──
+ * Selects the KEX and the host-key profile. Defaults reproduce the original
+ * hardcoded PQC run (mlkem768x25519-sha256 + ssh-mldsa-65). */
+enum { HOSTKEY_MLDSA65 = 0, HOSTKEY_ECDSA_P256 = 1 };
+static char g_cfg_kex[64]     = "mlkem768x25519-sha256";
+static char g_cfg_hostalg[40] = "ssh-mldsa-65";
+static int  g_cfg_keytype     = HOSTKEY_MLDSA65;
+
+EMSCRIPTEN_KEEPALIVE
+void set_handshake_config(const char *kex, const char *hostalg) {
+    if (kex && *kex)     { strncpy(g_cfg_kex, kex, sizeof g_cfg_kex - 1);
+                           g_cfg_kex[sizeof g_cfg_kex - 1] = '\0'; }
+    if (hostalg && *hostalg) { strncpy(g_cfg_hostalg, hostalg, sizeof g_cfg_hostalg - 1);
+                               g_cfg_hostalg[sizeof g_cfg_hostalg - 1] = '\0'; }
+    g_cfg_keytype = (strcmp(g_cfg_hostalg, "ecdsa-sha2-nistp256") == 0)
+                        ? HOSTKEY_ECDSA_P256 : HOSTKEY_MLDSA65;
+}
+
 static void emit_rv(const char *ctx, CK_RV rv) {
     char buf[96];
     snprintf(buf, sizeof buf, "%s rv=0x%lx", ctx, (unsigned long)rv);
@@ -158,40 +192,72 @@ static int pkcs11_bootstrap(void) {
 static int sm1_provision(void) {
     CK_OBJECT_CLASS pub_cls  = CKO_PUBLIC_KEY;
     CK_OBJECT_CLASS priv_cls = CKO_PRIVATE_KEY;
-    CK_KEY_TYPE     kt        = CKK_ML_DSA;
-    CK_ULONG        pset      = CKP_ML_DSA_65;
     CK_BBOOL        yes       = CK_TRUE;
     CK_BBOOL        no        = CK_FALSE;
     static const CK_BYTE host_id[] = { 's','s','h','d','-','h','o','s','t','-','k','e','y' };
 
-    CK_ATTRIBUTE pub_tmpl[] = {
-        { CKA_CLASS,         &pub_cls, sizeof pub_cls },
-        { CKA_KEY_TYPE,      &kt,      sizeof kt      },
-        { CKA_TOKEN,         &yes,     sizeof yes     },
-        { CKA_VERIFY,        &yes,     sizeof yes     },
-        { CKA_PARAMETER_SET, &pset,    sizeof pset    },
-        { CKA_ID,            (void*)host_id, sizeof host_id },
-    };
-    CK_ATTRIBUTE priv_tmpl[] = {
-        { CKA_CLASS,       &priv_cls, sizeof priv_cls },
-        { CKA_KEY_TYPE,    &kt,       sizeof kt       },
-        { CKA_TOKEN,       &yes,      sizeof yes      },
-        { CKA_PRIVATE,     &yes,      sizeof yes      },
-        { CKA_SIGN,        &yes,      sizeof yes      },
-        { CKA_EXTRACTABLE, &no,       sizeof no       },
-        { CKA_ID,          (void*)host_id, sizeof host_id },
-    };
-    CK_MECHANISM gen = { CKM_ML_DSA_KEY_PAIR_GEN, NULL_PTR, 0 };
+    /* Key-type-specific bits. */
+    CK_KEY_TYPE  kt;
+    CK_ULONG     pset = CKP_ML_DSA_65;       /* ML-DSA only */
+    CK_MECHANISM gen;
+    const char  *trace_key;
+    long         trace_mech;
+
+    /* Pub/priv templates are built per type below (ML-DSA uses CKA_PARAMETER_SET;
+     * ECDSA uses CKA_EC_PARAMS). */
+    CK_ATTRIBUTE pub_tmpl[6];
+    CK_ATTRIBUTE priv_tmpl[7];
+    CK_ULONG npub, npriv;
+
+    if (g_cfg_keytype == HOSTKEY_ECDSA_P256) {
+        kt = CKK_EC;
+        gen.mechanism = CKM_EC_KEY_PAIR_GEN; gen.pParameter = NULL_PTR; gen.ulParameterLen = 0;
+        trace_key = "ECDSA P-256 host key"; trace_mech = (long)CKM_EC_KEY_PAIR_GEN;
+        CK_ATTRIBUTE p[] = {
+            { CKA_CLASS,     &pub_cls, sizeof pub_cls },
+            { CKA_KEY_TYPE,  &kt,      sizeof kt      },
+            { CKA_TOKEN,     &yes,     sizeof yes     },
+            { CKA_VERIFY,    &yes,     sizeof yes     },
+            { CKA_EC_PARAMS, (void*)EC_PARAMS_P256, sizeof EC_PARAMS_P256 },
+            { CKA_ID,        (void*)host_id, sizeof host_id },
+        };
+        memcpy(pub_tmpl, p, sizeof p); npub = 6;
+    } else {
+        kt = CKK_ML_DSA;
+        gen.mechanism = CKM_ML_DSA_KEY_PAIR_GEN; gen.pParameter = NULL_PTR; gen.ulParameterLen = 0;
+        trace_key = "ML-DSA-65 host key"; trace_mech = (long)CKM_ML_DSA_KEY_PAIR_GEN;
+        CK_ATTRIBUTE p[] = {
+            { CKA_CLASS,         &pub_cls, sizeof pub_cls },
+            { CKA_KEY_TYPE,      &kt,      sizeof kt      },
+            { CKA_TOKEN,         &yes,     sizeof yes     },
+            { CKA_VERIFY,        &yes,     sizeof yes     },
+            { CKA_PARAMETER_SET, &pset,    sizeof pset    },
+            { CKA_ID,            (void*)host_id, sizeof host_id },
+        };
+        memcpy(pub_tmpl, p, sizeof p); npub = 6;
+    }
+    {
+        CK_ATTRIBUTE pr[] = {
+            { CKA_CLASS,       &priv_cls, sizeof priv_cls },
+            { CKA_KEY_TYPE,    &kt,       sizeof kt       },
+            { CKA_TOKEN,       &yes,      sizeof yes      },
+            { CKA_PRIVATE,     &yes,      sizeof yes      },
+            { CKA_SIGN,        &yes,      sizeof yes      },
+            { CKA_EXTRACTABLE, &no,       sizeof no       },
+            { CKA_ID,          (void*)host_id, sizeof host_id },
+        };
+        memcpy(priv_tmpl, pr, sizeof pr); npriv = 7;
+    }
+
     CK_OBJECT_HANDLE hPub = CK_INVALID_HANDLE, hPriv = CK_INVALID_HANDLE;
-    CK_RV rv = g_p11->C_GenerateKeyPair(g_session, &gen,
-        pub_tmpl,  sizeof pub_tmpl  / sizeof pub_tmpl[0],
-        priv_tmpl, sizeof priv_tmpl / sizeof priv_tmpl[0],
+    CK_RV rv = g_p11->C_GenerateKeyPair(g_session, &gen, pub_tmpl, npub, priv_tmpl, npriv,
         &hPub, &hPriv);
     if (rv != CKR_OK) { emit_rv("C_GenerateKeyPair", rv); return -1; }
     /* PKCS#11 trace: the host keypair is generated ON the token (shim-direct call,
      * so it isn't seen by the provider-path tap in pkcs11_static.c — emit it here). */
-    wasm_emit_event("pkcs11",
-        "{\"op\":\"C_GenerateKeyPair\",\"mech\":28,\"key\":\"ML-DSA-65 host key\"}");
+    { char b[96]; snprintf(b, sizeof b,
+        "{\"op\":\"C_GenerateKeyPair\",\"mech\":%ld,\"key\":\"%s\"}", trace_mech, trace_key);
+      wasm_emit_event("pkcs11", b); }
     wasm_emit_event("provisioned", "{\"key\":\"sshd-host-key\"}");
     return 0;
 }
@@ -213,9 +279,12 @@ static int pkcs11_find_host_key(void) {
     return 0;
 }
 
-/* SM1 proof: one single-part ML-DSA C_Sign with the token host key. */
+/* SM1 proof: one single-part C_Sign with the token host key (mechanism per the
+ * selected host-key profile). For ECDSA the input is a 32-byte digest; for
+ * ML-DSA (pure) it is the message itself. */
 static int sm1_prove_sign(void) {
-    CK_MECHANISM mech = { CKM_ML_DSA, NULL_PTR, 0 };
+    CK_MECHANISM mech = { (g_cfg_keytype == HOSTKEY_ECDSA_P256) ? CKM_ECDSA : CKM_ML_DSA,
+                          NULL_PTR, 0 };
     CK_BYTE data[32]; memset(data, 0xA5, sizeof data);
     CK_RV rv = g_p11->C_SignInit(g_session, &mech, g_host_key);
     if (rv != CKR_OK) { emit_rv("C_SignInit", rv); return -1; }
@@ -273,7 +342,7 @@ static int do_userauth(struct ssh *client, struct ssh *server, struct sshkey *au
     char *user = NULL, *service = NULL, *method = NULL, *alg = NULL;
     struct sshkey *recv_key = NULL;
     int r, g, ret = -1;
-    const char *U = "pqcuser", *SVC = "ssh-connection", *M = "publickey", *A = "ssh-mldsa-65";
+    const char *U = "pqcuser", *SVC = "ssh-connection", *M = "publickey", *A = g_cfg_hostalg;
 
     if ((b = sshbuf_new()) == NULL) { wasm_emit_event("error", "userauth sshbuf_new"); return -1; }
 
@@ -320,7 +389,9 @@ static int do_userauth(struct ssh *client, struct ssh *server, struct sshkey *au
     if ((r = sshkey_verify(recv_key, rsig, rsiglen, sshbuf_ptr(b), sshbuf_len(b),
         alg, server->compat, NULL)) != 0) { emit_rv("ua sshkey_verify", (CK_RV)r); goto out; }
     if (!sshkey_equal_public(recv_key, authkey)) { wasm_emit_event("error", "ua key not authorized"); goto out; }
-    wasm_emit_event("userauth_verified", "{\"method\":\"publickey\",\"alg\":\"ssh-mldsa-65\",\"verify\":\"sshkey_verify\"}");
+    { char e[120]; snprintf(e, sizeof e,
+        "{\"method\":\"publickey\",\"alg\":\"%s\",\"verify\":\"sshkey_verify\"}", g_cfg_hostalg);
+      wasm_emit_event("userauth_verified", e); }
     if ((r = sshpkt_start(server, SSH2_MSG_USERAUTH_SUCCESS)) != 0 ||
         (r = sshpkt_send(server)) != 0) { emit_rv("ua send success", (CK_RV)r); goto out; }
     deliver_all(server, client);
@@ -359,24 +430,27 @@ static int drive_kex(void) {
     nkeys = pkcs11_add_provider("softhsm", SM1_USER_PIN, &keys, &labels);
     if (nkeys <= 0) { emit_rv("pkcs11_add_provider", (CK_RV)(long)nkeys); return -1; }
     { char b[48]; snprintf(b, sizeof b, "{\"nkeys\":%d}", nkeys); wasm_emit_event("provider", b); }
+    /* Pick the host key matching the configured profile. */
+    int want_type = (g_cfg_keytype == HOSTKEY_ECDSA_P256) ? KEY_ECDSA : KEY_MLDSA_65;
     for (i = 0; i < nkeys; i++) {
-        if (keys[i] != NULL && keys[i]->type == KEY_MLDSA_65) { hostkey = keys[i]; break; }
+        if (keys[i] != NULL && keys[i]->type == want_type) { hostkey = keys[i]; break; }
     }
-    if (hostkey == NULL) { wasm_emit_event("error", "no ML-DSA-65 key returned by token"); return -1; }
+    if (hostkey == NULL) { wasm_emit_event("error", "configured host key not returned by token"); return -1; }
     if ((r = sshkey_from_private(hostkey, &pub)) != 0) { emit_rv("sshkey_from_private", (CK_RV)r); return -1; }
 
     memset(&kp, 0, sizeof kp);
     memcpy(kp.proposal, base, sizeof base);
-    kp.proposal[PROPOSAL_KEX_ALGS] = "mlkem768x25519-sha256";
-    kp.proposal[PROPOSAL_SERVER_HOST_KEY_ALGS] = "ssh-mldsa-65";
+    kp.proposal[PROPOSAL_KEX_ALGS] = g_cfg_kex;
+    kp.proposal[PROPOSAL_SERVER_HOST_KEY_ALGS] = g_cfg_hostalg;
 
     if ((r = ssh_init(&client, 0, &kp)) != 0) { emit_rv("ssh_init(client)", (CK_RV)r); return -1; }
     if ((r = ssh_init(&server, 1, &kp)) != 0) { emit_rv("ssh_init(server)", (CK_RV)r); return -1; }
     if ((r = ssh_add_hostkey(server, hostkey)) != 0) { emit_rv("ssh_add_hostkey(server)", (CK_RV)r); return -1; }
     if ((r = ssh_add_hostkey(client, pub)) != 0)     { emit_rv("ssh_add_hostkey(client)", (CK_RV)r); return -1; }
 
-    wasm_emit_event("kex_start",
-        "{\"kex\":\"mlkem768x25519-sha256\",\"hostkey\":\"ssh-mldsa-65\",\"sign\":\"C_Sign\"}");
+    { char b[160]; snprintf(b, sizeof b,
+        "{\"kex\":\"%s\",\"hostkey\":\"%s\",\"sign\":\"C_Sign\"}", g_cfg_kex, g_cfg_hostalg);
+      wasm_emit_event("kex_start", b); }
     int guard = 0;
     while ((!server->kex->done || !client->kex->done) && guard++ < 64) {
         if (sm2_pump(server, client) != 0) return -1;

--- a/openssh-pkcs11/wasm-shims/sshd_wasm_main.c
+++ b/openssh-pkcs11/wasm-shims/sshd_wasm_main.c
@@ -188,6 +188,10 @@ static int sm1_provision(void) {
         priv_tmpl, sizeof priv_tmpl / sizeof priv_tmpl[0],
         &hPub, &hPriv);
     if (rv != CKR_OK) { emit_rv("C_GenerateKeyPair", rv); return -1; }
+    /* PKCS#11 trace: the host keypair is generated ON the token (shim-direct call,
+     * so it isn't seen by the provider-path tap in pkcs11_static.c — emit it here). */
+    wasm_emit_event("pkcs11",
+        "{\"op\":\"C_GenerateKeyPair\",\"mech\":28,\"key\":\"ML-DSA-65 host key\"}");
     wasm_emit_event("provisioned", "{\"key\":\"sshd-host-key\"}");
     return 0;
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"
@@ -97,7 +97,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "hybrid-array 0.4.10",
+ "hybrid-array 0.4.13",
 ]
 
 [[package]]
@@ -265,13 +265,13 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
- "hybrid-array 0.4.10",
+ "hybrid-array 0.4.13",
  "num-traits",
  "rand_core 0.10.0",
  "subtle",
@@ -295,7 +295,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "hybrid-array 0.4.10",
+ "hybrid-array 0.4.13",
  "rand_core 0.10.0",
 ]
 
@@ -478,9 +478,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e84043d573efd4ac9d2d125817979a379204bf7e328b25a4a30487e8d100e618"
 dependencies = [
  "base16ct 1.0.0",
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.5",
  "crypto-common 0.2.1",
- "hybrid-array 0.4.10",
+ "hybrid-array 0.4.13",
  "pkcs8 0.11.0-rc.11",
  "rand_core 0.10.0",
  "rustcrypto-ff",
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "subtle",
  "typenum",
@@ -1186,7 +1186,7 @@ dependencies = [
  "base16ct 1.0.0",
  "ctutils",
  "der 0.8.0",
- "hybrid-array 0.4.10",
+ "hybrid-array 0.4.13",
  "subtle",
  "zeroize",
 ]
@@ -1461,9 +1461,9 @@ checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/rust/build-wasm-bundle.sh
+++ b/rust/build-wasm-bundle.sh
@@ -32,9 +32,13 @@ TC="$HOME/.rustup/toolchains/$TOOLCHAIN/bin"
 [[ -x "$TC/cargo" ]] || { echo "rustup toolchain not found at $TC" >&2; exit 1; }
 
 echo "▶ wasm-pack build ($PROFILE, target=bundler, toolchain=$TOOLCHAIN) → $OUT/"
+# --features acvp is required: without it C_Initialize rejects a non-null pReserved
+# (returns CKR_ARGUMENTS_BAD 0x07), which breaks all ACVP KAT seeding.
+# The acvp feature was removed from [default] on 2026-06-21 for compliance builds;
+# it must be explicitly requested here for the playground WASM bundle.
 PATH="$TC:$PATH" RUSTC="$TC/rustc" RUSTUP_TOOLCHAIN="$TOOLCHAIN" \
   ${EXTRA_RUSTFLAGS:+RUSTFLAGS="$EXTRA_RUSTFLAGS"} \
-  wasm-pack build --target bundler --out-dir "$OUT" --"$PROFILE"
+  wasm-pack build --target bundler --out-dir "$OUT" --"$PROFILE" -- --features acvp
 
 # ── Re-apply the __wbg_get_memory post-build shim (idempotent) ───────────────
 BG="$OUT/softhsmrustv3_bg.js"

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "asn1-rs"
@@ -318,6 +318,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher",
+ "dbl",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +491,15 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "der"
@@ -1376,6 +1396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,6 +1635,7 @@ dependencies = [
  "cbc",
  "chacha20 0.9.1",
  "chacha20poly1305",
+ "cmac",
  "console_error_panic_hook",
  "ctr",
  "ed25519-dalek",
@@ -1628,7 +1658,9 @@ dependencies = [
  "pkcs8 0.11.0",
  "rand 0.8.6",
  "rand_chacha",
+ "ripemd",
  "rsa",
+ "sha1",
  "sha2",
  "sha3",
  "signature 3.0.0",


### PR DESCRIPTION
Supports the hub playground integration of the real OpenSSH PQC handshake. No change to the proven handshake — SM1–SM4 still pass.

## Commits
- **trace-tap** (`65b5c2c`): `pkcs11_static.c` hands OpenSSH's provider a wrapped function list that emits a `pkcs11` event per `C_Login`/`C_FindObjects`/`C_GetAttributeValue`/`C_SignInit`/`C_Sign` before delegating to softhsm, so the hub can render the genuine call sequence (incl. both `C_Sign`s) without touching generated OpenSSH source. Provisioning `C_GenerateKeyPair` emitted from the shim.
- **parameterize** (`07cd2e0`): `set_handshake_config(kex, hostalg)` — selectable profile instead of the hardcoded combo. Host keys `ssh-mldsa-65` (CKM_ML_DSA) and `ecdsa-sha2-nistp256` (CKM_ECDSA) provision on the token and sign via the real provider; KEX is any compiled algorithm. Exports `_set_handshake_config`.
- **changelog** (`e912488`).

## Validation (local; Actions billing-blocked)
`node sm1-smoke.cjs` green; both profiles reach `USERAUTH_SUCCESS` (host_sig 64 ECDSA / 3309 ML-DSA); keys never leave the token.

**Do not merge yet** — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)