### PR TITLE
release: 0.7.0 — KMIP / crypto-agility hardening wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-07-02
+
+This release consolidates the KMIP / crypto-agility hardening wave: the KMIP server
+gains a real admin API, metrics, and audit streaming; the PKCS#11 and KMIP edges
+fail closed; the Rust engine reaches full PKCS#11 v3.2 conformance; and the KMIP
+wire format is validated against the OASIS conformance suite. It is the version now
+consumed by the pqctoday-sandbox 0.5.0 dev-sandbox (whose KMIP/CACP sample and
+per-language HSM-backed samples run against this engine and its `pqctoday-kmip-client`).
+
 ### Added — three new crypto-agility policies: auto-migrate-on-use, pkcs11-mechanism-lockdown, bsi-tr-02102 (2026-06-26)
 
 Three bundled policy presets for the CACP policy engine:


### PR DESCRIPTION
Cuts **0.7.0** (2026-07-02) from the accumulated `[Unreleased]` work — the KMIP / crypto-agility hardening wave:

- KMIP server: RESTful admin API v1 + OpenAPI 3.1, Prometheus `/metrics`, audit→SIEM streaming, self-minted admin certs
- Fail-closed hardening of the PKCS#11 / KMIP edges
- Rust engine: full native PKCS#11 v3.2 C-ABI conformance (315 PASS / 0 FAIL)
- KMIP request-wire encoder + OASIS bidirectional conformance gate
- NIST ACVP KAT coverage for HashML-DSA / HashSLH-DSA; C++↔Rust dual-engine cross-check
- Three new crypto-agility policies; C++ ChaCha20-Poly1305 AEAD fixes

Changelog only (the code already merged to main across #114–#122). This is the engine version consumed by pqctoday-sandbox 0.5.0.

Note: cut from `origin/main` via a git worktree so an in-flight branch's checkout was untouched; that branch will re-add its own `[Unreleased]` entries on top after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)