### PR TITLE
fix(tests): ship pqc_validate_ops.json (un-ignore template) so pqc_validate runs from a clean checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,10 @@ wasm/softhsm.wasm
 pqc_validate
 pqc_validate_asan
 pqc_validate_dbg
-pqc_validate_*.json
+# Ignore dated run-output files (pqc_validate_07042026.json, _r1, …) but NOT the
+# committed ops template pqc_validate_ops.json.
+pqc_validate_[0-9]*.json
+!tests/pqc_validate_ops.json
 
 # Backup files
 *.bak

--- a/docs/howtotestsofthsmv3.md
+++ b/docs/howtotestsofthsmv3.md
@@ -296,12 +296,16 @@ g++ -o pqc_validate tests/pqc_validate.cpp \
 > normal output. The phase tables in §7 are retained for historical context.
 
 ╔══ Summary ══╗
-  Total:   70
-  Passed:  52
+  Total:   15
+  Passed:  15
   Failed:  0
-  Skipped: 18
-  Output:  ./pqc_validate_03022026.json
+  Skipped: 0
+  Output:  ./pqc_validate_07042026.json
 ```
+
+(That is the shipped 15-case default ops file — all pass against a v0.8.0 token.
+A non-zero *Skipped* now means a mechanism is missing from the loaded module,
+and any *Failed* is a real regression.)
 
 ### 5.6 Exit codes
 
@@ -742,7 +746,7 @@ Omitting `CKA_VALUE_LEN` → `CKR_TEMPLATE_INCOMPLETE (0x000000d0)`.
 | File | Description |
 |---|---|
 | `tests/pqc_validate.cpp` | Standalone validation program |
-| `tests/pqc_validate_ops.json` | Operations template (70 test cases) |
+| `tests/pqc_validate_ops.json` | Operations template (shipped; 15-case runnable subset — round-trips + NIST/RFC KAT, extensible) |
 | `tests/README.md` | Build + run quick-reference |
 | `src/lib/test/` | CppUnit p11test suite |
 | `src/lib/pkcs11/pkcs11t.h` | All `CKM_*`, `CKK_*`, `CKA_*`, `CKP_*` constants |

--- a/tests/README.md
+++ b/tests/README.md
@@ -149,7 +149,12 @@ Exit code `0` is expected in all phases — SKIPs do not count as failures.
 
 ---
 
-## Mechanism Coverage (~70 test cases)
+## Mechanism Coverage
+
+The shipped default `pqc_validate_ops.json` is a **15-case runnable subset**
+(RNG, SHA-2 KAT, HMAC KAT, AES-GCM, ECDSA, EdDSA, ML-KEM ×3, ML-DSA ×3,
+SLH-DSA) — enough to validate the token from a clean checkout. The tool itself
+supports the fuller matrix below; extend the ops file to reach it.
 
 | Category | Count | Notes |
 |---|---|---|
@@ -174,9 +179,9 @@ Exit code `0` is expected in all phases — SKIPs do not count as failures.
 ```
 tests/
 ├── pqc_validate.cpp          Main validation program
-├── pqc_validate_ops.json     Operations template — REQUIRED by pqc_validate, but
-│                             NOT currently committed; supply your own before running
-│                             (the program exits with "cannot open ops file" if absent)
+├── pqc_validate_ops.json     Operations template (shipped) — 15 self-validating
+│                             round-trips + NIST/RFC known-answer vectors; the
+│                             default --ops-file. Extend with more cases as needed.
 ├── json.hpp                  nlohmann/json v3.11.3 (download via curl)
 └── README.md                 This file
 ```

--- a/tests/pqc_validate_ops.json
+++ b/tests/pqc_validate_ops.json
@@ -1,0 +1,131 @@
+{
+  "schema_version": "1.0",
+  "description": "pqc_validate operations template — self-validating round-trips plus canonical NIST/RFC known-answer vectors. Runnable from a clean checkout against a softhsmv3 token. Extend with more mechanisms/vectors as needed.",
+  "openssl_scope": "OpenSSL 3.5+ EVP backend (ML-KEM/ML-DSA/SLH-DSA + classical)",
+  "operations": [
+    {
+      "id": "rng-001",
+      "name": "C_GenerateRandom — 32 bytes",
+      "category": "RNG",
+      "mechanism_id": "0x00000000",
+      "params": { "length": 32 },
+      "expected": {}
+    },
+    {
+      "id": "hash-sha256-001",
+      "name": "SHA-256 — NIST vector (\"abc\")",
+      "category": "Hash",
+      "mechanism_id": "0x00000250",
+      "params": { "message_hex": "616263" },
+      "expected": { "digest_hex": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad" }
+    },
+    {
+      "id": "hash-sha384-001",
+      "name": "SHA-384 — NIST vector (\"abc\")",
+      "category": "Hash",
+      "mechanism_id": "0x00000260",
+      "params": { "message_hex": "616263" },
+      "expected": { "digest_hex": "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7" }
+    },
+    {
+      "id": "hash-sha512-001",
+      "name": "SHA-512 — NIST vector (\"abc\")",
+      "category": "Hash",
+      "mechanism_id": "0x00000270",
+      "params": { "message_hex": "616263" },
+      "expected": { "digest_hex": "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f" }
+    },
+    {
+      "id": "hmac-sha256-001",
+      "name": "HMAC-SHA256 — RFC 4231 test case 1",
+      "category": "HMAC",
+      "mechanism_id": "0x00000251",
+      "params": {
+        "key_hex": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+        "message_hex": "4869205468657265"
+      },
+      "expected": { "mac_hex": "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7" }
+    },
+    {
+      "id": "aes-gcm-256-001",
+      "name": "AES-256-GCM — encrypt/decrypt round-trip + tamper detect",
+      "category": "AES",
+      "mechanism": "CKM_AES_GCM",
+      "mechanism_id": "0x00001087",
+      "params": { "key_bits": 256, "plaintext_hex": "00112233445566778899aabbccddeeff", "aad_hex": "cafe" },
+      "expected": {}
+    },
+    {
+      "id": "ecdsa-p256-001",
+      "name": "ECDSA P-256 — sign/verify round-trip",
+      "category": "ECDSA",
+      "mechanism_id": "0x00001041",
+      "params": { "curve": "P-256", "message_hex": "616263" },
+      "expected": {}
+    },
+    {
+      "id": "eddsa-ed25519-001",
+      "name": "EdDSA Ed25519 — sign/verify round-trip",
+      "category": "EdDSA",
+      "mechanism_id": "0x00001057",
+      "params": { "curve": "Ed25519", "message_hex": "616263" },
+      "expected": {}
+    },
+    {
+      "id": "ml-kem-512-001",
+      "name": "ML-KEM-512 — encapsulate/decapsulate round-trip",
+      "category": "ML-KEM",
+      "mechanism_id": "0x0000000f",
+      "params": { "parameter_set": "ML-KEM-512", "parameter_set_id": "0x00000001" },
+      "expected": {}
+    },
+    {
+      "id": "ml-kem-768-001",
+      "name": "ML-KEM-768 — encapsulate/decapsulate round-trip",
+      "category": "ML-KEM",
+      "mechanism_id": "0x0000000f",
+      "params": { "parameter_set": "ML-KEM-768", "parameter_set_id": "0x00000002" },
+      "expected": {}
+    },
+    {
+      "id": "ml-kem-1024-001",
+      "name": "ML-KEM-1024 — encapsulate/decapsulate round-trip",
+      "category": "ML-KEM",
+      "mechanism_id": "0x0000000f",
+      "params": { "parameter_set": "ML-KEM-1024", "parameter_set_id": "0x00000003" },
+      "expected": {}
+    },
+    {
+      "id": "ml-dsa-44-001",
+      "name": "ML-DSA-44 — sign/verify round-trip",
+      "category": "ML-DSA",
+      "mechanism_id": "0x0000001d",
+      "params": { "parameter_set": "ML-DSA-44", "parameter_set_id": "0x00000001", "message_hex": "616263" },
+      "expected": {}
+    },
+    {
+      "id": "ml-dsa-65-001",
+      "name": "ML-DSA-65 — sign/verify round-trip",
+      "category": "ML-DSA",
+      "mechanism_id": "0x0000001d",
+      "params": { "parameter_set": "ML-DSA-65", "parameter_set_id": "0x00000002", "message_hex": "616263" },
+      "expected": {}
+    },
+    {
+      "id": "ml-dsa-87-001",
+      "name": "ML-DSA-87 — sign/verify round-trip",
+      "category": "ML-DSA",
+      "mechanism_id": "0x0000001d",
+      "params": { "parameter_set": "ML-DSA-87", "parameter_set_id": "0x00000003", "message_hex": "616263" },
+      "expected": {}
+    },
+    {
+      "id": "slh-dsa-sha2-128s-001",
+      "name": "SLH-DSA-SHA2-128s — sign/verify round-trip",
+      "category": "SLH-DSA",
+      "mechanism_id": "0x0000002e",
+      "params": { "parameter_set": "SLH-DSA-SHA2-128s", "parameter_set_id": "0x00000001", "message_hex": "616263" },
+      "expected": {}
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
`pqc_validate` hard-requires `--ops-file` (exits `cannot open ops file` if absent), and its default is `tests/pqc_validate_ops.json` — but that file was never committed, so the tool could not run from a clean checkout.

## Root cause
`.gitignore` had `pqc_validate_*.json`, intended to ignore the tool's **dated run-output** files (`pqc_validate_07042026.json`, `_r1`, …). The glob also matched the **input template** `pqc_validate_ops.json`, silently making it un-committable.

## Fix
- Tighten the ignore to `pqc_validate_[0-9]*.json` (dated outputs only) + explicit `!tests/pqc_validate_ops.json` negation.
- Commit a real `tests/pqc_validate_ops.json` — 15 cases: RNG, SHA-2 KAT ("abc"), HMAC-SHA256 (RFC 4231), AES-256-GCM, ECDSA P-256, EdDSA Ed25519, ML-KEM 512/768/1024, ML-DSA 44/65/87, SLH-DSA-SHA2-128s. Round-trips are self-validating; hash/HMAC use canonical vectors. Mechanism/param-set IDs verified against `src/lib/pkcs11/pkcs11t.h`.
- Docs: `tests/README.md` + `docs/howtotestsofthsmv3.md` describe the shipped 15-case subset (was stale "70 test cases" / "not committed").

## Verification
Compiled `pqc_validate` and ran it against a native `libsofthsmv3.so`: **15/15 PASS, 0 fail, 0 skip** (KAT vectors matched, all round-trips passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)