### PR TITLE
Gap-remediation audit: Destroy/attribute-mutation/RSA-Register/Encrypt-Decrypt/Locate honesty (v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,87 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-07-09
+
+A follow-up audit of the `HONEST_MAXIMUM_PLAN.md` work in 0.12.0: a
+dedicated pass over the PKCS#11 and KMIP Rust crates looking specifically
+for stub/placeholder code and silently-dropped errors. It found 13 real
+gaps, all fixed here in 9 phases (documented in
+`kmip/docs/GAP_REMEDIATION_PLAN.md`), plus two further bugs the fix work
+itself surfaced along the way. Every fix ships with new tests, and the
+full OASIS mandatory conformance corpus (97 tests) still passes end to
+end.
+
+### Fixed
+
+- **`Destroy` now genuinely scrubs key material.** Registered/imported
+  objects had their raw key bytes zeroized in memory before being
+  dropped, and SQLite's `secure_delete` pragma is now enabled — "the key
+  material SHALL be destroyed" (§6.1.19) previously only flipped a
+  lifecycle flag while the plaintext sat in the database.
+- **`SetAttribute` / `ModifyAttribute` / `DeleteAttribute` no longer
+  silently drop attributes.** Several attributes (`CryptographicParameters`,
+  `UsageLimits`, `ProtectionLevel`, four Link types) returned a wire
+  `Success` while persisting nothing; a separate group
+  (`CryptographicDomainParameters`, `ProtectionStorageMask`, and 11
+  others) is now honestly rejected as Read-Only instead of the same
+  silent no-op. `UsageLimits` also gained its §4.69 guard: once `Get
+  Usage Allocation` has granted an allocation, the budget can no longer
+  be silently re-set. Auditing `DeleteAttribute`'s independent code path
+  for the same class of bug also caught two more real bugs: `AddAttribute`
+  wrongly rejected a legitimate first-time add, and `DeleteAttribute` by
+  name could never actually find a Link attribute due to a space-vs-no-space
+  string mismatch.
+- **Three wire-encoding round-trip gaps.** The attribute-name lookup table
+  used by `AdjustAttribute`/`DeleteAttribute` was missing 6 entries;
+  `CryptographicParameters` encoding dropped 7 real fields (tag length,
+  random IV, deterministic signing, context string, and more); and
+  `Register`ing a `SecretData` object always reported its type back as
+  `Password` regardless of what was actually registered.
+- **`Register` RSA public/private key honesty.** Engine-import failures
+  were previously discarded, so a malformed or unsupported key could
+  register successfully and only fail on first use. RSA public keys can
+  now genuinely be registered in PKCS#8 form (previously silently
+  produced no usable key), and — found via the OASIS conformance replay
+  while verifying this fix — the "Transparent RSA Public Key" wire form
+  never actually worked either; it does now.
+- **`CreateKeyPair` persists `CryptographicParameters` and rejects false
+  `QuantumSafe` claims.** A key's declared default padding/hash (e.g.
+  PSS/SHA-384) was silently lost, same as `Create` already handles
+  correctly; `QuantumSafe=true` on a non-PQC algorithm is now rejected,
+  matching `Create`'s existing check.
+- **`Encrypt`/`Decrypt` now pass real AAD and OAEP-hash choices through
+  for engine-generated keys.** Only `Register`'d (raw-material) keys
+  previously got the client's actual AAD / RSA-OAEP hash selection;
+  `Create`/`CreateKeyPair`'d keys silently got empty AAD and a hardcoded
+  SHA-256 default. Found and fixed along the way: RSA-OAEP encryption
+  against an engine-generated key had never worked at all, due to an
+  internal key-format mismatch.
+- **Batch `Undo` / `$IDPlaceholder` now cover every UID-minting
+  operation.** `Encapsulate`, `Decapsulate`, `CreateSplitKey`, and
+  `JoinSplitKey` were the only operations the dispatcher didn't know how
+  to roll back or chain — a batch `Undo` after one of them left the new
+  object behind instead of deleting it, and a later batch item couldn't
+  reference `$IDPlaceholder` after one ran.
+- **`Locate` can now filter by cryptographic length, usage mask, and
+  unique identifier** — previously accepted as valid filter syntax and
+  silently ignored, returning every object instead of narrowing.
+- **`AlternativeName`'s Type is no longer discarded.** Registering a name
+  as e.g. a URI previously always reported back as plain text; the type
+  now genuinely round-trips.
+- **SQLite storage now protects Initial Date / Original Creation Date**
+  from being overwritten on update, matching the guarantee in-memory
+  storage already provided.
+
+### Internal
+
+- Nine stale code comments corrected — several claimed features were
+  still unimplemented (session tickets, audit event emission, batch
+  processing, HSS/XMSS key generation, multi-part crypto operations)
+  when they had genuinely shipped since the comment was written.
+- The syslog audit sink now logs and counts dropped events on a send
+  failure, matching every other audit sink instead of failing silently.
+
 ## [0.12.0] — 2026-07-08
 
 Closes the KMIP `HONEST_MAXIMUM_PLAN.md` initiative: every advertised KMIP 3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,11 +72,13 @@ engine. It has its own checked-in PKCS#11 v3.2 conformance evidence
 The original Phase 0–6 roadmap (import + strip legacy, OpenSSL 3.x EVP
 migration, ML-DSA, ML-KEM, Emscripten WASM, npm package, app integration) is
 **complete**, as is the later hardening/conformance work. Current release is
-tracked in `CHANGELOG.md` (**0.12.0**, 2026-07-08). Recent programs: PKCS#11 v3.2
+tracked in `CHANGELOG.md` (**0.13.0**, 2026-07-09). Recent programs: PKCS#11 v3.2
 + KMIP 3.0 conformance evidence (real Split Key + asynchronous processing,
-honest `Query`), the CACP crypto-agility policy engine (with its fail-open
-enforcement seams closed), and hybrid KEMs. See `CHANGELOG.md` for the
-authoritative per-release history rather than this file.
+honest `Query`), a follow-up gap-remediation audit (13 findings across both
+crates — silently-dropped errors, stub behavior — all fixed), the CACP
+crypto-agility policy engine (with its fail-open enforcement seams closed),
+and hybrid KEMs. See `CHANGELOG.md` for the authoritative per-release history
+rather than this file.
 
 ## Key PKCS#11 v3.2 Constants (PQC)
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ The `softhsmv3` implementations maintain strict compliance with current ACVP tes
 
 A formal security audit was conducted in March 2026 covering C++ memory safety, PKCS#11 API validation, cryptographic implementation, WASM/JS bindings, Rust PKCS#11, and build/supply chain. A subsequent hardening sweep occurred in April 2026 focusing on bounds control.
 
-**As of the v0.4.24 hardening sweep (April 2026): all HIGH and MEDIUM findings resolved, remaining LOW findings patched.** Security-relevant work since then is recorded in `CHANGELOG.md` (through v0.8.0).
+**As of the v0.4.24 hardening sweep (April 2026): all HIGH and MEDIUM findings resolved, remaining LOW findings patched.** Security-relevant work since then is recorded in `CHANGELOG.md`.
 
 | Severity | Original | Fixed in v0.4.24 | Remaining |
 | --- | --- | --- | --- |

--- a/kmip/Cargo.lock
+++ b/kmip/Cargo.lock
@@ -1942,6 +1942,7 @@ dependencies = [
  "uuid",
  "x509-cert",
  "x509-parser",
+ "zeroize",
 ]
 
 [[package]]

--- a/kmip/Cargo.lock
+++ b/kmip/Cargo.lock
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "pqctoday-kmip"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "softhsmrustv3"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",

--- a/kmip/Cargo.toml
+++ b/kmip/Cargo.toml
@@ -132,6 +132,10 @@ prometheus = { version = "0.13", default-features = false, optional = true }
 rand        = "0.8"
 sha2        = "0.10"
 hmac        = "0.12"
+# Gap-remediation Phase A — Destroy must scrub Register/Import'd
+# ObjectRecord.key_material, not just flip the lifecycle state. Same
+# crate + `.zeroize()` discipline `rust/src/ffi.rs` already uses.
+zeroize     = "1"
 # K20 — Derive Key PBKDF2 method (RFC 2898 via the RustCrypto crate;
 # same version the engine uses for TokenState PIN hashing).
 pbkdf2      = "0.12"

--- a/kmip/Cargo.toml
+++ b/kmip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pqctoday-kmip"
-version     = "0.12.0"
+version     = "0.13.0"
 edition     = "2024"
 license     = "MIT"
 description = "KMIP 3.0 PQC + classical key management wrapper over pqctoday-hsm PKCS#11"

--- a/kmip/conformance/REPLAY_REPORT.json
+++ b/kmip/conformance/REPLAY_REPORT.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": 1783483343,
+  "generated_at": 1783560804,
   "summary": {
     "pass": 97,
     "fail": 0,

--- a/kmip/conformance/REPLAY_REPORT.md
+++ b/kmip/conformance/REPLAY_REPORT.md
@@ -1,6 +1,6 @@
 # OASIS KMIP 3.0 Dispatcher Replay Report
 
-Generated: 2026-07-08 04:02:23 UTC
+Generated: 2026-07-09 01:33:24 UTC
 
 
 ## Aggregate

--- a/kmip/docs/CONFORMANCE_REPORT.md
+++ b/kmip/docs/CONFORMANCE_REPORT.md
@@ -1,18 +1,23 @@
 # KMIP 3.0 Conformance Report
 
-> **Current as of v0.12.0.** The replay figures below are regenerated per run via
+> **Current as of v0.13.0.** The replay figures below are regenerated per run via
 > `../conformance/harness/dispatcher_replay.py` (`cargo test` in CI also gates
 > them); the dated stamps below are when the prose was last edited, not a ceiling
 > on validity.
 
-**Generated**: 2026-06-08 · **Updated**: 2026-07-08 (HONEST_MAXIMUM_PLAN Phases 0–4, 6.1 complete)
+**Generated**: 2026-06-08 · **Updated**: 2026-07-09 (`GAP_REMEDIATION_PLAN.md` Phases A–I complete)
 **Subsystem**: `pqctoday-kmip` (`kmip/` crate)
 **Spec**: OASIS Key Management Interoperability Protocol v3.0 **Committee Specification Draft 01
 (CSD01, 23 Aug 2024)** — a draft, not a ratified OASIS Standard. PQC extensions (Encapsulate /
 Decapsulate, hybrid KEMs) are implemented per the later **Working Draft 19 (WD19, 14 Feb 2025)**,
 also unpublished/unratified; the PQC surface has no OASIS test vectors (§4.1, §7 below). See
 `../docs/HONEST_MAXIMUM_PLAN.md` for the roadmap this report reflects the completion of (Phases
-0–4 and 6.1; Phase 5 — server-to-client — is deliberately parked, see §5).
+0–4 and 6.1; Phase 5 — server-to-client — is deliberately parked, see §5), and
+`GAP_REMEDIATION_PLAN.md` for a follow-up audit (13 findings, all fixed) that specifically
+targeted silently-dropped errors and stub/placeholder behavior the dispatcher-conformance figures
+below wouldn't have caught on their own (they test observable request/response shape, not every
+internal error-propagation path — e.g. a discarded engine-import `Result` that still returns wire
+`Success`).
 **Test corpus**: `kmip-profiles-v3.0.zip` (`test-cases/kmip-v3.0/{mandatory,optional}/*.xml`) — CSD01-era, contains zero PQC test cases.
 
 ## TL;DR
@@ -35,6 +40,34 @@ out of scope for the `softhsmrustv3` backend (`kmip/DEPRECATED.md`). There are, 
 revision, **zero** other skip categories: no `SKIP_OP`, no `SKIP_PRECONDITION`, no
 `SKIP_POLICY_VARIANT`, no `SKIP_PARSE` — every transcript the harness can meaningfully run,
 it runs to a real PASS or FAIL.
+
+## 0. Gap-remediation follow-up (v0.13.0, 2026-07-09)
+
+The 97/97 corpus-replay figure above hasn't moved — but it was never designed to catch every gap
+this class of bug produces. A dedicated audit of both the `rust/` (PKCS#11 engine) and `kmip/`
+crates for stub/placeholder code and silently-dropped errors found 13 real gaps, none of which
+changed an op's observable wire shape enough to fail a corpus transcript on its own (the corpus
+mostly exercises the happy path with well-formed requests). All 13 are fixed, documented phase by
+phase in `GAP_REMEDIATION_PLAN.md`, each with new regression tests:
+
+- `Destroy` now genuinely scrubs key material instead of only flipping a lifecycle flag.
+- `SetAttribute`/`ModifyAttribute`/`DeleteAttribute` no longer silently drop several attributes,
+  and correctly reject others as Read-Only that previously fell through a permissive catch-all.
+- Three wire-encoding round-trip gaps (attribute-name lookup table, `CryptographicParameters`
+  field coverage, `SecretData` type persistence).
+- `Register` no longer discards engine-import errors, and RSA public keys registered in PKCS#8 or
+  Transparent form now genuinely produce a usable engine object (previously silent no-ops).
+- `CreateKeyPair` persists `CryptographicParameters` and rejects false `QuantumSafe` claims.
+- `Encrypt`/`Decrypt` pass real AAD and OAEP-hash choices through for engine-generated keys, not
+  just `Register`'d ones.
+- Batch `Undo`/`$IDPlaceholder` now cover `Encapsulate`/`Decapsulate`/`CreateSplitKey`/`JoinSplitKey`.
+- `Locate` filters by cryptographic length, usage mask, and unique identifier instead of silently
+  ignoring them.
+
+One genuine regression was caught and fixed during this work itself: re-running the full
+mandatory corpus replay while verifying the Locate fix turned up that the RSA-Register honesty fix
+had exposed a pre-existing, separate bug (Transparent RSA Public Key registration never actually
+worked) as a hard failure instead of a silent one. Both are fixed; the corpus is back to 97/0/5.
 
 ## 1. Test corpus inventory
 

--- a/kmip/docs/GAP_REMEDIATION_PLAN.md
+++ b/kmip/docs/GAP_REMEDIATION_PLAN.md
@@ -1,0 +1,501 @@
+# Post-"Honest Maximum" Gap Remediation Plan
+
+> **Status:** PLAN (not yet executed) · **Authored:** 2026-07-08 · **Revised:** 2026-07-08 (v2)
+> **Source:** an 8-agent parallel audit of `rust/` (PKCS#11 engine, 31.5k lines) and `kmip/`
+> (KMIP 3.0 server, 44.8k lines), run immediately after `HONEST_MAXIMUM_PLAN.md` shipped
+> (v0.12.0), specifically hunting for stub/fake/silently-dropped behavior that plan's own
+> scope didn't cover.
+> **Headline result:** `rust/` came back clean (0 functional findings, a few stale comments).
+> `kmip/` has **9 real gaps** (2 of them security-relevant, not just honesty-relevant) and
+> **4 medium-priority gaps**, concentrated in areas `HONEST_MAXIMUM_PLAN.md` didn't touch:
+> attribute mutation, Register/Destroy, and wire-layer round-tripping.
+
+**Anchor:** every finding below is cited to a real `file:line`. v1 of this plan was itself
+audited before any code was touched — every phase's claims were independently re-verified
+against source (and, for attribute-modifiability claims, against the actual KMIP 3.0 spec
+attribute-rules tables, not assumption). **That pass found 5 concrete errors in v1**, all
+corrected below and marked `[v2 correction]`. The remaining 8 findings held up under direct
+re-verification with zero changes. Treat this document, not v1, as authoritative — the
+correction history is kept inline rather than hidden so the *type* of error (a false
+dependency claim, three spec-contradicting classifications, an unverified effort estimate, an
+overstated risk level) stays visible for whoever executes this.
+
+---
+
+## 0. Scope and non-scope
+
+**In scope:** the 13 numbered findings from the audit (9 high, 4 medium), all in `kmip/`.
+
+**Out of scope for this plan** (tracked here for completeness, fixed opportunistically, not
+phased): a handful of stale doc comments in `rust/` (`ck_abi.rs`, `constants.rs`, `sign.rs`
+module doc, `lms.rs` dead code) and in `kmip/` (`ops/session_and_auth.rs`, `ops/mod.rs`,
+`policy/rule.rs`'s `MaxKeyAgeDays` comment, `auditlog/mod.rs`'s status table) that describe
+behavior which has since been fixed and were never updated. None of these change behavior —
+see §9 for the full list and a one-pass cleanup task.
+
+**Before starting any phase:** re-verify that phase's specific claims against current source
+as T0, not a formality — this is the single practice that caught all 5 v1 errors. Findings
+age; line numbers drift; a subagent's synthesis (or a plan author's own paraphrase of one) can
+misstate a dependency or a spec rule with total confidence. Don't skip this because the
+finding "already sounds verified" in this document.
+
+---
+
+## 1. Phase A — Security: Destroy must actually destroy (P0)
+
+**Finding #1.** `kmip/src/ops/destroy.rs:85-112`. For objects imported via `Register` (not
+engine-generated), the raw key bytes live in `ObjectRecord.key_material` in the KMIP store
+itself (`store/traits.rs:94-99`). `Destroy` calls `native::destroy_object` on the engine
+handle *if one exists*, flips `state`/`destroy_date`, and calls `store.update(obj)` — but
+never clears `key_material`. `Export`'s own code filters `key_material` at *read* time
+specifically because Destroy never clears it at the *source* — this is a load-bearing
+workaround for a bug, not a design choice.
+
+**Why this is P0, not just an honesty gap:** a "destroyed" key's plaintext bytes remain
+fully recoverable (store dump, DB backup, memory inspection) indefinitely. This is the kind
+of gap that fails an actual security review, not just a corpus-honesty review.
+
+- **T1** In `destroy()`, after the engine-handle destroy (or when no engine handle exists),
+  zero and clear `obj.key_material` (`Some(vec)` → `None`, zeroizing the vec's backing bytes
+  first — this repo already depends on the `zeroize` crate elsewhere per `rust/Cargo.toml`,
+  reuse that discipline here rather than a bare `drop`).
+- **T2** Audit every other place `key_material` is read to confirm none of them need it
+  post-Destroy for a legitimate reason (Export already correctly refuses to return it for a
+  Destroyed object — after T1 that check becomes redundant-but-harmless defense in depth,
+  leave it in place rather than removing it).
+- **T3 `[v2 correction]`** T1 alone is necessary but **not sufficient** for the `SqliteStore`
+  backend. Verified: `store/sqlite.rs`'s connection setup (`~line 76-84`) configures
+  `journal_mode = WAL`, `synchronous = NORMAL`, `busy_timeout`, `foreign_keys` — **no
+  `PRAGMA secure_delete`**. Without it, SQLite doesn't overwrite deleted content; it marks
+  the page free for reuse, and the WAL file can retain the old plaintext until checkpointed.
+  Clearing `key_material` in Rust and calling `store.update()` therefore does NOT guarantee
+  the bytes are gone from disk — add `PRAGMA secure_delete = ON` (or `FAST`, which limits the
+  overwrite to pages actually containing the deleted data — cheaper, still real) to the same
+  connection-setup block. Confirm this doesn't have an unacceptable write-amplification cost
+  given this store's actual write volume before picking `ON` vs `FAST`.
+- **T4** New test: Register a `SecretData`/`SymmetricKey` with `key_material` set, Destroy it,
+  assert `store.get(uid).unwrap().key_material.is_none()`. Also assert Export against the
+  destroyed UID still correctly fails (regression-proofing the existing behavior, not just
+  the new one). A disk-level "is the plaintext actually gone" test isn't practical in a unit
+  test — T3's PRAGMA is the control for that; don't try to assert it via file inspection.
+- *Exit:* no `ObjectRecord` in any store backend carries `key_material: Some(_)` once its
+  `state == Destroyed`, **and** the SQLite backend is configured not to leave the old bytes
+  recoverable in freed pages/WAL.
+
+*(S / P0 — small, isolated, no dependency on other phases. T3 raised the scope slightly but
+is still contained to one connection-setup block.)*
+
+---
+
+## 2. Phase B — Security/honesty: SetAttribute stops lying about success (P0)
+
+**Finding #2.** `kmip/src/ops/attribute_mutate.rs:239-267,637`. `apply_attribute`'s final
+match arm is a bare `_ => {}`, documented as "read-only or server-managed... a no-op" — but
+it also silently swallows attribute types that are **neither** read-only **nor** explicitly
+handled. `SetAttribute`/`ModifyAttribute` on any of these returns a genuine wire `Success`
+while persisting nothing.
+
+**`[v2 correction]`** v1 bucketed 5 attributes as "genuinely settable" by inference from
+context, without checking the spec's own attribute-rules tables. Re-verified directly against
+`kmip-spec-v3.0.pdf` (Tables 89, 93, and the Protection Storage Mask / Key Format Type
+equivalents) — **3 of the 5 were wrong**, and implementing v1's plan as written would have
+shipped a *new* spec violation in the same PR meant to fix one:
+
+| Attribute | Spec: "Modifiable by client" | Correct bucket |
+|---|---|---|
+| `CryptographicParameters` | **Yes** | Genuinely settable (v1 was right) |
+| `UsageLimits` | **Yes — but only while `Get Usage Allocation` has not yet been performed** | Genuinely settable, **with a guard condition v1 missed entirely** |
+| `CryptographicDomainParameters` | **No** | Read-only rejection (v1 wrongly said settable) |
+| `ProtectionStorageMask` | **No** | Read-only rejection (v1 wrongly said settable) |
+| `KeyFormatType` | **No** | Read-only rejection (v1 wrongly said settable) |
+
+- **T1** Split the catch-all into two real cases, using the corrected table above:
+  - **Genuinely settable:** `CryptographicParameters` (unconditional) and `UsageLimits`
+    (conditional — see T2). Add real `apply_attribute` arms that persist them onto the
+    `ObjectRecord`, mirroring how `Create`/`Register` already populate these same fields.
+  - **Genuinely server-managed, currently missing from `attribute_is_read_only`:**
+    `CryptographicDomainParameters`, `ProtectionStorageMask`, `KeyFormatType`, the four `Link`
+    variants, `DigitalSignatureAlgorithm`, `NistKeyType`, `ProtectionLevel`,
+    `RevocationReasonCode`, `DeactivationReasonCode`, `CertificateType`, `CertificateValue`,
+    the four `SplitKey*` attributes: add them to `attribute_is_read_only` so `SetAttribute`
+    honestly rejects with `AttributeReadOnly` (§11, same code `BL-M-7` already pins for the
+    existing read-only set) instead of silently no-op'ing.
+- **T2** `UsageLimits`'s guard condition: `SetAttribute(UsageLimits)` must itself check
+  whether `Get Usage Allocation` has already been called against this object (track via
+  whatever state already distinguishes "budget set at creation, never allocated against" from
+  "at least one allocation has been granted" — `usage_limits_remaining < usage_limits_total`
+  is the obvious signal if nothing more explicit exists) and reject with the spec-appropriate
+  error once it has, rather than silently allowing an unbounded re-budget after allocation has
+  started.
+- **T3 `[v2 correction]`** v1 claimed "sequence C before B... since AdjustAttribute/
+  DeleteAttribute depend on [Finding #7's] table." **Verified false by reading the call
+  graph directly**: `SetAttribute`/`ModifyAttribute` (this phase) decode an inline
+  `Attribute` value and never call `tag_name_from_code` at all. `AdjustAttribute` (which
+  *does* use it) has its own separate, already-honest 2-attribute-only handler
+  (`attribute_mutate.rs:271-323` — `CryptographicUsageMask`/`CryptographicLength` only,
+  everything else already correctly rejects `OperationNotSupported`) that never calls
+  `apply_attribute`. `DeleteAttribute` uses a *third*, independent name-based removal path
+  (`remove_attribute_by_name`/`attribute_name_present`) that this audit did not examine —
+  **flag as an unaudited area**, not a known-clean one; check it for the same class of gap
+  before considering attribute mutation fully closed. **B and C have no code dependency** —
+  land in either order, or in parallel.
+- **T4** New tests: for `CryptographicParameters` and (pre-allocation) `UsageLimits`, a
+  `SetAttribute` → `GetAttributes` round-trip proving persistence; for post-allocation
+  `UsageLimits`, a rejection test; for every attribute newly moved to "read-only," a
+  `SetAttribute` → `AttributeReadOnly` rejection test.
+- *Exit:* `apply_attribute`'s catch-all arm is unreachable in practice — every `Attribute`
+  variant either persists for real (per its actual spec modifiability rule, not inference)
+  or is honestly rejected as read-only.
+
+*(M / P0 — no dependency on Phase C. The spec-verification step in T1's table is the one to
+repeat for any attribute not already covered here before assuming it's safe to make settable.)*
+
+---
+
+## 3. Phase C — Wire-layer round-trip fidelity
+
+Three independent wire-layer gaps, groupable into one phase since they're all in
+`kmip30/wire.rs` and share the same "decodes fine, doesn't round-trip back out" shape. **No
+longer a prerequisite for Phase B** (see Phase B/T3) — can land in either order.
+
+**Finding #7.** `wire.rs:5004-5161` — `tag_code_from_name`/`tag_name_from_code` (used
+*specifically* by `AdjustAttribute`'s and `DeleteAttribute`'s numeric `AttributeReference`
+resolution — confirmed via direct read, not `SetAttribute`/`ModifyAttribute` per Phase B's
+correction above) omit `CryptographicDomainParameters` and all five Split Key attributes,
+even though `decode_attribute_v3` fully decodes them. A numeric reference to any of these
+resolves to the literal string `"Unknown"` instead of the real name, so the mutation
+silently targets nothing.
+- **T1** Add the missing 6 entries to both directions of the table, verified against the same
+  tag constants `decode_attribute_v3`/`encode_attribute_v3` already use (no new tag values
+  needed — this is purely a lookup-table gap, not a missing wire encoding).
+- **T2** Test: `AdjustAttribute`/`DeleteAttribute` referencing each of the 6 attributes by
+  numeric `AttributeReference` code, not just by inline `Attribute` value. Note
+  `AdjustAttribute` will still honestly reject 5 of these 6 as `OperationNotSupported` per
+  its own narrow attribute list (Phase B/T3) — the fix here is that it resolves the *name*
+  correctly before that rejection, not that it starts accepting them.
+
+**Finding #6.** `wire.rs:3129-3158` `encode_cryptographic_parameters` drops 7 real struct
+fields present in `decode_cryptographic_parameters`/`CryptographicParameters`
+(`ops.rs:1349-1413`): `tag_length`, `random_iv`, `deterministic`, `context_string`,
+`internal`, `external_mu`, `random`. A PQC signing object with `Deterministic`/
+`ContextString` set, or an AEAD object with `TagLength` set, loses those fields on every
+`GetAttributes`/`Export` response. **Re-verified line-for-line against both functions —
+accurate exactly as stated, no correction.**
+- **T1** Add the 7 missing fields to the encoder, mirroring the decoder's tag constants.
+- **T2** Strengthen the existing round-trip test
+  (`k18_cryptographic_parameters_salt_length_decodes_and_round_trips`) to cover all fields,
+  not just `salt_length` — this is the test gap that let the original bug through CI.
+
+**Finding #8.** `wire.rs:4013-4023` `decode_register_req`'s `SecretData` arm captures the
+inner `KeyBlock` but explicitly (per its own comment) drops the sibling `SecretDataType`
+enum. `RegisterRequest` (`ops.rs:1721-1739`) has no field to carry it. A later `Get` reports
+the hardcoded default (`Password`) regardless of what was actually registered. **Re-verified
+— confirmed, and the adjacent `OpaqueObject` arm two cases below handles its own analogous
+type field correctly, confirming this is an inconsistency rather than a deliberate policy.**
+- **T1** Add `secret_data_type: Option<u32>` to `RegisterRequest`, decode it alongside
+  `KeyBlock` in the `SecretData` arm (mirroring the adjacent `OpaqueObject` arm), and persist
+  it onto the `ObjectRecord` in `register_import_export.rs`.
+- **T2** Test: Register a `SecretData` with `SecretDataType=Seed(0x02)`, `Get` it back,
+  assert the type round-trips instead of silently becoming `Password`.
+
+*(M / P1 — three independent, low-risk, additive fixes; no shared state, can land as one PR
+or three small ones.)*
+
+---
+
+## 4. Phase D — Register import honesty (RSA public keys)
+
+**Finding #3.** `register_import_export.rs:267-293`. `let _ = native::register_rsa_public_key_der(...)`
+(and two sibling calls) discard the `Result`, contradicting the file's own stated invariant
+two paragraphs later ("Register must NOT succeed-then-fail-at-use"). **Independently
+re-verified on both sides of the crate boundary**: the KMIP-layer comment says "PKCS_1
+RSAPublicKey or PKCS_8 SubjectPublicKeyInfo — store the DER as-is" with genuinely zero
+`KeyFormatType` branching (confirmed by reading the full match arm — `material` passes
+straight through); the engine's `register_rsa_public_key_der`
+(`rust/src/native/keygen.rs:1020-1046`) calls `RsaPublicKey::from_pkcs1_der` only and maps
+any parse failure (including well-formed PKCS#8 input) to `CKR_KEY_TYPE_INCONSISTENT`. A
+PKCS#8-form Register call returns wire `Success` with a stored `ObjectRecord`, but no engine
+object exists — a later `SignatureVerify` against it fails with an unrelated "not found"
+error instead of `Register` honestly rejecting the malformed input.
+
+- **T1** Replace all `let _ = native::register_*(...)` in this file with `.map_err(...)?`,
+  matching the PQC/HSS import blocks in the same file that already do this correctly.
+- **T2** Either (a) add real PKCS#8→PKCS#1 conversion before calling
+  `register_rsa_public_key_der` so the doc comment's claimed PKCS#8 support becomes real, or
+  (b) narrow the doc comment to "PKCS#1 only" and make the handler reject PKCS#8 input with a
+  clear `InvalidField`/`KeyFormatTypeNotSupported` error instead of silently succeeding.
+  **Recommend (a)** — PKCS#8 SPKI is the more common wire format for RSA public keys in
+  practice, so silently narrowing support is a bigger behavioral regression for real clients
+  than adding the conversion. `[v2 correction]` v1 estimated this conversion at "~10 lines" —
+  **that was an unverified guess, not a checked estimate; nobody prototyped it.** The `rsa`
+  crate's `pkcs8::DecodePublicKey` trait (the `pkcs8` crate is already a dependency per
+  `rust/Cargo.toml`) likely makes `RsaPublicKey::from_public_key_der(der)` a drop-in fallback
+  when `from_pkcs1_der` fails, which would keep this small — but confirm the trait impl and
+  actual API before committing to (a)'s effort size; if it turns out to need manual ASN.1
+  surgery instead, reconsider (b).
+- **T3** Test: Register an RSA public key in both PKCS#1 and PKCS#8 form (via T2's chosen
+  fix), confirm both produce a working engine object usable by a subsequent
+  `SignatureVerify`; test that a genuinely malformed key now fails `Register` itself, not a
+  later operation.
+- *Exit:* no `register_*` call in this file has its `Result` discarded.
+
+*(M / P1 — T1 is mechanical; T2's real effort is unknown until the `pkcs8` trait is checked
+— do that check first, before estimating further.)*
+
+---
+
+## 5. Phase E — CryptographicParameters persistence gaps
+
+Two related findings, both about a field not making it onto the stored `ObjectRecord` where
+it should. **Both re-verified directly, no corrections — held up exactly as v1 described.**
+
+**Finding #5.** `create_key_pair.rs` (~lines 331, 403). Re-verified: the shared
+`extract_attrs` helper (`register_import_export.rs:807-850`) genuinely parses
+`CryptographicParameters` into `priv_x.cryptographic_parameters`/
+`pub_x.cryptographic_parameters` (confirmed at line 831) — `create_key_pair.rs` simply never
+reads that field on either struct (zero matches on a direct grep for the field name in the
+file). Unlike `create.rs`, `register_import_export.rs`, and `derive_key.rs`, which all
+persist this field correctly. A key's declared default padding/hash (e.g. PSS/SHA-384) is
+silently lost; later bare Sign/Verify falls back to the mechanism default.
+- **T1** Add `cryptographic_parameters: Some(parsed)` to both `deps.store.put(...)` calls in
+  `create_key_pair.rs`, mirroring `create.rs`'s existing pattern exactly.
+- **T2** Test: CreateKeyPair with an explicit `CryptographicParameters` template (e.g. RSA +
+  PSS + SHA-384), confirm `GetAttributes` reports it back and a bare `Sign` (no per-request
+  override) actually uses PSS/SHA-384 rather than the mechanism default.
+
+**Finding #13.** `create_key_pair.rs` never checks a client's `QuantumSafe=true` claim
+against the resolved algorithm. Re-verified: `create.rs:137-151` performs this check
+(citing the real OASIS `QS-M-2` corpus test), a direct grep for `QuantumSafe`/`quantum_safe`
+in `create_key_pair.rs` returns zero hits.
+- **T1** Port the same check from `create.rs` into `create_key_pair.rs`.
+- **T2** Test: CreateKeyPair(RSA, QuantumSafe=true) → rejected, matching `create.rs`'s
+  existing test for the same scenario.
+
+*(S / P1 — both fixes are "copy the pattern that already exists two files over," low risk.)*
+
+---
+
+## 6. Phase F — Encrypt/Decrypt parameter fidelity for engine-resident keys
+
+**Finding #4.** `encrypt.rs:631`, `decrypt.rs:296`. For `Create`/`CreateKeyPair`'d keys
+(engine-resident, no `key_material` in the KMIP store), Encrypt/Decrypt call
+`native::encrypt`/`decrypt(session, handle, mech, data, iv)` — confirmed by reading the
+function directly (`rust/src/native/encrypt.rs:557-605`) to have **no AAD, tag-length, or
+OAEP-hash parameters at all**; the `CKM_AES_GCM` arm hardcodes empty AAD with a comment
+admitting it, and `CKM_RSA_PKCS_OAEP` hardcodes SHA-256 defaults with a similar comment.
+Those client-supplied values are only wired through on the `Register`'d-key (raw-material)
+path.
+
+`[v2 correction]` v1 flagged this as the highest-risk phase ("M–L... higher risk than the
+others because it changes a function signature multiple call sites depend on") and treated it
+as needing new engine-layer design work. **That overstated the risk.** Directly reading the
+target function revealed `native::encrypt_with_key_bytes`
+(`rust/src/native/encrypt.rs:702-744`) **already contains the complete real logic** — it's
+essentially the same match arms as `encrypt()`, with `aad`/`tag_len`/`oaep` genuinely threaded
+through to `aes_gcm_encrypt`/`rsa_oaep_encrypt`. The engine code's own comment on the gap
+(`encrypt.rs:572-574`) points at this exact function as the reference implementation. This is
+a plumbing/refactor task — reuse the existing, already-correct match body for the
+handle-based path — not new cryptography.
+
+- **T1** Refactor the shared match logic out of `encrypt_with_key_bytes`/
+  `decrypt_with_key_bytes` into a private helper both the raw-bytes path and a new/extended
+  handle-based path call, then extend `native::encrypt`/`native::decrypt`'s signature to
+  accept the same optional AAD/tag-length/OAEP-hash parameters, resolving the key bytes via
+  the existing `get_object_value(key_handle)` call already present in `encrypt()` and handing
+  them to the shared helper.
+- **T2** Update every existing caller of `native::encrypt`/`decrypt` in `kmip/` (not just
+  Encrypt/Decrypt's own handlers — check `helpers.rs` and any other call site) to pass the
+  new parameters instead of silently omitting them.
+- **T3** Test: Encrypt/Decrypt an engine-generated AES-GCM key with real AAD, confirm it's
+  genuinely authenticated (tampering the AAD on decrypt fails); Encrypt with an engine-
+  generated RSA key + explicit non-default OAEP hash (e.g. SHA-384 instead of SHA-256),
+  confirm the real hash was used (cross-check against an independent OAEP implementation, not
+  just "no error").
+- *Exit:* AAD/tag-length/OAEP-hash behave identically regardless of whether the key came from
+  `Create`/`CreateKeyPair` or `Register` — ideally because both paths now call the *same*
+  underlying match body, not two parallel implementations that happen to agree.
+
+*(M / P1 — downgraded from v1's M–L: the crypto logic already exists and is proven correct by
+`encrypt_with_key_bytes`'s own callers; this is call-site plumbing + a signature extension,
+not new engine design. Still the only phase touching `rust/`, still worth care on the
+multi-call-site update in T2.)*
+
+---
+
+## 7. Phase G — Dispatcher Undo / IDPlaceholder completeness
+
+**Finding #9.** `dispatcher/mod.rs`'s `newly_created_uids` doesn't match
+`ResponsePayload::Encapsulate`/`Decapsulate`/`CreateSplitKey`/`JoinSplitKey` — every other
+UID-producing op is handled, these four fall through the `_ => Vec::new()` catch-all.
+**Re-verified by reading both functions in full — confirmed on both:**
+`newly_created_uids` (`dispatcher/mod.rs:645-678`) has arms for Create, CreateKeyPair,
+Register, Import, CreateCredential, CreateGroup, CreateUser, DeriveKey, ReKey, ReKeyKeyPair,
+Certify, ReCertify, and Sign's `rekeyed` field — genuinely nothing for the four PQC/Split-Key
+ops. `update_id_placeholder` (`dispatcher/mod.rs:760-790`) has the identical gap. Two
+consequences: (a) a batch `Undo` after one of these ops succeeds leaks the newly-created
+object instead of rolling it back; (b) a later batch item referencing `$IDPlaceholder` after
+one of these fails with a spurious "ID Placeholder not set" error.
+
+Note: `EncapsulateResponse.rekeyed: Option<EncapsulateRekeyInfo>` already carries a doc
+comment stating it exists specifically so the dispatcher can find both new-key halves on
+rollback — the field was built for this and never wired up.
+
+- **T1** Add match arms for all four response types in `newly_created_uids`:
+  `Encapsulate` → the new Secret Data object's UID (+ `rekeyed`'s two UIDs when present, same
+  pattern `Sign`'s arm already uses for its own `rekeyed` field); `Decapsulate` → its new
+  shared-secret UID; `CreateSplitKey` → all `uids`; `JoinSplitKey` → its `uid`.
+- **T2** Add the same four arms to `update_id_placeholder`.
+- **T3** Test: a 2-item batch with `BatchErrorContinuationOption::Undo` where item 1 is one
+  of the four ops and item 2 deliberately fails — assert item 1's object is genuinely gone
+  from the store after Undo (not just relabeled `OperationUndone` in the response). Separately,
+  a 2-item batch where item 1 is one of the four ops and item 2 references
+  `$IDPlaceholder` — assert it resolves to the real UID instead of failing.
+- *Exit:* `newly_created_uids`/`update_id_placeholder` handle every `ResponsePayload` variant
+  that mints a UID — cross-check against the full enum rather than eyeballing.
+
+*(S / P1 — small, mechanical, no engine changes, but worth real tests since the bug is a
+silent object leak, not a loud failure.)*
+
+---
+
+## 8. Phase H — Remaining medium-priority gaps
+
+Three independent, low-effort items — batch together, no shared code. All three re-verified
+directly; two carry a clarifying note that changes context but not the fix.
+
+**Finding #10 — Locate filters most attributes silently.** `locate.rs:229-258`'s
+`build_filters` recognizes exactly 7 attribute types (`CryptographicAlgorithm`, `ObjectType`,
+`State`, `Name`, `ApplicationSpecificInformation`, `GroupLink`, `ObjectGroup` — confirmed by
+reading the function); anything else hits `_ => {}` and is dropped, so filtering by e.g.
+`CryptographicLength` is accepted as valid syntax and silently ignored (over-broad results,
+not an error). `[v2 clarification]` checked `LocateRequest`
+(`kmip30/ops.rs:553-566`) and confirmed `StorageStatusMask` is a **separate, dedicated
+top-level field**, not routed through `build_filters`'s generic `Attribute` list at all — it
+is genuinely implemented (3 existing tests) and **entirely unaffected by this gap**. Scope
+this fix to the generic attribute-list filters only; don't touch `StorageStatusMask` handling.
+- **T1** Either implement filters for the highest-value missing attributes
+  (`CryptographicLength`, `CryptographicUsageMask`, `UniqueIdentifier` at minimum — check
+  which ones the OASIS corpus's Locate tests actually exercise, since those already pass and
+  shouldn't regress), or make the decoder reject a Locate template containing an
+  unsupported filter attribute with a clear error instead of silently ignoring it. **Prefer
+  implementing the filters** — a Locate that returns too much is less harmful than one that
+  starts erroring on previously-silently-accepted templates, but confirm against whichever
+  real clients/tests currently send these before deciding.
+- **T2** Test: Locate with a `CryptographicLength` filter, confirm results are genuinely
+  narrowed, not just "doesn't error."
+
+**Finding #11 — AlternativeName Type is hardcoded/discarded.** `wire.rs:2788-2803` (decode)
+keeps only the Value half of the `AlternativeName` Structure; `wire.rs:4881-4887` (encode)
+always emits `Type=1` ("Uninterpreted Text String") regardless of what was set. Register with
+`Type=URI` → GetAttributes always reports `Type=1`. `[v2 clarification]` the decode side's
+own comment reveals this was a **known, deliberate trim from earlier this session**
+("Honest-Maximum Phase 2.1... the Type enumeration isn't read back by anything downstream
+yet"), found via the OASIS TL-M-2/TL-M-3 transcripts at the time — not a freshly-discovered
+silent bug. This is a documented deferred item finally getting completed, not a new
+regression. Doesn't change the fix.
+- **T1** Add a `Type` field wherever `AlternativeName`'s value is currently stored, decode +
+  persist + encode it for real.
+- **T2** Test: Register with `AlternativeNameType=URI(2)`, confirm it round-trips.
+
+**Finding #12 — SQLite store doesn't re-assert immutable dates on update.** Re-verified both
+functions directly: `MemoryStore::update` (`store/memory.rs:59-75`) fetches the existing
+record's `initial_date`/`original_creation_date` and overwrites the incoming record's fields
+with them before persisting — genuine defense-in-depth. `SqliteStore::update`
+(`store/sqlite.rs:196-250`) fetches only `state` (a targeted `SELECT state FROM objects`) for
+the FSM check, then serializes and writes the full passed-in record with no re-assertion.
+Confirmed as described, no correction.
+- **T1** Port the same re-assertion `MemoryStore::update` does into `SqliteStore::update`, so
+  both backends give the identical guarantee `store/lifecycle.rs`'s doc comment claims for
+  "this layer."
+- **T2** Test: call `update()` with a mutated `initial_date` against both backends, assert
+  both silently correct it back to the original rather than only one of them doing so.
+
+*(S / P2 — each is a small, contained fix; can be split across 3 tiny PRs or done together.)*
+
+---
+
+## 9. Phase I — Doc-only cleanup (no behavior change)
+
+One pass fixing stale comments found incidentally during the audit — none affect behavior,
+grouped here so they're tracked rather than silently forgotten:
+
+| File | Stale claim | Reality |
+|---|---|---|
+| `kmip/src/ops/session_and_auth.rs:1-6` | "acknowledge-only... Phase 12" | Login/Logout ticket issuance/expiry/invalidation is real (Phase 1.4, shipped) |
+| `kmip/src/ops/mod.rs:34` | "v0.1 uses placeholders so tests run without a token" | Extensive real PKCS#11 engine wiring exists now |
+| `kmip/src/policy/rule.rs:136-138` | "`MaxKeyAgeDays` never fires" | `check_pass2` genuinely evaluates it; `object_activation_date` is populated by 5 op handlers |
+| `kmip/src/auditlog/mod.rs:29-31` | P2/P3 events "⏳ Phase 5-6" pending | All emitted throughout `ops/*.rs` today |
+| `kmip/src/kmip30/message.rs:34-35` | Correlation Value/Async Indicator/Authentication "omitted in v0.1" | All three genuinely implemented |
+| `rust/src/ffi.rs:1201-1203` | "Stateful HBS keygen is not implemented" | HSS/XMSS/XMSS-MT keygen all call real tree generation |
+| `rust/src/native/sign.rs` module doc | excludes "stateful HSS / XMSS / LMS paths" | HSS is fully implemented (only XMSS genuinely absent, and that correctly errors) |
+| `rust/src/ck_abi.rs:39-49` | 64-bit pointer marshaling "returns `CKR_FUNCTION_FAILED`" | Marshals correctly at native width; the file's own test asserts `CKR_OK` |
+| `rust/src/constants.rs:693` | "Multi-part operation stubs... only supports single-shot" | Real multi-part accumulator state + `C_*Update`/`C_*Final` flows exist |
+
+Also: `kmip/src/auditlog/syslog.rs:62` swallows a UDP send failure with no log line, unlike
+every sibling sink (`otlp.rs`/`ring.rs`/`jsonl.rs` all log+count losses) — add the same
+`tracing::warn!` + drop-counter this repo's `AuditSink` trait doc says a sink "should" do on
+failure. Small enough to fold into this phase rather than its own.
+
+*(S / P3 — zero risk, do whenever convenient, e.g. bundled into whichever other phase's PR
+touches the same file.)*
+
+---
+
+## 10. Sequencing & dependencies
+
+```
+A (Destroy)                — independent, do first (P0, security)
+B (SetAttribute)            — independent of C (v1's claimed dependency was false — verified)
+C (wire tables)              — independent of B
+D (Register RSA)            — independent; check the pkcs8 trait before estimating T2 further
+E (CryptoParams)            — independent
+F (Encrypt/Decrypt)         — independent; lower risk than v1 stated, but still the only
+                               phase touching rust/ — do after the pure-kmip/ phases so any
+                               engine-side review bandwidth is used once, not interleaved
+G (Dispatcher Undo)         — independent
+H (medium-priority)         — independent, lowest priority of the numbered findings
+I (doc cleanup)             — zero-risk, fold into whichever PR touches each file
+```
+
+**Recommended order:** A → B → C → D → E → G → F → H → I (opportunistic). B/C/D/E/G have no
+inter-dependencies and can genuinely run in parallel if more than one person/session is
+available — the linear order above is for a single-threaded execution, not a hard requirement.
+
+## 11. Effort / risk
+
+| Tier | Phases |
+|---|---|
+| S / low | A, E, G, H, I |
+| M | B, C, D, F *(F downgraded from v1's M–L after reading the target function)* |
+
+*(v1 also listed a standalone "M–L / higher risk" tier containing only F; folded into M above
+per the Phase F correction — verify this still feels right once T1's refactor is scoped, since
+"the logic already exists" and "the refactor is risk-free" aren't quite the same claim.)*
+
+## 12. Definition of done
+
+- No `ObjectRecord` with `state == Destroyed` retains `key_material`, and the SQLite backend
+  has `secure_delete` configured (Phase A).
+- Every non-custom `Attribute` variant either genuinely persists via `SetAttribute` (per its
+  real spec modifiability rule) or is honestly rejected `AttributeReadOnly` — no silent
+  no-op, and no attribute made settable that the spec says isn't (Phase B).
+- `DeleteAttribute`'s independent name-based removal path has been checked for the same class
+  of gap, not assumed clean by association with the other two ops (Phase B/T3 follow-up).
+- `AdjustAttribute`/`DeleteAttribute` by numeric `AttributeReference` resolves every attribute
+  that decodes to its real name (Phase C) — resolving correctly is distinct from
+  `AdjustAttribute` *accepting* it, which stays narrowly scoped per its own spec-honest design.
+- `CryptographicParameters` round-trips fully (all fields) through `GetAttributes`/`Export`,
+  and is persisted by `CreateKeyPair` the same way `Create`/`Register`/`DeriveKey` already do
+  (Phases C, E).
+- `Register` never discards an engine-import failure (Phase D).
+- AAD/tag-length/OAEP-hash behave identically for engine-generated and Register'd keys,
+  ideally via one shared implementation rather than two that happen to agree (Phase F).
+- Batch `Undo`/`$IDPlaceholder` handle all UID-producing response types, not a subset
+  (Phase G).
+- `Locate` either filters or honestly rejects every attribute template clients can send,
+  without touching the already-working `StorageStatusMask` path (Phase H).
+- Every doc comment flagged in Phase I matches the code it describes.
+- `cargo test` green on both crates; new regression test per finding (not just "existing
+  suite still passes" — each fix ships with a test that would have caught the original gap).
+- Each phase's T0 (re-verify against current source before implementing) was actually done,
+  not skipped because this document already sounds confident.

--- a/kmip/src/auditlog/mod.rs
+++ b/kmip/src/auditlog/mod.rs
@@ -22,16 +22,18 @@
 //! [`RingSink`] for isolation. The trait is `Send + Sync` so one sink
 //! safely fans across concurrent emissions.
 //!
-//! ## What each plane emits (today vs planned)
+//! ## What each plane emits
 //!
-//! | Plane | Events | Status |
-//! |-------|--------|--------|
-//! | P1 — agility | `PolicyActivated`, `PolicyDecided`, `RekeyPlanned` | ✅ wired (this phase) |
-//! | P2 — KMIP    | `KmipRequestReceived`, `KmipResponseSent`, `KmipObjectStateChanged` | ⏳ Phase 5–6 |
-//! | P3 — PKCS#11 | `Pkcs11Call`, `Pkcs11SessionLifecycle` | ⏳ Phase 5 (when ops drive the bridge) |
+//! | Plane | Events |
+//! |-------|--------|
+//! | P1 — agility | `PolicyActivated`, `PolicyDecided`, `RekeyPlanned` |
+//! | P2 — KMIP    | `KmipRequestReceived`, `KmipResponseSent`, `KmipObjectStateChanged` |
+//! | P3 — PKCS#11 | `Pkcs11Call`, `Pkcs11SessionLifecycle` |
 //!
-//! Variant shape is committed wire-format — Phase 5 / 6 emitters fill in
-//! the payload fields, no schema change.
+//! All three planes are wired and emitted throughout `ops/*.rs` today
+//! (`emit_request`/`emit_success`/`emit_pkcs11*` helpers), driving real
+//! `Pkcs11Call` records with the actual softhsmrustv3 entry point + rv
+//! whenever `deps.engine_session` is present.
 
 pub mod composite;
 pub mod event;

--- a/kmip/src/auditlog/syslog.rs
+++ b/kmip/src/auditlog/syslog.rs
@@ -13,10 +13,13 @@
 //!
 //! Priority: `LOCAL0.INFO` (facility 16, severity 6 → encoded as 16*8+6 = 134).
 //!
-//! Failure mode: best-effort — any send error is silently ignored (same
-//! contract as [`super::sink::AuditSink`]).
+//! Failure mode: best-effort — a send error does not panic and the event
+//! is still dropped (UDP has no retry story here), but per the
+//! `AuditSink` trait's own "should log internally and drop" contract the
+//! loss is no longer silent — see [`SyslogSink::dropped`].
 
 use std::net::{SocketAddr, UdpSocket};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::event::AuditEvent;
 use super::sink::AuditSink;
@@ -28,6 +31,11 @@ pub struct SyslogSink {
     socket: UdpSocket,
     dest: SocketAddr,
     hostname: String,
+    /// Gap-remediation Phase I — count of events dropped due to a send
+    /// failure (serialise error or UDP `send_to` error). Every sibling
+    /// sink (otlp/ring/jsonl) already logs+counts its losses; this one
+    /// previously swallowed the error with no log line and no counter.
+    dropped: AtomicU64,
 }
 
 impl SyslogSink {
@@ -37,7 +45,13 @@ impl SyslogSink {
         let socket = UdpSocket::bind("0.0.0.0:0")?;
         socket.set_nonblocking(true)?;
         let hostname = hostname_str();
-        Ok(Self { socket, dest, hostname })
+        Ok(Self { socket, dest, hostname, dropped: AtomicU64::new(0) })
+    }
+
+    /// Number of audit events dropped due to a serialise or UDP send
+    /// failure.
+    pub fn dropped(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
     }
 }
 
@@ -47,6 +61,7 @@ impl AuditSink for SyslogSink {
             Ok(s) => s,
             Err(e) => {
                 tracing::error!(target: "audit.syslog", "serialise failed: {e}");
+                self.dropped.fetch_add(1, Ordering::Relaxed);
                 return;
             }
         };
@@ -58,8 +73,13 @@ impl AuditSink for SyslogSink {
             PRI = SYSLOG_PRI,
             host = self.hostname,
         );
-        // UDP is fire-and-forget; a full buffer or network error is silent.
-        let _ = self.socket.send_to(msg.as_bytes(), self.dest);
+        // UDP is fire-and-forget; a full buffer or network error still
+        // drops the event (no retry story here), but is now logged +
+        // counted instead of silently swallowed.
+        if let Err(e) = self.socket.send_to(msg.as_bytes(), self.dest) {
+            tracing::warn!(target: "audit.syslog", "send failed: {e}");
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
     }
 }
 
@@ -69,4 +89,32 @@ fn hostname_str() -> String {
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "pqctoday-kmip".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auditlog::event::{DecisionSummary, EventPayload, Plane};
+
+    /// Gap-remediation Phase I — `dropped()` exists and starts at 0; a
+    /// normal local send (127.0.0.1 UDP is effectively always
+    /// deliverable to the kernel's own loopback socket buffer) does not
+    /// increment it.
+    #[test]
+    fn dropped_starts_at_zero_and_stays_zero_on_a_normal_send() {
+        let sink = SyslogSink::open("127.0.0.1:514".parse().unwrap()).unwrap();
+        assert_eq!(sink.dropped(), 0);
+        sink.emit(AuditEvent::at(
+            time::OffsetDateTime::now_utc(),
+            Plane::Kmip,
+            "c",
+            EventPayload::PolicyDecided {
+                op: "t".into(),
+                algorithm: None,
+                outcome: DecisionSummary::Allow { algorithm_override: None, substituted_by_rule: None },
+                policy_fingerprint: "test".into(),
+            },
+        ));
+        assert_eq!(sink.dropped(), 0);
+    }
 }

--- a/kmip/src/dispatcher/mod.rs
+++ b/kmip/src/dispatcher/mod.rs
@@ -673,6 +673,25 @@ fn newly_created_uids(payload: &ResponsePayload) -> Vec<String> {
             Some(info) => vec![info.new_private_key_uid.clone(), info.new_public_key_uid.clone()],
             None => Vec::new(),
         },
+        // Gap-remediation Phase G, Finding #9 — these four PQC/Split-Key
+        // ops mint UIDs just like every arm above, but fell through to
+        // the catch-all: a batch Undo after one of them succeeded leaked
+        // the newly-created object instead of rolling it back.
+        // Encapsulate always mints a new Secret Data object for the
+        // shared secret (`uid`); `rekeyed` (same shape/rationale as
+        // Sign's own field above) additionally mints a fresh key pair
+        // when a crypto-agility rekey fired inline.
+        ResponsePayload::Encapsulate(r) => {
+            let mut uids = vec![r.uid.clone()];
+            if let Some(info) = &r.rekeyed {
+                uids.push(info.new_private_key_uid.clone());
+                uids.push(info.new_public_key_uid.clone());
+            }
+            uids
+        }
+        ResponsePayload::Decapsulate(r) => vec![r.uid.clone()],
+        ResponsePayload::CreateSplitKey(r) => r.uids.clone(),
+        ResponsePayload::JoinSplitKey(r) => vec![r.uid.clone()],
         _ => Vec::new(),
     }
 }
@@ -784,6 +803,15 @@ fn update_id_placeholder(state: &mut BatchState, payload: &ResponsePayload) {
         // Placeholder for the rest of the batch.
         ResponsePayload::Certify(r)      => Some(&r.uid),
         ResponsePayload::ReCertify(r)    => Some(&r.uid),
+        // Gap-remediation Phase G, Finding #9 — same 4 ops as
+        // `newly_created_uids` above; a batch item referencing
+        // `$IDPlaceholder` right after one of these used to fail with a
+        // spurious "ID Placeholder not set" instead of resolving to the
+        // real UID.
+        ResponsePayload::Encapsulate(r)   => Some(&r.uid),
+        ResponsePayload::Decapsulate(r)   => Some(&r.uid),
+        ResponsePayload::CreateSplitKey(r) => r.uids.first().map(|s| s.as_str()),
+        ResponsePayload::JoinSplitKey(r)  => Some(&r.uid),
         _ => None,
     };
     if let Some(u) = uid { state.id_placeholder = Some(u.to_string()); }

--- a/kmip/src/kmip30/attrs.rs
+++ b/kmip/src/kmip30/attrs.rs
@@ -328,7 +328,12 @@ pub enum Attribute {
 
     /// Identity / description strings.
     ShortUniqueIdentifier(String),
-    AlternativeName(String),
+    /// KMIP 3.0 §4.5 — Structure of `{ Alternative Name Value,
+    /// Alternative Name Type }`. Gap-remediation Phase H, Finding #11:
+    /// `name_type` used to be discarded on decode and hardcoded to `1`
+    /// (Uninterpreted Text String) on encode regardless of what the
+    /// client actually set; now genuinely carried through.
+    AlternativeName { value: String, name_type: u32 },
     Comment(String),
     Description(String),
     ContactInformation(String),

--- a/kmip/src/kmip30/message.rs
+++ b/kmip/src/kmip30/message.rs
@@ -26,14 +26,16 @@
 //!
 //! ## v0.1 simplifying assumptions
 //!
-//! - **One batch item per message.** The wire codec handles a single
-//!   Batch Item child of the Request/Response Message structure. Multi-op
-//!   batching is a spec feature deferred to v0.2.
 //! - **Protocol Version hardcoded `3.0`** (major=3, minor=0) — this is
 //!   the only version the engine speaks.
-//! - **Optional header fields omitted** — no Maximum Response Size,
-//!   Correlation Value, Asynchronous Indicator, Attestation, Authentication
-//!   in v0.1.
+//! - **Multi-item batching, Client/Server Correlation Value,
+//!   Asynchronous Indicator, and Authentication (Credential list) are
+//!   all genuinely implemented** — `batch_items: Vec<...>` on both
+//!   Request/ResponseMessage, `dispatcher::dispatch` iterates every item
+//!   (with Stop/Undo error-continuation semantics and §6.4 ID
+//!   Placeholder threading between items), Login/Logout issue and
+//!   validate real per-session tickets, and `AsynchronousIndicator`
+//!   drives `dispatcher`'s real async-job enqueue path for eligible ops.
 
 use time::OffsetDateTime;
 
@@ -70,10 +72,12 @@ pub struct RequestHeader {
     /// the encoded ResponseMessage would exceed it. `None` ≡ no
     /// limit.
     pub maximum_response_size: Option<i32>,
-    /// KMIP 3.0 §8.1.2 `Asynchronous Indicator` Enumeration. This
-    /// server has no asynchronous capability, so `Mandatory` fails
-    /// every batch item with `OperationNotSupported`; `Optional` /
-    /// `Prohibited` / absent all process synchronously (K4).
+    /// KMIP 3.0 §8.1.2 `Asynchronous Indicator` Enumeration. `Mandatory`
+    /// on an async-eligible op (`dispatcher::is_async_eligible`) enqueues
+    /// a real job (§9.1 Asynchronous Correlation Value) instead of
+    /// running inline, returning `OperationPending`; `Mandatory` on an
+    /// ineligible op fails that item with `OperationNotSupported`.
+    /// `Optional` / `Prohibited` / absent all process synchronously (K4).
     pub asynchronous_indicator: Option<AsynchronousIndicator>,
     /// KMIP 3.0 §8.1.2 / §9.4 `Authentication` Structure — "Credential,
     /// MAY be repeated" (spec Table 504). Empty ≡ the Authentication

--- a/kmip/src/kmip30/mod.rs
+++ b/kmip/src/kmip30/mod.rs
@@ -110,7 +110,7 @@ pub use message::{
     KMIP_VERSION_MINOR,
 };
 pub use wire::{
-    decode_request_message, decode_transparent_rsa_private_key, encode_request_message,
-    encode_response_message, ttlv_decode_key_value, ttlv_encode_key_value,
-    TransparentRsaPrivateKeyFields, WireError,
+    decode_request_message, decode_transparent_rsa_private_key, decode_transparent_rsa_public_key,
+    encode_request_message, encode_response_message, ttlv_decode_key_value, ttlv_encode_key_value,
+    TransparentRsaPrivateKeyFields, TransparentRsaPublicKeyFields, WireError,
 };

--- a/kmip/src/kmip30/ops.rs
+++ b/kmip/src/kmip30/ops.rs
@@ -1736,6 +1736,13 @@ pub struct RegisterRequest {
     /// populate `certificate_value` / `certificate_length` /
     /// `certificate_subject_cn` in one place.
     pub certificate_payload: Option<(u32, Vec<u8>)>,
+    /// Gap-remediation Phase C, Finding #8 — KMIP 3.0 §6.2 `SecretData`
+    /// Structure carries `SecretDataType` (Password = 0x01, Seed = 0x02)
+    /// alongside the `KeyBlock`; only meaningful when `object_type ==
+    /// SecretData`. Previously decoded then silently dropped, so a later
+    /// `Get` always reported the hardcoded `Password` default regardless
+    /// of what was actually registered.
+    pub secret_data_type: Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/kmip/src/kmip30/wire.rs
+++ b/kmip/src/kmip30/wire.rs
@@ -2782,21 +2782,31 @@ fn decode_attribute_v3(frame: &TtlvFrame) -> Result<Option<Attribute>, WireError
         // itself, so every real client-set AlternativeName (which always
         // wire-encodes as a Structure) silently decoded to `Ok(None)` and
         // was dropped — found via the OASIS TL-M-2/TL-M-3 conformance
-        // transcripts (Honest-Maximum Phase 2.1). We keep only the Value
-        // half on `Attribute::AlternativeName(String)`; the Type
-        // enumeration isn't read back by anything downstream yet.
+        // transcripts (Honest-Maximum Phase 2.1).
+        //
+        // Gap-remediation Phase H, Finding #11 — the Type enumeration is
+        // now decoded for real instead of being discarded. `1`
+        // (Uninterpreted Text String) is the spec default and also what
+        // a non-compliant bare-TextString frame implies.
         tags::AlternativeName => {
             if let Value::TextString(s) = &frame.value {
-                Attribute::AlternativeName(s.clone())
+                Attribute::AlternativeName { value: s.clone(), name_type: 1 }
             } else if let Value::Structure(children) = &frame.value {
                 let mut value = None;
+                let mut name_type = 1u32;
                 for c in children {
-                    if c.tag.0 == tags::AlternativeNameValue {
-                        if let Value::TextString(s) = &c.value { value = Some(s.clone()); }
+                    match c.tag.0 {
+                        tags::AlternativeNameValue => {
+                            if let Value::TextString(s) = &c.value { value = Some(s.clone()); }
+                        }
+                        tags::AlternativeNameType => {
+                            if let Value::Enumeration(v) = c.value { name_type = v; }
+                        }
+                        _ => {}
                     }
                 }
                 match value {
-                    Some(s) => Attribute::AlternativeName(s),
+                    Some(value) => Attribute::AlternativeName { value, name_type },
                     None => return Ok(None),
                 }
             } else { return Ok(None); }
@@ -4414,6 +4424,60 @@ pub fn decode_transparent_rsa_private_key(
     Ok(f)
 }
 
+/// `TransparentRSAPublicKey`'s `KeyMaterial` — just Modulus + Public
+/// Exponent (both mandatory per §6.2.1 Table 158).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TransparentRsaPublicKeyFields {
+    pub modulus: Vec<u8>,
+    pub public_exponent: Vec<u8>,
+}
+
+/// Gap-remediation Phase D/H (found via BL-M-8-30 conformance replay,
+/// not originally called out by name in Finding #3's text) — mirrors
+/// [`decode_transparent_rsa_private_key`] for the public-key half. Per
+/// `decode_key_block`'s own comment ("K8 stores its TTLV encoding
+/// verbatim... and the Register path can parse typed fields out of
+/// it" — citing BL-M-8 directly), this was always the intended design;
+/// only the private-key parser was ever implemented. Before this,
+/// `register_import_export.rs` fed the raw TTLV `KeyMaterial` bytes
+/// straight to `register_rsa_public_key_der` (which expects real DER),
+/// so a `TransparentRSAPublicKey` Register always failed internally —
+/// silently, while Finding #3's discarded-`Result` bug was still in
+/// place, and loudly (a regression this fix closes) once that bug was
+/// fixed.
+pub fn decode_transparent_rsa_public_key(
+    ttlv_key_material: &[u8],
+) -> Result<TransparentRsaPublicKeyFields, WireError> {
+    let frame = decode_one(ttlv_key_material)?;
+    if frame.tag.0 != tags::KeyMaterial {
+        return Err(WireError::UnexpectedTag {
+            got: frame.tag.0,
+            expected: tags::KeyMaterial,
+            name: "Transparent RSA Public Key material",
+        });
+    }
+    let mut f = TransparentRsaPublicKeyFields::default();
+    for c in expect_structure(&frame, "Key Material")? {
+        let dst = match c.tag.0 {
+            tags::Modulus        => &mut f.modulus,
+            tags::PublicExponent => &mut f.public_exponent,
+            _ => continue,
+        };
+        if let Value::BigInteger(b) = &c.value {
+            *dst = b.clone();
+        }
+    }
+    for (field, tag, name) in [
+        (&f.modulus, tags::Modulus, "Modulus"),
+        (&f.public_exponent, tags::PublicExponent, "Public Exponent"),
+    ] {
+        if field.is_empty() {
+            return Err(WireError::Missing { tag, name });
+        }
+    }
+    Ok(f)
+}
+
 /// Encode an Export response payload per §6.1.22 / Table 317:
 /// ObjectType + UID + Attributes (Structure) + Any Object (SymmetricKey
 /// / PublicKey / PrivateKey wrapping a KeyBlock).
@@ -4908,16 +4972,15 @@ fn encode_attribute_v3(a: &Attribute) -> TtlvFrame {
             TtlvFrame::new(Tag(tags::ShortUniqueIdentifier), Value::ByteString(bytes))
         }
         // KMIP 3.0 §4.5 — Structure { Alternative Name Value, Alternative
-        // Name Type }, mirroring the decode side. We only track the Value
-        // half internally, so Type is a fixed `Uninterpreted Text String`
-        // (§11.2 Alternative Name Type Enumeration, value 1) — the correct
-        // default for a free-text label with no more specific semantic
-        // (not a URI / serial number / email / DNS name / X.500 DN / IP).
-        Attribute::AlternativeName(s) => TtlvFrame::new(
+        // Name Type }, mirroring the decode side. Gap-remediation Phase
+        // H, Finding #11 — `name_type` now genuinely round-trips instead
+        // of always being re-emitted as `1` (Uninterpreted Text String)
+        // regardless of what the client set.
+        Attribute::AlternativeName { value, name_type } => TtlvFrame::new(
             Tag(tags::AlternativeName),
             Value::Structure(vec![
-                TtlvFrame::new(Tag(tags::AlternativeNameValue), Value::TextString(s.clone())),
-                TtlvFrame::new(Tag(tags::AlternativeNameType), Value::Enumeration(1)),
+                TtlvFrame::new(Tag(tags::AlternativeNameValue), Value::TextString(value.clone())),
+                TtlvFrame::new(Tag(tags::AlternativeNameType), Value::Enumeration(*name_type)),
             ]),
         ),
         Attribute::Comment(s)                  => TtlvFrame::new(Tag(tags::Comment),                  Value::TextString(s.clone())),
@@ -6562,5 +6625,35 @@ mod tests {
         ];
         let req = decode_delete_attribute_req(&frames).unwrap();
         assert_eq!(req.attribute_reference.as_deref(), Some("Split Key Method"));
+    }
+
+    /// Gap-remediation Phase H, Finding #11 — `AlternativeNameType` must
+    /// survive decode → encode instead of being silently discarded on
+    /// decode and hardcoded to `1` (Uninterpreted Text String) on
+    /// encode regardless of what the client set. `2` = URI per §11.2.
+    #[test]
+    fn alternative_name_type_round_trips_through_structure_form() {
+        let frame = TtlvFrame::new(Tag(tags::AlternativeName), Value::Structure(vec![
+            TtlvFrame::new(Tag(tags::AlternativeNameValue), Value::TextString("https://example/asset/1".into())),
+            TtlvFrame::new(Tag(tags::AlternativeNameType), Value::Enumeration(2)), // URI
+        ]));
+        let decoded = decode_attribute_v3(&frame).unwrap().unwrap();
+        assert_eq!(
+            decoded,
+            Attribute::AlternativeName { value: "https://example/asset/1".into(), name_type: 2 },
+        );
+        let re_encoded = encode_attribute_v3(&decoded);
+        let round_tripped = decode_attribute_v3(&re_encoded).unwrap().unwrap();
+        assert_eq!(round_tripped, decoded, "Type must survive an encode/decode round trip, not just decode");
+    }
+
+    /// A bare `TextString` AlternativeName (non-compliant but seen in
+    /// the wild) defaults to Type `1` (Uninterpreted Text String), the
+    /// same default the encoder used to hardcode unconditionally.
+    #[test]
+    fn alternative_name_bare_text_string_defaults_to_uninterpreted_type() {
+        let frame = TtlvFrame::new(Tag(tags::AlternativeName), Value::TextString("legacy-label".into()));
+        let decoded = decode_attribute_v3(&frame).unwrap().unwrap();
+        assert_eq!(decoded, Attribute::AlternativeName { value: "legacy-label".into(), name_type: 1 });
     }
 }

--- a/kmip/src/kmip30/wire.rs
+++ b/kmip/src/kmip30/wire.rs
@@ -3149,8 +3149,34 @@ fn encode_cryptographic_parameters(cp: &CryptographicParameters) -> TtlvFrame {
     if let Some(v) = cp.block_cipher_mode {
         children.push(TtlvFrame::new(Tag(tags::BlockCipherMode), Value::Enumeration(v)));
     }
+    // Gap-remediation Phase C, Finding #6 — these 7 fields were fully
+    // decoded (see `decode_cryptographic_parameters` below) but never
+    // encoded back out, so a PQC signing object with Deterministic/
+    // ContextString set, or an AEAD object with TagLength set, lost
+    // those fields on every GetAttributes/Export response.
+    if let Some(v) = cp.tag_length {
+        children.push(TtlvFrame::new(Tag(tags::TagLength), Value::Integer(v)));
+    }
+    if let Some(v) = cp.random_iv {
+        children.push(TtlvFrame::new(Tag(tags::RandomIV), Value::Boolean(v)));
+    }
     if let Some(v) = cp.salt_length {
         children.push(TtlvFrame::new(Tag(tags::SaltLength), Value::Integer(v)));
+    }
+    if let Some(v) = cp.deterministic {
+        children.push(TtlvFrame::new(Tag(tags::Deterministic), Value::Boolean(v)));
+    }
+    if let Some(b) = &cp.context_string {
+        children.push(TtlvFrame::new(Tag(tags::ContextString), Value::ByteString(b.clone())));
+    }
+    if let Some(v) = cp.internal {
+        children.push(TtlvFrame::new(Tag(tags::Internal), Value::Boolean(v)));
+    }
+    if let Some(v) = cp.external_mu {
+        children.push(TtlvFrame::new(Tag(tags::ExternalMu), Value::Boolean(v)));
+    }
+    if let Some(b) = &cp.random {
+        children.push(TtlvFrame::new(Tag(tags::PqcRandom), Value::ByteString(b.clone())));
     }
     if let Some(k) = cp.kem_algorithm {
         children.push(TtlvFrame::new(Tag(tags::KemAlgorithm), Value::Enumeration(k.to_wire_value())));
@@ -3991,6 +4017,7 @@ fn decode_register_req(children: &[TtlvFrame]) -> Result<RegisterRequest, WireEr
     let mut managed_object = None;
     let mut protection_storage_masks = None;
     let mut certificate_payload: Option<(u32, Vec<u8>)> = None;
+    let mut secret_data_type: Option<u32> = None;
     for c in children {
         match c.tag.0 {
             tags::ObjectType => {
@@ -4012,12 +4039,19 @@ fn decode_register_req(children: &[TtlvFrame]) -> Result<RegisterRequest, WireEr
             }
             tags::SecretData => {
                 // KMIP 3.0 §6.2 SecretData Structure: SecretDataType
-                // (Enumeration) + KeyBlock. v0.1 captures the inner
-                // KeyBlock and silently drops the type; future Get
-                // can echo it as ObjectType=SecretData.
+                // (Enumeration) + KeyBlock. Gap-remediation Phase C,
+                // Finding #8 — the type is now captured too (mirroring
+                // the adjacent OpaqueObject arm's OpaqueDataType
+                // handling) instead of being silently dropped.
                 for child in expect_structure(c, "Secret Data")? {
-                    if child.tag.0 == tags::KeyBlock {
-                        managed_object = Some(decode_key_block(child)?);
+                    match child.tag.0 {
+                        tags::KeyBlock => {
+                            managed_object = Some(decode_key_block(child)?);
+                        }
+                        tags::SecretDataType => {
+                            secret_data_type = Some(expect_enum(child, "Secret Data Type")?);
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -4110,6 +4144,7 @@ fn decode_register_req(children: &[TtlvFrame]) -> Result<RegisterRequest, WireEr
         managed_object,
         protection_storage_masks,
         certificate_payload,
+        secret_data_type,
     })
 }
 
@@ -5077,6 +5112,18 @@ fn tag_code_from_name(name: &str) -> Option<u32> {
         "Digest"                 => tags::Digest,
         "RandomNumberGenerator"  => tags::RandomNumberGenerator,
         "CryptographicParameters" => tags::CryptographicParameters,
+        // Gap-remediation Phase C, Finding #7 — `decode_attribute_v3`
+        // already fully decodes these 6; the numeric-`AttributeReference`
+        // lookup table (used by AdjustAttribute/DeleteAttribute per the
+        // Phase B/T3 correction — SetAttribute/ModifyAttribute never
+        // call this) just never learned their names, so a reference by
+        // code resolved to "Unknown" instead of the real attribute.
+        "CryptographicDomainParameters" => tags::CryptographicDomainParameters,
+        "SplitKeyMethod"         => tags::SplitKeyMethod,
+        "SplitKeyParts"          => tags::SplitKeyParts,
+        "SplitKeyThreshold"      => tags::SplitKeyThreshold,
+        "KeyPartIdentifier"      => tags::KeyPartIdentifier,
+        "SplitKeyPolynomial"     => tags::SplitKeyPolynomial,
         _ => return None,
     })
 }
@@ -5156,6 +5203,14 @@ fn tag_name_from_code(code: u32) -> &'static str {
         tags::ReplacedObjectLink     => "Replaced Object Link",
         tags::ReplacementObjectLink  => "Replacement Object Link",
         tags::ApplicationSpecificInformation => "Application Specific Information",
+        // Gap-remediation Phase C, Finding #7 — inverse of the 6 entries
+        // just added to `tag_code_from_name`.
+        tags::CryptographicDomainParameters => "Cryptographic Domain Parameters",
+        tags::SplitKeyMethod         => "Split Key Method",
+        tags::SplitKeyParts          => "Split Key Parts",
+        tags::SplitKeyThreshold      => "Split Key Threshold",
+        tags::KeyPartIdentifier      => "Key Part Identifier",
+        tags::SplitKeyPolynomial     => "Split Key Polynomial",
         _ => "Unknown",
     }
 }
@@ -6400,6 +6455,48 @@ mod tests {
         assert_eq!(decode_cryptographic_parameters(&neg).unwrap().salt_length, Some(-1));
     }
 
+    /// Gap-remediation Phase C, Finding #6 — `encode_cryptographic_parameters`
+    /// dropped 7 real fields (`tag_length`, `random_iv`, `deterministic`,
+    /// `context_string`, `internal`, `external_mu`, `random`) that
+    /// `decode_cryptographic_parameters` already understood. This is the
+    /// test gap the original K18 test above didn't cover (it never
+    /// populated any of these 7 fields, so the encoder's silent drop
+    /// never surfaced). Populate every one and prove the round trip is
+    /// truly lossless — not just for the 3 fields K18 already exercised.
+    #[test]
+    fn cryptographic_parameters_full_field_set_round_trips() {
+        let frame = TtlvFrame::new(Tag(tags::CryptographicParameters), Value::Structure(vec![
+            TtlvFrame::new(Tag(tags::HashingAlgorithm), Value::Enumeration(0x06)), // SHA-256
+            TtlvFrame::new(Tag(tags::CryptographicAlgorithm), Value::Enumeration(
+                crate::kmip30::KmipAlgorithm::MlDsa65.to_wire_value(),
+            )),
+            TtlvFrame::new(Tag(tags::PaddingMethod), Value::Enumeration(0x0a)), // PSS
+            TtlvFrame::new(Tag(tags::MaskGenerator), Value::Enumeration(0x01)), // MGF1
+            TtlvFrame::new(Tag(tags::MaskGeneratorHashingAlgorithm), Value::Enumeration(0x06)),
+            TtlvFrame::new(Tag(tags::PSource), Value::ByteString(vec![0x01, 0x02])),
+            TtlvFrame::new(Tag(tags::BlockCipherMode), Value::Enumeration(0x06)), // GCM
+            TtlvFrame::new(Tag(tags::TagLength), Value::Integer(16)),
+            TtlvFrame::new(Tag(tags::RandomIV), Value::Boolean(true)),
+            TtlvFrame::new(Tag(tags::SaltLength), Value::Integer(32)),
+            TtlvFrame::new(Tag(tags::Deterministic), Value::Boolean(true)),
+            TtlvFrame::new(Tag(tags::ContextString), Value::ByteString(vec![0xAA, 0xBB])),
+            TtlvFrame::new(Tag(tags::Internal), Value::Boolean(true)),
+            TtlvFrame::new(Tag(tags::ExternalMu), Value::Boolean(false)),
+            TtlvFrame::new(Tag(tags::PqcRandom), Value::ByteString(vec![0xCC; 4])),
+        ]));
+        let cp = decode_cryptographic_parameters(&frame).unwrap();
+        assert_eq!(cp.tag_length, Some(16));
+        assert_eq!(cp.random_iv, Some(true));
+        assert_eq!(cp.deterministic, Some(true));
+        assert_eq!(cp.context_string, Some(vec![0xAA, 0xBB]));
+        assert_eq!(cp.internal, Some(true));
+        assert_eq!(cp.external_mu, Some(false));
+        assert_eq!(cp.random, Some(vec![0xCC; 4]));
+
+        let cp2 = decode_cryptographic_parameters(&encode_cryptographic_parameters(&cp)).unwrap();
+        assert_eq!(cp2, cp, "every field must survive an encode/decode round trip");
+    }
+
     /// K10 — ML-KEM decapsulation round-trip: the request decodes the
     /// encapsulation bytes from `Data`, and the response carries the
     /// recovered shared secret in `Data` — no IvCounterNonce, no
@@ -6425,5 +6522,45 @@ mod tests {
         assert_eq!(data.value, Value::ByteString(vec![0x55; 32]));
         assert!(frames.iter().all(|f| f.tag.0 != tags::IvCounterNonce
             && f.tag.0 != super::super::vendor_tags::PQCTODAY_SHARED_SECRET));
+    }
+
+    /// Gap-remediation Phase C, Finding #7 — `tag_code_from_name`/
+    /// `tag_name_from_code` omitted `CryptographicDomainParameters` and
+    /// all 5 Split Key attributes even though `decode_attribute_v3`
+    /// fully decodes them, so a numeric `AttributeReference` (used by
+    /// AdjustAttribute/DeleteAttribute) to any of them resolved to the
+    /// literal string "Unknown" instead of the real name.
+    #[test]
+    fn tag_name_table_covers_domain_parameters_and_split_key_attributes() {
+        let pairs: &[(u32, &str)] = &[
+            (tags::CryptographicDomainParameters, "CryptographicDomainParameters"),
+            (tags::SplitKeyMethod, "SplitKeyMethod"),
+            (tags::SplitKeyParts, "SplitKeyParts"),
+            (tags::SplitKeyThreshold, "SplitKeyThreshold"),
+            (tags::KeyPartIdentifier, "KeyPartIdentifier"),
+            (tags::SplitKeyPolynomial, "SplitKeyPolynomial"),
+        ];
+        for (code, canonical) in pairs {
+            assert_eq!(tag_code_from_name(canonical), Some(*code), "{canonical} → code");
+            let name = tag_name_from_code(*code);
+            assert_ne!(name, "Unknown", "{canonical} (0x{code:08x}) must resolve to a real name");
+            let round_trip: String = name.chars().filter(|c| c.is_alphanumeric()).collect();
+            assert_eq!(&round_trip, canonical, "name → canonical round trip for {canonical}");
+        }
+    }
+
+    /// `DeleteAttribute`'s `AttributeReference` MAY arrive as a numeric
+    /// Enumeration (the tag codepoint) rather than a name Structure —
+    /// this only resolves to the right attribute if `tag_name_from_code`
+    /// knows it. Proves the fix end-to-end through the actual decoder,
+    /// not just the lookup table in isolation.
+    #[test]
+    fn delete_attribute_resolves_numeric_reference_for_split_key_method() {
+        let frames = vec![
+            TtlvFrame::new(Tag(tags::UniqueIdentifier), Value::TextString("u".into())),
+            TtlvFrame::new(Tag(tags::AttributeReference), Value::Enumeration(tags::SplitKeyMethod)),
+        ];
+        let req = decode_delete_attribute_req(&frames).unwrap();
+        assert_eq!(req.attribute_reference.as_deref(), Some("Split Key Method"));
     }
 }

--- a/kmip/src/ops/attribute_mutate.rs
+++ b/kmip/src/ops/attribute_mutate.rs
@@ -126,6 +126,20 @@ pub fn modify_attribute(
             KmipError::attribute_read_only(attribute_name(&req.new_attribute))));
     }
 
+    // Gap-remediation Phase B — §4.69 Table 90's guard condition:
+    // Usage Limits stops being client-modifiable once Get Usage
+    // Allocation has granted at least one allocation against it.
+    if matches!(&req.new_attribute, Attribute::UsageLimits { .. }) && usage_limits_locked(&obj) {
+        return Err(fail_err(deps, correlation_id, "ModifyAttribute",
+            KmipError::failed(
+                ResultReason::InvalidField,
+                format!(
+                    "UsageLimits on {} is no longer client-modifiable — Get Usage Allocation has already granted against it",
+                    req.uid,
+                ),
+            )));
+    }
+
     // Per KMIP 3.0 §11 attribute table — `Activation Date` is modifiable
     // only while the object is in `PreActive`. AKLC-M-3 + SKLC-M-3 step #4
     // both pin `WrongKeyLifecycleState` once the object is Active.
@@ -204,6 +218,20 @@ pub fn delete_attribute(
                     "Current Attribute does not match any existing value".to_string(),
                 )));
         }
+        // Gap-remediation Phase B/T3 — §4.69 Table 90: "Deletable by
+        // client: Yes, as long as Get Usage Allocation has not been
+        // performed" — the same guard condition as Set/ModifyAttribute,
+        // just phrased for Delete.
+        if matches!(current, Attribute::UsageLimits { .. }) && usage_limits_locked(&obj) {
+            return Err(fail_err(deps, correlation_id, "DeleteAttribute",
+                KmipError::failed(
+                    ResultReason::InvalidField,
+                    format!(
+                        "UsageLimits on {} is no longer client-deletable — Get Usage Allocation has already granted against it",
+                        req.uid,
+                    ),
+                )));
+        }
         remove_attribute_by_value(&mut obj, current);
     } else if let Some(name) = &req.attribute_reference {
         if attribute_name_is_required(name) {
@@ -218,6 +246,17 @@ pub fn delete_attribute(
                 KmipError::failed(
                     ResultReason::ItemNotFound,
                     format!("attribute {name} not present on {}", req.uid),
+                )));
+        }
+        let canonical_name: String = name.chars().filter(|c| c.is_alphanumeric()).collect();
+        if canonical_name == "UsageLimits" && usage_limits_locked(&obj) {
+            return Err(fail_err(deps, correlation_id, "DeleteAttribute",
+                KmipError::failed(
+                    ResultReason::InvalidField,
+                    format!(
+                        "UsageLimits on {} is no longer client-deletable — Get Usage Allocation has already granted against it",
+                        req.uid,
+                    ),
                 )));
         }
         remove_attribute_by_name(&mut obj, name);
@@ -256,6 +295,20 @@ pub fn set_attribute(
             KmipError::failed(
                 ResultReason::InvalidField,
                 format!("attribute {:?} is Read-Only", attribute_name(&req.new_attribute)),
+            )));
+    }
+
+    // Gap-remediation Phase B — §4.69 Table 90's guard condition:
+    // Usage Limits stops being client-modifiable once Get Usage
+    // Allocation has granted at least one allocation against it.
+    if matches!(&req.new_attribute, Attribute::UsageLimits { .. }) && usage_limits_locked(&obj) {
+        return Err(fail_err(deps, correlation_id, "SetAttribute",
+            KmipError::failed(
+                ResultReason::InvalidField,
+                format!(
+                    "UsageLimits on {} is no longer client-modifiable — Get Usage Allocation has already granted against it",
+                    req.uid,
+                ),
             )));
     }
 
@@ -392,6 +445,16 @@ fn attribute_name_is_required(name: &str) -> bool {
 /// Per KMIP 3.0 §11 attribute table these attributes are Read-Only —
 /// server SHALL NOT honour client attempts to add or modify them. The
 /// list below mirrors the spec's "Modifiable by client = No" column.
+///
+/// Gap-remediation Phase B — every entry below (past the original
+/// v0.1 set) was verified directly against the spec's own
+/// attribute-rules tables (`kmip-spec-v3.0.pdf` §4.x, "Modifiable by
+/// client" row), not inferred from context — a first-pass draft of
+/// this fix had 3 wrong entries (CryptographicDomainParameters,
+/// ProtectionStorageMask, KeyFormatType belong here; the Link
+/// sub-types and ProtectionLevel do NOT — see `apply_attribute`)
+/// caught only by re-checking every attribute against the spec text
+/// before implementing.
 fn attribute_is_read_only(a: &Attribute) -> bool {
     matches!(a,
         Attribute::UniqueIdentifier(_) |
@@ -419,8 +482,52 @@ fn attribute_is_read_only(a: &Attribute) -> bool {
         Attribute::CertificateSubjectCN(_) |
         Attribute::X509CertificateSubject(_) |
         Attribute::X509CertificateIssuer(_) |
-        Attribute::X509CertificateIdentifier(_)
+        Attribute::X509CertificateIdentifier(_) |
+        // §4.16 Table 89 — "Modifiable by client: No". Distinct from
+        // `CryptographicParameters`, which IS client-modifiable
+        // (Table 93) — see `apply_attribute`.
+        Attribute::CryptographicDomainParameters { .. } |
+        // §4.50 — "Modifiable by client: No". The server is the only
+        // authority on which storage classes actually back an object.
+        Attribute::ProtectionStorageMask(_) |
+        // §4.29 — "Modifiable by client: No".
+        Attribute::KeyFormatType(_) |
+        // §4.25 — "Modifiable by client: No".
+        Attribute::DigitalSignatureAlgorithm(_) |
+        // §4.38 — "Modifiable by client: No".
+        Attribute::NistKeyType(_) |
+        // §4.53 — "Modifiable by client: No". Set by Revoke, not
+        // client-editable afterward.
+        Attribute::RevocationReasonCode(_) |
+        // §4.21 — "Modifiable by client: No". Set by Deactivate.
+        Attribute::DeactivationReasonCode(_) |
+        // §4.7 — "Modifiable by client: No". Server-derived from the
+        // Certificate Value DER at Register time, same posture as the
+        // CertificateLength/SubjectCN/Issuer/Subject group above.
+        Attribute::CertificateType(_) |
+        Attribute::CertificateValue(_) |
+        // §4.63-4.66 — all four Split Key attributes plus Key Part
+        // Identifier are "Modifiable by client: No"; they describe the
+        // share's own math (method/threshold/parts/index/polynomial),
+        // fixed at Create Split Key time, not something to edit after
+        // the fact.
+        Attribute::SplitKeyMethod(_) |
+        Attribute::SplitKeyParts(_) |
+        Attribute::SplitKeyThreshold(_) |
+        Attribute::KeyPartIdentifier(_) |
+        Attribute::SplitKeyPolynomial(_)
     )
+}
+
+/// Gap-remediation Phase B — §4.69 Table 90: `Usage Limits` is
+/// "Modifiable by client: Yes (Usage Limits Total and/or Usage Limits
+/// Unit only, as long as Get Usage Allocation has not been performed)".
+/// `usage_limits_remaining` starts `None` and only becomes `Some(_)`
+/// once `GetUsageAllocation` grants the first allocation
+/// (`ops/allocation_and_config.rs`) — exactly the signal the spec's
+/// guard condition needs.
+fn usage_limits_locked(obj: &ObjectRecord) -> bool {
+    obj.usage_limits_remaining.is_some()
 }
 
 /// True if `obj` currently has a value for the attribute carried in `a`.
@@ -438,6 +545,24 @@ fn attribute_present(obj: &ObjectRecord, a: &Attribute) -> bool {
         Attribute::PreviousLink(_)           => obj.links.contains_key("PreviousLink"),
         Attribute::PublicKeyLink(_)          => obj.links.contains_key("PublicKeyLink"),
         Attribute::PrivateKeyLink(_)         => obj.links.contains_key("PrivateKeyLink"),
+        // Gap-remediation Phase B/T3 — these 5 link types (the
+        // pre-existing GroupLink plus the 4 newly-settable Derivation/
+        // Replacement links) fell through to the `true` catch-all
+        // below, which made `AddAttribute` on a *fresh* object (that
+        // never had the link set) wrongly fail with
+        // `AttributeSingleValued` instead of succeeding — harmless
+        // while these were no-ops in `apply_attribute`, load-bearing
+        // now that they're genuinely persisted.
+        Attribute::GroupLink(_)                   => obj.links.contains_key("GroupLink"),
+        Attribute::DerivationBaseObjectLink(_)    => obj.links.contains_key("DerivationBaseObjectLink"),
+        Attribute::DerivedObjectLink(_)            => obj.links.contains_key("DerivedObjectLink"),
+        Attribute::ReplacedObjectLink(_)           => obj.links.contains_key("ReplacedObjectLink"),
+        Attribute::ReplacementObjectLink(_)        => obj.links.contains_key("ReplacementObjectLink"),
+        // Same class of gap for the three attributes Phase B just made
+        // genuinely settable.
+        Attribute::ProtectionLevel(_)         => obj.protection_level.is_some(),
+        Attribute::CryptographicParameters(_) => obj.cryptographic_parameters.is_some(),
+        Attribute::UsageLimits { .. }         => obj.usage_limits_total.is_some(),
         // KMIP `Object Group` is multi-instance: "present" means THIS
         // exact membership already exists. AddAttribute may add further
         // distinct groups; re-adding the same one trips the §6.1.2
@@ -482,7 +607,22 @@ fn attribute_name_present(obj: &ObjectRecord, name: &str) -> bool {
         "CryptographicLength"     => obj.cryptographic_length > 0,
         "CryptographicUsageMask"  => !obj.usage_mask.is_empty(),
         "ObjectType" | "State" | "UniqueIdentifier" => true,
-        _ => obj.custom_attributes.contains_key(name) || obj.links.contains_key(name),
+        // Gap-remediation Phase B/T3 — same three attributes as
+        // `attribute_present`'s corresponding fix.
+        "ProtectionLevel"         => obj.protection_level.is_some(),
+        "CryptographicParameters" => obj.cryptographic_parameters.is_some(),
+        "UsageLimits"             => obj.usage_limits_total.is_some(),
+        // Gap-remediation Phase B/T3 — the pre-existing catch-all
+        // checked `obj.links.contains_key(name)` against the RAW
+        // decoded reference (e.g. "Next Link", spec-cased with a
+        // space per `tag_name_from_code`), never matching the
+        // no-space keys `apply_attribute` actually writes
+        // ("NextLink"). Every `DeleteAttribute` by name against any
+        // Link attribute has always spuriously returned
+        // `ItemNotFound` as a result. Match on `canonical` (already
+        // space-stripped) instead, same as `remove_attribute_by_name`
+        // below.
+        _ => obj.custom_attributes.contains_key(name) || obj.links.contains_key(&canonical),
     }
 }
 
@@ -496,6 +636,19 @@ fn link_target(a: &Attribute) -> Option<(&'static str, &str)> {
         Attribute::PublicKeyLink(uid)  => Some(("PublicKeyLink", uid)),
         Attribute::PrivateKeyLink(uid) => Some(("PrivateKeyLink", uid)),
         Attribute::GroupLink(uid)      => Some(("GroupLink", uid)),
+        // Gap-remediation Phase B — KMIP 3.0 Tables 136/138/160/162 all
+        // say "Modifiable by client: Yes" for these four (verified
+        // directly against the spec, not assumed), so `apply_attribute`
+        // below now persists them for real. Wiring them into
+        // `link_target` too means `check_circular_link` (already called
+        // generically by Add/Modify/SetAttribute) actually protects
+        // them — without this, making them settable would let a client
+        // create a genuine circular link the way ReKey/DeriveKey's own
+        // internal writes never could.
+        Attribute::DerivationBaseObjectLink(uid) => Some(("DerivationBaseObjectLink", uid)),
+        Attribute::DerivedObjectLink(uid)         => Some(("DerivedObjectLink", uid)),
+        Attribute::ReplacedObjectLink(uid)         => Some(("ReplacedObjectLink", uid)),
+        Attribute::ReplacementObjectLink(uid)      => Some(("ReplacementObjectLink", uid)),
         _ => None,
     }
 }
@@ -590,6 +743,17 @@ fn apply_attribute(obj: &mut ObjectRecord, a: &Attribute) {
         Attribute::PublicKeyLink(uid)        => { obj.links.insert("PublicKeyLink".into(), uid.clone()); }
         Attribute::PrivateKeyLink(uid)       => { obj.links.insert("PrivateKeyLink".into(), uid.clone()); }
         Attribute::GroupLink(uid)            => { obj.links.insert("GroupLink".into(), uid.clone()); }
+        // Gap-remediation Phase B — §4.19/§4.22/§4.51/§4.52 (Tables
+        // 136/138/160/162): all "Modifiable by client: Yes", same
+        // posture as the five link types just above. `link_target`
+        // (used by `check_circular_link`, already called generically
+        // by every caller of `apply_attribute`) now recognizes these
+        // four too, so making them real doesn't also open a
+        // circular-link hole.
+        Attribute::DerivationBaseObjectLink(uid) => { obj.links.insert("DerivationBaseObjectLink".into(), uid.clone()); }
+        Attribute::DerivedObjectLink(uid)         => { obj.links.insert("DerivedObjectLink".into(), uid.clone()); }
+        Attribute::ReplacedObjectLink(uid)         => { obj.links.insert("ReplacedObjectLink".into(), uid.clone()); }
+        Attribute::ReplacementObjectLink(uid)      => { obj.links.insert("ReplacementObjectLink".into(), uid.clone()); }
         // KMIP `Object Group` (0x420056) — multi-instance: AddAttribute
         // appends a fresh membership; SetAttribute reuses this path so a
         // repeated value is idempotent (deduped).
@@ -630,10 +794,35 @@ fn apply_attribute(obj: &mut ObjectRecord, a: &Attribute) {
         Attribute::RotateInterval(n)           => obj.rotate_interval = Some(*n),
         Attribute::RotateOffset(n)             => obj.rotate_offset = Some(*n),
         Attribute::RotateGeneration(n)         => obj.rotate_generation = Some(*n),
+        // §4.48 Table 148 — "Modifiable by client: Yes".
+        Attribute::ProtectionLevel(n)          => obj.protection_level = Some(*n),
+        // Gap-remediation Phase B — §4.18 Table 93: "Modifiable by
+        // client: Yes", unconditionally (unlike UsageLimits below, no
+        // guard condition). Distinct from `CryptographicDomainParameters`
+        // (read-only, see `attribute_is_read_only`).
+        Attribute::CryptographicParameters(cp) => obj.cryptographic_parameters = Some(cp.clone()),
+        // Gap-remediation Phase B — §4.69 Table 90: "Modifiable by
+        // client: Yes (Usage Limits Total and/or Usage Limits Unit
+        // only, as long as Get Usage Allocation has not been
+        // performed)". The guard condition is enforced by the callers
+        // (`set_attribute`/`modify_attribute`, via `usage_limits_locked`)
+        // before this ever runs; `count` (the remaining budget) is
+        // deliberately NOT settable here — that's server-managed via
+        // GetUsageAllocation, same as `extract_attrs`'s identical
+        // Create/Register-time handling of this attribute.
+        Attribute::UsageLimits { total, unit, .. } => {
+            obj.usage_limits_total = Some(*total);
+            obj.usage_limits_unit = *unit;
+        }
         // Read-only or server-managed Baseline attributes (Initial Date,
         // Last Change Date, Original Creation Date, Short UID, Always/
-        // Never Sensitive, Key Value Present, Certificate*, etc.) — the
-        // server sets these; client AddAttribute is a no-op.
+        // Never Sensitive, Key Value Present, Certificate*, Split Key*,
+        // etc.) — the server sets these; client AddAttribute is a no-op.
+        // Every non-custom variant that reaches this arm is intentional:
+        // it's either genuinely read-only (guarded by
+        // `attribute_is_read_only` before `apply_attribute` is ever
+        // called) or a vendor/forward-compat variant this store doesn't
+        // yet route to a typed field.
         _ => {}
     }
 }
@@ -647,6 +836,32 @@ fn remove_attribute_by_value(obj: &mut ObjectRecord, a: &Attribute) {
         // KMIP `Object Group` multi-instance — drop just the named
         // membership, leaving the object in any other groups.
         Attribute::ObjectGroup(g)            => { obj.object_groups.retain(|x| x != g); }
+        // Gap-remediation Phase B/T3 — `DeleteAttribute`'s
+        // `current_attribute`-value path had no arms at all for any
+        // Link type or for the three attributes Phase B just made
+        // genuinely settable: `attribute_present`/`attribute_is_required`
+        // would let the delete through, but this function then did
+        // nothing, so the client got a `Success` while the value stayed
+        // in the store. `UsageLimits`'s own guard (§4.69 Table 90:
+        // "Deletable by client: Yes, as long as Get Usage Allocation has
+        // not been performed") is enforced by the caller
+        // (`delete_attribute`, via `usage_limits_locked`) before this
+        // ever runs — mirrors the Set/ModifyAttribute guard exactly.
+        Attribute::NextLink(_)                    => { obj.links.remove("NextLink"); }
+        Attribute::PreviousLink(_)                => { obj.links.remove("PreviousLink"); }
+        Attribute::PublicKeyLink(_)               => { obj.links.remove("PublicKeyLink"); }
+        Attribute::PrivateKeyLink(_)              => { obj.links.remove("PrivateKeyLink"); }
+        Attribute::GroupLink(_)                   => { obj.links.remove("GroupLink"); }
+        Attribute::DerivationBaseObjectLink(_)    => { obj.links.remove("DerivationBaseObjectLink"); }
+        Attribute::DerivedObjectLink(_)           => { obj.links.remove("DerivedObjectLink"); }
+        Attribute::ReplacedObjectLink(_)          => { obj.links.remove("ReplacedObjectLink"); }
+        Attribute::ReplacementObjectLink(_)       => { obj.links.remove("ReplacementObjectLink"); }
+        Attribute::ProtectionLevel(_)             => { obj.protection_level = None; }
+        Attribute::CryptographicParameters(_)     => { obj.cryptographic_parameters = None; }
+        Attribute::UsageLimits { .. }             => {
+            obj.usage_limits_total = None;
+            obj.usage_limits_unit = None;
+        }
         // Required / Read-Only attributes guarded earlier.
         _ => {}
     }
@@ -658,6 +873,17 @@ fn remove_attribute_by_name(obj: &mut ObjectRecord, name: &str) {
         "Name"                   => obj.name = None,
         "CryptographicLength"    => obj.cryptographic_length = 0,
         "CryptographicUsageMask" => obj.usage_mask = UsageMask::empty(),
+        // Gap-remediation Phase B/T3 — same three attributes as
+        // `remove_attribute_by_value`'s corresponding fix; the generic
+        // `other` arm below only clears `custom_attributes`/`links`, so
+        // these three (stored in dedicated typed fields) need explicit
+        // arms or a name-based Delete silently no-ops for them too.
+        "ProtectionLevel"         => obj.protection_level = None,
+        "CryptographicParameters" => obj.cryptographic_parameters = None,
+        "UsageLimits"             => {
+            obj.usage_limits_total = None;
+            obj.usage_limits_unit = None;
+        }
         other => {
             obj.custom_attributes.remove(other);
             obj.links.remove(other);
@@ -1064,5 +1290,294 @@ mod tests {
             d.store.get("a").unwrap().unwrap().links.get("NextLink").map(String::as_str),
             Some("b")
         );
+    }
+
+    // ── Gap-remediation Phase B ─────────────────────────────────────────
+
+    /// §4.18 Table 93 — `CryptographicParameters` is client-modifiable
+    /// (unlike `CryptographicDomainParameters`, which is not). SetAttribute
+    /// must persist it for real, not silently drop it.
+    #[test]
+    fn set_attribute_cryptographic_parameters_round_trips() {
+        let d = deps_with();
+        put(&d, "u");
+        let cp = crate::kmip30::ops::CryptographicParameters {
+            padding_method: Some(0x07), // OAEP
+            ..Default::default()
+        };
+        set_attribute(&d, SetAttributeRequest {
+            uid: "u".into(),
+            new_attribute: Attribute::CryptographicParameters(cp.clone()),
+        }, "c").unwrap();
+        assert_eq!(
+            d.store.get("u").unwrap().unwrap().cryptographic_parameters,
+            Some(cp),
+        );
+    }
+
+    /// §4.48 Table 148 — `ProtectionLevel` is client-modifiable.
+    #[test]
+    fn set_attribute_protection_level_round_trips() {
+        let d = deps_with();
+        put(&d, "u");
+        set_attribute(&d, SetAttributeRequest {
+            uid: "u".into(),
+            new_attribute: Attribute::ProtectionLevel(1),
+        }, "c").unwrap();
+        assert_eq!(d.store.get("u").unwrap().unwrap().protection_level, Some(1));
+    }
+
+    /// §4.69 Table 90 — `UsageLimits` Total/Unit are client-modifiable
+    /// *before* Get Usage Allocation has been performed.
+    #[test]
+    fn set_attribute_usage_limits_round_trips_before_allocation() {
+        let d = deps_with();
+        put(&d, "u");
+        set_attribute(&d, SetAttributeRequest {
+            uid: "u".into(),
+            new_attribute: Attribute::UsageLimits { total: 500, count: None, unit: Some(1) },
+        }, "c").unwrap();
+        let rec = d.store.get("u").unwrap().unwrap();
+        assert_eq!(rec.usage_limits_total, Some(500));
+        assert_eq!(rec.usage_limits_unit, Some(1));
+    }
+
+    /// §4.69 Table 90's guard condition — once Get Usage Allocation has
+    /// granted at least one allocation, UsageLimits is no longer
+    /// client-modifiable via SetAttribute or ModifyAttribute.
+    #[test]
+    fn set_and_modify_attribute_usage_limits_rejected_after_allocation() {
+        let d = deps_with();
+        put(&d, "u");
+        let mut rec = d.store.get("u").unwrap().unwrap();
+        rec.usage_limits_total = Some(1000);
+        rec.usage_limits_remaining = Some(700); // Get Usage Allocation already ran.
+        d.store.update(rec).unwrap();
+
+        let err = set_attribute(&d, SetAttributeRequest {
+            uid: "u".into(),
+            new_attribute: Attribute::UsageLimits { total: 2000, count: None, unit: None },
+        }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::InvalidField);
+
+        let err = modify_attribute(&d, ModifyAttributeRequest {
+            uid: "u".into(),
+            current_attribute: None,
+            new_attribute: Attribute::UsageLimits { total: 2000, count: None, unit: None },
+        }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::InvalidField);
+
+        // The stored value must be untouched by the rejected attempts.
+        assert_eq!(d.store.get("u").unwrap().unwrap().usage_limits_total, Some(1000));
+    }
+
+    /// §4.16 Table 89 — `CryptographicDomainParameters` is Read-Only,
+    /// distinct from the client-modifiable `CryptographicParameters`
+    /// above; a first-pass draft of this fix conflated the two.
+    #[test]
+    fn set_attribute_cryptographic_domain_parameters_rejected_read_only() {
+        let d = deps_with();
+        put(&d, "u");
+        let err = set_attribute(&d, SetAttributeRequest {
+            uid: "u".into(),
+            new_attribute: Attribute::CryptographicDomainParameters { qlength: None, recommended_curve: None },
+        }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::InvalidField);
+    }
+
+    /// §4.50 — `ProtectionStorageMask` is Read-Only.
+    #[test]
+    fn set_attribute_protection_storage_mask_rejected_read_only() {
+        let d = deps_with();
+        put(&d, "u");
+        let err = set_attribute(&d, SetAttributeRequest {
+            uid: "u".into(),
+            new_attribute: Attribute::ProtectionStorageMask(1),
+        }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::InvalidField);
+    }
+
+    /// §4.29 — `KeyFormatType` is Read-Only.
+    #[test]
+    fn set_attribute_key_format_type_rejected_read_only() {
+        let d = deps_with();
+        put(&d, "u");
+        let err = set_attribute(&d, SetAttributeRequest {
+            uid: "u".into(),
+            new_attribute: Attribute::KeyFormatType(0x01), // Raw
+        }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::InvalidField);
+    }
+
+    /// Tables 136/138/160/162 — the four Derivation/Replacement link
+    /// types are client-modifiable, and (per `link_target`) still get
+    /// real circular-link protection: a direct A→B / B→A cycle via the
+    /// *same* link type (not the spec inverse) must be rejected.
+    #[test]
+    fn set_attribute_derivation_link_round_trips_and_detects_cycle() {
+        let d = deps_with();
+        put(&d, "a");
+        put(&d, "b");
+        set_attribute(&d, SetAttributeRequest {
+            uid: "a".into(),
+            new_attribute: Attribute::DerivationBaseObjectLink("b".into()),
+        }, "c").unwrap();
+        assert_eq!(
+            d.store.get("a").unwrap().unwrap().links.get("DerivationBaseObjectLink").map(String::as_str),
+            Some("b")
+        );
+
+        // b → a via the SAME (non-inverse) link type closes a true cycle.
+        let err = set_attribute(&d, SetAttributeRequest {
+            uid: "b".into(),
+            new_attribute: Attribute::DerivationBaseObjectLink("a".into()),
+        }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::CircularLinkError);
+
+        // b → a via the spec INVERSE (DerivedObjectLink) is the
+        // legitimate back edge and must be accepted.
+        set_attribute(&d, SetAttributeRequest {
+            uid: "b".into(),
+            new_attribute: Attribute::DerivedObjectLink("a".into()),
+        }, "c").unwrap();
+        assert_eq!(
+            d.store.get("b").unwrap().unwrap().links.get("DerivedObjectLink").map(String::as_str),
+            Some("a")
+        );
+    }
+
+    // ── Gap-remediation Phase B/T3 — DeleteAttribute's independent path ─
+
+    /// Before this fix, `attribute_present`'s catch-all unconditionally
+    /// claimed `ProtectionLevel`/`CryptographicParameters`/`UsageLimits`
+    /// were already present, so the very first `AddAttribute` for any of
+    /// them wrongly failed with `AttributeSingleValued` on a fresh
+    /// object that had never had the value set.
+    #[test]
+    fn add_attribute_protection_level_succeeds_on_fresh_object() {
+        let d = deps_with();
+        put(&d, "u");
+        add_attribute(&d, AddAttributeRequest {
+            uid: "u".into(),
+            new_attribute: Attribute::ProtectionLevel(1),
+        }, "c").unwrap();
+        assert_eq!(d.store.get("u").unwrap().unwrap().protection_level, Some(1));
+    }
+
+    /// Same class of gap for a Link type's first-time `AddAttribute`.
+    #[test]
+    fn add_attribute_derivation_link_succeeds_on_fresh_object() {
+        let d = deps_with();
+        put(&d, "a");
+        put(&d, "b");
+        add_attribute(&d, AddAttributeRequest {
+            uid: "a".into(),
+            new_attribute: Attribute::DerivationBaseObjectLink("b".into()),
+        }, "c").unwrap();
+        assert_eq!(
+            d.store.get("a").unwrap().unwrap().links.get("DerivationBaseObjectLink").map(String::as_str),
+            Some("b")
+        );
+    }
+
+    /// `DeleteAttribute` by `current_attribute` value must actually clear
+    /// `ProtectionLevel`/`CryptographicParameters`/`UsageLimits` and every
+    /// Link type — before this fix `remove_attribute_by_value` had no
+    /// arms for any of them and silently no-op'd.
+    #[test]
+    fn delete_attribute_by_value_clears_settable_attributes_and_links() {
+        let d = deps_with();
+        put(&d, "u");
+        set_attribute(&d, SetAttributeRequest {
+            uid: "u".into(), new_attribute: Attribute::ProtectionLevel(2),
+        }, "c").unwrap();
+        delete_attribute(&d, DeleteAttributeRequest {
+            uid: "u".into(),
+            current_attribute: Some(Attribute::ProtectionLevel(2)),
+            attribute_reference: None,
+        }, "c").unwrap();
+        assert_eq!(d.store.get("u").unwrap().unwrap().protection_level, None);
+
+        put(&d, "a");
+        put(&d, "b");
+        set_attribute(&d, SetAttributeRequest {
+            uid: "a".into(), new_attribute: Attribute::NextLink("b".into()),
+        }, "c").unwrap();
+        delete_attribute(&d, DeleteAttributeRequest {
+            uid: "a".into(),
+            current_attribute: Some(Attribute::NextLink("b".into())),
+            attribute_reference: None,
+        }, "c").unwrap();
+        assert!(d.store.get("a").unwrap().unwrap().links.get("NextLink").is_none());
+    }
+
+    /// `DeleteAttribute` by `attribute_reference` name for a Link type —
+    /// before this fix, `attribute_name_present`'s catch-all compared the
+    /// raw decoded reference name (spec-cased with a space, e.g. "Next
+    /// Link") against `obj.links`' no-space keys ("NextLink"), so this
+    /// always spuriously returned `ItemNotFound`.
+    #[test]
+    fn delete_attribute_by_name_finds_and_clears_link() {
+        let d = deps_with();
+        put(&d, "a");
+        put(&d, "b");
+        set_attribute(&d, SetAttributeRequest {
+            uid: "a".into(), new_attribute: Attribute::NextLink("b".into()),
+        }, "c").unwrap();
+        // Simulates the space-cased name `tag_name_from_code` decodes.
+        delete_attribute(&d, DeleteAttributeRequest {
+            uid: "a".into(),
+            current_attribute: None,
+            attribute_reference: Some("Next Link".into()),
+        }, "c").unwrap();
+        assert!(d.store.get("a").unwrap().unwrap().links.get("NextLink").is_none());
+    }
+
+    /// `DeleteAttribute` by `attribute_reference` name for `UsageLimits`
+    /// — before this fix the generic fallback arm only cleared
+    /// `custom_attributes`/`links`, so this silently no-op'd.
+    #[test]
+    fn delete_attribute_by_name_clears_usage_limits() {
+        let d = deps_with();
+        put(&d, "u");
+        set_attribute(&d, SetAttributeRequest {
+            uid: "u".into(),
+            new_attribute: Attribute::UsageLimits { total: 100, count: None, unit: Some(1) },
+        }, "c").unwrap();
+        delete_attribute(&d, DeleteAttributeRequest {
+            uid: "u".into(),
+            current_attribute: None,
+            attribute_reference: Some("Usage Limits".into()),
+        }, "c").unwrap();
+        assert_eq!(d.store.get("u").unwrap().unwrap().usage_limits_total, None);
+    }
+
+    /// §4.69 Table 90 — "Deletable by client: Yes, as long as Get Usage
+    /// Allocation has not been performed": once locked, DeleteAttribute
+    /// must reject both the by-value and by-name forms.
+    #[test]
+    fn delete_attribute_usage_limits_rejected_after_allocation() {
+        let d = deps_with();
+        put(&d, "u");
+        let mut rec = d.store.get("u").unwrap().unwrap();
+        rec.usage_limits_total = Some(1000);
+        rec.usage_limits_remaining = Some(700);
+        d.store.update(rec).unwrap();
+
+        let err = delete_attribute(&d, DeleteAttributeRequest {
+            uid: "u".into(),
+            current_attribute: Some(Attribute::UsageLimits { total: 1000, count: None, unit: None }),
+            attribute_reference: None,
+        }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::InvalidField);
+
+        let err = delete_attribute(&d, DeleteAttributeRequest {
+            uid: "u".into(),
+            current_attribute: None,
+            attribute_reference: Some("Usage Limits".into()),
+        }, "c").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::InvalidField);
+
+        assert_eq!(d.store.get("u").unwrap().unwrap().usage_limits_total, Some(1000));
     }
 }

--- a/kmip/src/ops/attribute_mutate.rs
+++ b/kmip/src/ops/attribute_mutate.rs
@@ -575,7 +575,7 @@ fn attribute_present(obj: &ObjectRecord, a: &Attribute) -> bool {
         Attribute::Description(_)            => obj.description.is_some(),
         Attribute::Comment(_)                => obj.comment.is_some(),
         Attribute::ContactInformation(_)     => obj.contact_information.is_some(),
-        Attribute::AlternativeName(_)        => obj.alternative_name.is_some(),
+        Attribute::AlternativeName { .. }    => obj.alternative_name.is_some(),
         Attribute::ObjectClass(_)            => obj.object_class.is_some(),
         Attribute::KeyValueLocation(_)       => obj.key_value_location.is_some(),
         Attribute::ActivationDate(_)         => obj.activation_date.is_some(),
@@ -779,7 +779,10 @@ fn apply_attribute(obj: &mut ObjectRecord, a: &Attribute) {
         Attribute::Fresh(b)                    => obj.fresh = Some(*b),
         Attribute::QuantumSafe(b)              => obj.quantum_safe = Some(*b),
         Attribute::RotateAutomatic(b)          => obj.rotate_automatic = Some(*b),
-        Attribute::AlternativeName(s)          => obj.alternative_name = Some(s.clone()),
+        Attribute::AlternativeName { value, name_type } => {
+            obj.alternative_name = Some(value.clone());
+            obj.alternative_name_type = Some(*name_type);
+        }
         Attribute::Comment(s)                  => obj.comment = Some(s.clone()),
         Attribute::Description(s)              => obj.description = Some(s.clone()),
         Attribute::ContactInformation(s)       => obj.contact_information = Some(s.clone()),

--- a/kmip/src/ops/create.rs
+++ b/kmip/src/ops/create.rs
@@ -197,6 +197,7 @@ pub fn create(deps: &Deps, mut req: CreateRequest, correlation_id: &str) -> Resu
         supersedes: None,
         name: x.name.clone(),
         alternative_name: x.alternative_name.clone(),
+        alternative_name_type: x.alternative_name_type,
         links: std::collections::HashMap::new(),
         // Y1 — persist the request's custom attributes so use-time gates read
         // the classification tag off the stored symmetric key.

--- a/kmip/src/ops/create_key_pair.rs
+++ b/kmip/src/ops/create_key_pair.rs
@@ -183,6 +183,30 @@ pub fn create_key_pair(
 
     let kmip_algo = parse_algorithm(&resolved_algorithm)?;
 
+    // Gap-remediation Phase E, Finding #13 — KMIP 3.0 §11 — reject
+    // `QuantumSafe=true` claims on non-PQC algorithms, same check
+    // `create.rs` already performs (QS-M-2 pins this with AES +
+    // QuantumSafe=true → `GeneralFailure` "NOT_SAFE"). QuantumSafe MAY
+    // ride on any of the three attribute baskets (Common/Private/Public),
+    // so check the full merged set like the Y1 custom-attribute lookup
+    // above does, not just one half.
+    {
+        let x = super::register_import_export::extract_attrs(&all_attrs);
+        if matches!(x.quantum_safe, Some(true))
+            && !super::register_import_export::algorithm_is_quantum_safe(kmip_algo)
+        {
+            return fail(
+                deps,
+                correlation_id,
+                op_canonical,
+                KmipError::failed(
+                    ResultReason::GeneralFailure,
+                    format!("QuantumSafe=true claimed for non-PQC algorithm {kmip_algo:?}"),
+                ),
+            );
+        }
+    }
+
     // Label-only Montgomery KEM: when the policy resolved the algorithm to
     // `X25519`/`X448` (a name, not a template CryptographicDomainParameters),
     // supply the matching RecommendedCurve + §6.7 mech-info length here so the
@@ -361,6 +385,14 @@ pub fn create_key_pair(
             // (Sign/Encrypt) can read the classification back off the object.
             custom_attributes: super::helpers::raw_custom_attrs(&all_attrs),
 
+            // Gap-remediation Phase E, Finding #5 — `create.rs`,
+            // `register_import_export.rs`, and `derive_key.rs` all
+            // persist this field; `create_key_pair.rs` never read it off
+            // `priv_x`/`pub_x`, so a key's declared default padding/hash
+            // (e.g. PSS/SHA-384) was silently lost and a later bare
+            // Sign/Verify fell back to the mechanism default.
+            cryptographic_parameters: priv_x.cryptographic_parameters.clone(),
+
 
             // K6 — hybrid private keys are engine-backed (two handles behind
             // pkcs11_cka_id + pkcs11_cka_id_secondary); no material here, so Get
@@ -429,6 +461,10 @@ pub fn create_key_pair(
 
             custom_attributes: std::collections::HashMap::new(),
 
+            // Gap-remediation Phase E, Finding #5 — same fix as the
+            // private half above; the public half has its own
+            // independently-templated CryptographicParameters basket.
+            cryptographic_parameters: pub_x.cryptographic_parameters.clone(),
 
             // K6 — composite public key material for a hybrid KEM.
             key_material: hybrid_pub_material,
@@ -1059,5 +1095,80 @@ rules: []
         // Classical sized names collapse to base.
         assert_eq!(parse_algorithm("AES-256").unwrap(), KmipAlgorithm::Aes);
         assert_eq!(parse_algorithm("ECDSA-P256").unwrap(), KmipAlgorithm::Ecdsa);
+    }
+
+    const PERMISSIVE_POLICY: &str = r#"
+schema_version: 1
+metadata: { name: t, description: t, authority: t, effective: "always" }
+rules: []
+"#;
+
+    /// Gap-remediation Phase E, Finding #5 — a key's declared default
+    /// `CryptographicParameters` (e.g. PSS/SHA-384) must survive onto
+    /// BOTH halves' stored `ObjectRecord`, independently per half, not
+    /// silently dropped (`create.rs`/`register_import_export.rs`/
+    /// `derive_key.rs` all persist this field already; `create_key_pair`
+    /// previously never read it off `priv_x`/`pub_x`).
+    #[test]
+    fn create_key_pair_persists_cryptographic_parameters_on_both_halves() {
+        let (_ring, d) = deps_with(PERMISSIVE_POLICY);
+        let priv_cp = crate::kmip30::ops::CryptographicParameters {
+            padding_method: Some(0x0a), // PSS
+            hashing_algorithm: Some(crate::kmip30::ops::HashingAlgorithm::Sha384),
+            ..Default::default()
+        };
+        let pub_cp = crate::kmip30::ops::CryptographicParameters {
+            padding_method: Some(0x0a),
+            hashing_algorithm: Some(crate::kmip30::ops::HashingAlgorithm::Sha256),
+            ..Default::default()
+        };
+        let req = CreateKeyPairRequest {
+            common_attributes: vec![Attribute::CryptographicAlgorithm(KmipAlgorithm::Rsa)],
+            private_key_attributes: vec![Attribute::CryptographicParameters(priv_cp.clone())],
+            public_key_attributes: vec![Attribute::CryptographicParameters(pub_cp.clone())],
+            seed: None,
+        };
+        let resp = create_key_pair(&d, req, "CreateKeyPair:Sign", "corr-cp").unwrap();
+        let priv_record = d.store.get(&resp.private_key_uid).unwrap().unwrap();
+        let pub_record = d.store.get(&resp.public_key_uid).unwrap().unwrap();
+        assert_eq!(priv_record.cryptographic_parameters, Some(priv_cp));
+        assert_eq!(pub_record.cryptographic_parameters, Some(pub_cp));
+    }
+
+    /// Gap-remediation Phase E, Finding #13 — `QuantumSafe=true` on a
+    /// non-PQC algorithm must be rejected, matching `create.rs`'s
+    /// existing check for the same scenario (QS-M-2).
+    #[test]
+    fn create_key_pair_quantum_safe_true_on_rsa_is_rejected() {
+        let (_ring, d) = deps_with(PERMISSIVE_POLICY);
+        let req = CreateKeyPairRequest {
+            common_attributes: vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::Rsa),
+                Attribute::QuantumSafe(true),
+            ],
+            private_key_attributes: vec![],
+            public_key_attributes: vec![],
+            seed: None,
+        };
+        let err = create_key_pair(&d, req, "CreateKeyPair:Sign", "corr-qs").unwrap_err();
+        assert_eq!(err.result_reason(), ResultReason::GeneralFailure);
+    }
+
+    /// A genuinely PQC algorithm with `QuantumSafe=true` must still
+    /// succeed — the check only rejects the false claim, not the
+    /// attribute itself.
+    #[test]
+    fn create_key_pair_quantum_safe_true_on_ml_dsa_succeeds() {
+        let (_ring, d) = deps_with(PERMISSIVE_POLICY);
+        let req = CreateKeyPairRequest {
+            common_attributes: vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::MlDsa87),
+                Attribute::QuantumSafe(true),
+            ],
+            private_key_attributes: vec![],
+            public_key_attributes: vec![],
+            seed: None,
+        };
+        create_key_pair(&d, req, "CreateKeyPair:Sign", "corr-qs-ok").unwrap();
     }
 }

--- a/kmip/src/ops/decrypt.rs
+++ b/kmip/src/ops/decrypt.rs
@@ -297,8 +297,13 @@ fn decrypt_classical(
         let handle = softhsmrustv3::native::find_by_cka_id(session, &obj.pkcs11_cka_id)
             .map_err(|rv| super::helpers::ck_rv_to_kmip_error(rv, "Decrypt:find"))?
             .ok_or_else(|| KmipError::object_not_found(&req.uid))?;
-        let r =
-            softhsmrustv3::native::decrypt(session, handle, mech, &req.data, req.iv.as_deref());
+        // Gap-remediation Phase F, Finding #4 — same fix as Encrypt's
+        // handle-based branch: forward the already-computed
+        // oaep/aad/tag_len instead of letting the engine silently
+        // apply its hardcoded defaults for an engine-resident key.
+        let r = softhsmrustv3::native::decrypt(
+            session, handle, mech, &req.data, req.iv.as_deref(), oaep.as_ref(), aad, tag_len,
+        );
         emit_pkcs11_result(deps, correlation_id, "native::decrypt", Some(mech), &r);
         r.map_err(|rv| super::helpers::ck_rv_to_kmip_error(rv, "Decrypt"))?
     } else {

--- a/kmip/src/ops/destroy.rs
+++ b/kmip/src/ops/destroy.rs
@@ -19,6 +19,7 @@
 
 use std::collections::HashMap;
 use time::OffsetDateTime;
+use zeroize::Zeroize;
 
 use crate::error::{KmipError, Result};
 use crate::kmip30::{DestroyRequest, DestroyResponse, State};
@@ -109,6 +110,22 @@ pub fn destroy(deps: &Deps, req: DestroyRequest, correlation_id: &str) -> Result
     obj.state = target_state;
     obj.destroy_date = Some(now);
     obj.last_change_date = Some(now);
+
+    // Gap-remediation Phase A — "the key material for the specified
+    // Managed Object SHALL be destroyed" (§6.1.19) means destroyed, not
+    // "state flipped while the plaintext sits in the store forever."
+    // For Register/Import'd objects the raw bytes live in
+    // `ObjectRecord.key_material` (there is no engine handle for them
+    // to destroy above); zeroize the backing buffer before dropping it
+    // rather than a bare `= None`, matching the `.zeroize()` discipline
+    // `rust/src/ffi.rs` already uses for sensitive buffers. `Export`'s
+    // own `key_material` filter for Destroyed objects becomes
+    // redundant-but-harmless defense in depth after this, not load-
+    // bearing — left in place.
+    if let Some(mut material) = obj.key_material.take() {
+        material.zeroize();
+    }
+
     deps.store.update(obj)?;
 
     emit_state_change(
@@ -221,5 +238,69 @@ mod tests {
         put(&d, "u", State::Destroyed);
         let err = destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap_err();
         assert_eq!(err.result_reason(), crate::error::ResultReason::ObjectDestroyed);
+    }
+
+    /// Gap-remediation Phase A — a Register/Import'd object's raw key
+    /// bytes live in `ObjectRecord.key_material` (no engine handle to
+    /// destroy). Destroy must scrub that field for real, not just flip
+    /// the lifecycle state and leave the plaintext sitting in the
+    /// store. Also confirms the pre-existing Export-side suppression
+    /// (§6.1.22: Destroyed objects never return key material) still
+    /// holds — that check becomes redundant-but-harmless defense in
+    /// depth after this fix, not the only thing standing between a
+    /// client and a "destroyed" key's plaintext.
+    #[test]
+    fn destroy_scrubs_key_material_for_registered_objects() {
+        use crate::kmip30::ExportRequest;
+        use crate::ops::register_import_export::export;
+
+        let d = deps_with();
+        d.store
+            .put(ObjectRecord {
+                uid: "u".into(),
+                object_type: ObjectType::SecretData,
+                algorithm: KmipAlgorithm::Aes,
+                cryptographic_length: 256,
+                usage_mask: UsageMask::ENCRYPT,
+                state: State::PreActive,
+                pkcs11_cka_id: vec![],
+                pkcs11_slot: 0,
+                initial_date: OffsetDateTime::UNIX_EPOCH,
+                activation_date: None,
+                supersedes: None,
+                name: None,
+                links: std::collections::HashMap::new(),
+                custom_attributes: std::collections::HashMap::new(),
+                key_material: Some(vec![0xAB; 32]),
+                key_format_type: None,
+                ..ObjectRecord::default()
+            })
+            .unwrap();
+
+        destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap();
+
+        let stored = d.store.get("u").unwrap().unwrap();
+        assert!(
+            stored.key_material.is_none(),
+            "Destroy must scrub key_material, not just flip lifecycle state"
+        );
+
+        // Export still honestly reports no material for a Destroyed
+        // object (pre-existing §6.1.22 behavior) — proves this path
+        // stays correct now that it's no longer the only thing hiding
+        // the plaintext.
+        let exported = export(
+            &d,
+            ExportRequest {
+                uid: "u".into(),
+                key_format_type: None,
+                key_wrap_type: None,
+                key_compression_type: None,
+                key_wrapping_specification: None,
+            },
+            "c",
+        )
+        .unwrap();
+        assert!(exported.managed_object.is_none());
     }
 }

--- a/kmip/src/ops/encrypt.rs
+++ b/kmip/src/ops/encrypt.rs
@@ -632,7 +632,15 @@ fn encrypt_classical(
         let handle = softhsmrustv3::native::find_by_cka_id(session, &obj.pkcs11_cka_id)
             .map_err(|rv| super::helpers::ck_rv_to_kmip_error(rv, "Encrypt:find"))?
             .ok_or_else(|| KmipError::object_not_found(&req.uid))?;
-        let r = softhsmrustv3::native::encrypt(session, handle, mech, data_for_shim, effective_iv);
+        // Gap-remediation Phase F, Finding #4 — `oaep`/`aad`/`tag_len`
+        // were already computed above (same effective-CP derivation the
+        // `encrypt_with_key_bytes` branch above uses) but never
+        // forwarded here; the engine hardcoded empty AAD and the
+        // SHA-256 OAEP default for every engine-resident key regardless
+        // of what the client actually requested.
+        let r = softhsmrustv3::native::encrypt(
+            session, handle, mech, data_for_shim, effective_iv, oaep.as_ref(), aad, tag_len,
+        );
         emit_pkcs11_result(deps, correlation_id, "native::encrypt", Some(mech), &r);
         r.map_err(|rv| super::helpers::ck_rv_to_kmip_error(rv, "Encrypt"))?
     } else {

--- a/kmip/src/ops/get_attributes.rs
+++ b/kmip/src/ops/get_attributes.rs
@@ -152,7 +152,12 @@ fn attributes_from_record(r: &ObjectRecord) -> Vec<Attribute> {
         });
         out.push(Attribute::ShortUniqueIdentifier(sid));
     }
-    if let Some(s) = &r.alternative_name { out.push(Attribute::AlternativeName(s.clone())); }
+    if let Some(s) = &r.alternative_name {
+        out.push(Attribute::AlternativeName {
+            value: s.clone(),
+            name_type: r.alternative_name_type.unwrap_or(1),
+        });
+    }
     if let Some((ns, data)) = &r.application_specific_information {
         out.push(Attribute::ApplicationSpecificInformation { namespace: ns.clone(), data: data.clone() });
     }
@@ -355,7 +360,7 @@ pub(crate) fn canonical_attribute_name(attr: &Attribute) -> &'static str {
         Attribute::QuantumSafe(_)            => "QuantumSafe",
         Attribute::RotateAutomatic(_)        => "RotateAutomatic",
         Attribute::ShortUniqueIdentifier(_)  => "ShortUniqueIdentifier",
-        Attribute::AlternativeName(_)        => "AlternativeName",
+        Attribute::AlternativeName { .. }    => "AlternativeName",
         Attribute::Comment(_)                => "Comment",
         Attribute::Description(_)            => "Description",
         Attribute::ContactInformation(_)     => "ContactInformation",
@@ -660,5 +665,46 @@ mod tests {
         // OASIS corpus BL-M-20-30.xml pins ItemNotFound for a missing
         // UID on GetAttributes (corpus is authoritative over the sweep).
         assert_eq!(err.result_reason(), crate::error::ResultReason::ItemNotFound);
+    }
+
+    /// Gap-remediation Phase H, Finding #11 — Register with
+    /// `AlternativeNameType=URI(2)` must round-trip through
+    /// GetAttributes, not silently collapse to the `1`
+    /// (Uninterpreted Text String) default.
+    #[test]
+    fn register_alternative_name_type_round_trips_through_get_attributes() {
+        use crate::kmip30::{KeyBlock, KeyFormatType, RegisterRequest};
+        use crate::ops::register_import_export::register;
+
+        let d = deps_with();
+        let resp = register(&d, RegisterRequest {
+            secret_data_type: None,
+            object_type: ObjectType::SymmetricKey,
+            attributes: vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
+                Attribute::CryptographicLength(128),
+                Attribute::CryptographicUsageMask(UsageMask::ENCRYPT),
+                Attribute::AlternativeName { value: "https://example/asset/1".into(), name_type: 2 },
+            ],
+            managed_object: Some(KeyBlock {
+                key_format_type: KeyFormatType::Raw,
+                cryptographic_algorithm: KmipAlgorithm::Aes,
+                cryptographic_length: 128,
+                key_value: vec![0x11; 16],
+                key_wrapping_data: None,
+            }),
+            protection_storage_masks: None,
+            certificate_payload: None,
+        }, "c").unwrap();
+
+        let r = get_attributes(&d, GetAttributesRequest {
+            uid: resp.uid,
+            attribute_references: vec![],
+        }, "c").unwrap();
+        let found = r.attributes.iter().find_map(|a| match a {
+            Attribute::AlternativeName { value, name_type } => Some((value.clone(), *name_type)),
+            _ => None,
+        });
+        assert_eq!(found, Some(("https://example/asset/1".to_string(), 2)));
     }
 }

--- a/kmip/src/ops/locate.rs
+++ b/kmip/src/ops/locate.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use time::OffsetDateTime;
 
 use crate::error::Result;
-use crate::kmip30::{Attribute, KmipAlgorithm, LocateRequest, LocateResponse, ObjectType, State};
+use crate::kmip30::{Attribute, KmipAlgorithm, LocateRequest, LocateResponse, ObjectType, State, UsageMask};
 use crate::policy::{Decision, PolicyRequest};
 use crate::store::ObjectRecord;
 
@@ -173,6 +173,17 @@ struct LocateFilters {
     /// equals this value (Object Group is multi-instance). This is the
     /// capability behind SASED-M-3 step #0's group-membership Locate.
     object_group: Option<String>,
+    /// Gap-remediation Phase H, Finding #10 — previously accepted as
+    /// valid Locate syntax and then silently dropped (over-broad
+    /// results, not an error). The OASIS mandatory corpus's own
+    /// SKFF-M-5..8 Locate steps filter by `UniqueIdentifier` and relied
+    /// on this being harmlessly over-broad; narrowing it for real is
+    /// still correct for those steps (`UniqueIdentifier` filter must
+    /// pick out AT MOST the one matching object, a strict subset of
+    /// "every object").
+    cryptographic_length: Option<u32>,
+    cryptographic_usage_mask: Option<UsageMask>,
+    unique_identifier: Option<String>,
 }
 
 impl LocateFilters {
@@ -222,6 +233,25 @@ impl LocateFilters {
                 return false;
             }
         }
+        if let Some(want) = self.cryptographic_length {
+            if r.cryptographic_length != want {
+                return false;
+            }
+        }
+        // Per §11 `Cryptographic Usage Mask` is bit-valued; a Locate
+        // filter matches when the record's mask has ALL requested bits
+        // set (a subset check, not exact equality — the same semantics
+        // GetAttributes/other consumers use elsewhere for this field).
+        if let Some(want) = self.cryptographic_usage_mask {
+            if !r.usage_mask.contains(want) {
+                return false;
+            }
+        }
+        if let Some(want) = &self.unique_identifier {
+            if &r.uid != want {
+                return false;
+            }
+        }
         true
     }
 }
@@ -235,6 +265,9 @@ fn build_filters(attrs: &[Attribute]) -> LocateFilters {
         application_specific_information: None,
         group_link: None,
         object_group: None,
+        cryptographic_length: None,
+        cryptographic_usage_mask: None,
+        unique_identifier: None,
     };
     for a in attrs {
         match a {
@@ -248,6 +281,14 @@ fn build_filters(attrs: &[Attribute]) -> LocateFilters {
             Attribute::GroupLink(uid) => {
                 f.group_link = Some(uid.clone());
             }
+            // Gap-remediation Phase H, Finding #10 — 3 highest-value
+            // missing filters, per the OASIS corpus's own Locate usage
+            // (UniqueIdentifier appears in SKFF-M-5..8; Length/UsageMask
+            // aren't corpus-exercised but are the next most useful
+            // generic filters per the plan).
+            Attribute::CryptographicLength(n) => f.cryptographic_length = Some(*n),
+            Attribute::CryptographicUsageMask(m) => f.cryptographic_usage_mask = Some(*m),
+            Attribute::UniqueIdentifier(uid) => f.unique_identifier = Some(uid.clone()),
             Attribute::ObjectGroup(g) => {
                 f.object_group = Some(g.clone());
             }
@@ -607,5 +648,80 @@ mod tests {
             ..Default::default()
         }, "c").unwrap();
         assert_eq!(r.uids, vec!["dead", "live"]);
+    }
+
+    /// Gap-remediation Phase H, Finding #10 — `CryptographicLength` was
+    /// previously accepted as valid Locate syntax and silently dropped
+    /// (over-broad results, not an error). Confirms it now genuinely
+    /// narrows instead of just "doesn't error."
+    #[test]
+    fn locate_filters_by_cryptographic_length() {
+        let d = deps_with();
+        for (uid, length) in [("aes128", 128u32), ("aes256", 256u32)] {
+            d.store.put(ObjectRecord {
+                uid: uid.into(),
+                object_type: ObjectType::SymmetricKey,
+                algorithm: KmipAlgorithm::Aes,
+                cryptographic_length: length,
+                state: State::Active,
+                initial_date: OffsetDateTime::UNIX_EPOCH,
+                ..ObjectRecord::default()
+            }).unwrap();
+        }
+
+        let r = locate(&d, LocateRequest {
+            attributes: vec![Attribute::CryptographicLength(256)],
+            ..Default::default()
+        }, "c").unwrap();
+        assert_eq!(r.uids, vec!["aes256"]);
+    }
+
+    /// `CryptographicUsageMask` — matches when the record's mask
+    /// contains ALL requested bits (subset check).
+    #[test]
+    fn locate_filters_by_cryptographic_usage_mask() {
+        let d = deps_with();
+        d.store.put(ObjectRecord {
+            uid: "enc-only".into(),
+            object_type: ObjectType::SymmetricKey,
+            algorithm: KmipAlgorithm::Aes,
+            usage_mask: UsageMask::ENCRYPT,
+            state: State::Active,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            ..ObjectRecord::default()
+        }).unwrap();
+        d.store.put(ObjectRecord {
+            uid: "enc-dec".into(),
+            object_type: ObjectType::SymmetricKey,
+            algorithm: KmipAlgorithm::Aes,
+            usage_mask: UsageMask::ENCRYPT | UsageMask::DECRYPT,
+            state: State::Active,
+            initial_date: OffsetDateTime::UNIX_EPOCH,
+            ..ObjectRecord::default()
+        }).unwrap();
+
+        let mut r = locate(&d, LocateRequest {
+            attributes: vec![Attribute::CryptographicUsageMask(UsageMask::DECRYPT)],
+            ..Default::default()
+        }, "c").unwrap().uids;
+        r.sort();
+        assert_eq!(r, vec!["enc-dec"]);
+    }
+
+    /// `UniqueIdentifier` — the OASIS mandatory corpus's SKFF-M-5..8
+    /// Locate steps filter by this and previously relied on it being
+    /// harmlessly ignored (returning every object); narrowing it to the
+    /// single matching UID is still correct for those steps.
+    #[test]
+    fn locate_filters_by_unique_identifier() {
+        let d = deps_with();
+        put(&d, "target", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Active);
+        put(&d, "other", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Active);
+
+        let r = locate(&d, LocateRequest {
+            attributes: vec![Attribute::UniqueIdentifier("target".into())],
+            ..Default::default()
+        }, "c").unwrap();
+        assert_eq!(r.uids, vec!["target"]);
     }
 }

--- a/kmip/src/ops/mod.rs
+++ b/kmip/src/ops/mod.rs
@@ -121,6 +121,26 @@ pub(crate) mod test_rsa_fixture {
         buf.to_vec()
     }
 
+    /// Gap-remediation Phase D/H — the PUBLIC-key half of the same
+    /// fixture (Modulus + Public Exponent only), TTLV-encoded exactly
+    /// as BL-M-8-30's `TransparentRSAPublicKey` Register request
+    /// carries it.
+    pub fn ttlv_public_key_material() -> Vec<u8> {
+        let big = |tag: u32, hex_str: &str| {
+            TtlvFrame::new(Tag(tag), Value::BigInteger(hex::decode(hex_str).unwrap()))
+        };
+        let frame = TtlvFrame::new(
+            Tag(tags::KeyMaterial),
+            Value::Structure(vec![
+                big(tags::Modulus, MODULUS),
+                big(tags::PublicExponent, PUBLIC_EXPONENT),
+            ]),
+        );
+        let mut buf = bytes::BytesMut::new();
+        encode(&frame, &mut buf);
+        buf.to_vec()
+    }
+
     /// The same key as an `rsa::RsaPrivateKey` (for deriving PKCS#1 /
     /// PKCS#8 DER expectations in conversion tests).
     pub fn rsa_key() -> rsa::RsaPrivateKey {

--- a/kmip/src/ops/mod.rs
+++ b/kmip/src/ops/mod.rs
@@ -30,9 +30,10 @@
 //! 3. Call `deps.engine.evaluate(&policy_request)`.
 //! 4. Map `(KmipAlgorithm, PkcsOp) → CKM_*` via
 //!    `KmipAlgorithm::to_pkcs11_mech` (Phase 3).
-//! 5. Emit Plane-3 `Pkcs11Call`s; call the bridge (Phase 7 wires real
-//!    softhsmrustv3 entries; v0.1 uses placeholders so tests run without
-//!    a token).
+//! 5. Emit Plane-3 `Pkcs11Call`s; call the bridge — real `softhsmrustv3`
+//!    engine entries when `deps.engine_session` is wired (production +
+//!    e2e tests), a documented soft placeholder path for engine-less
+//!    unit tests (see e.g. `create_key_pair::engine_generate_keypair`).
 //! 6. Persist any store mutations.
 //! 7. Emit Plane-2 `KmipResponseSent`.
 //!

--- a/kmip/src/ops/register_import_export.rs
+++ b/kmip/src/ops/register_import_export.rs
@@ -1556,6 +1556,38 @@ mod tests {
         assert_eq!(hex::encode(&f.public_exponent), crate::ops::test_rsa_fixture::PUBLIC_EXPONENT);
     }
 
+    /// Gap-remediation Phase D/H — public-key half of the same fixture
+    /// (found broken via BL-M-8-30 conformance replay; the real-engine
+    /// round-trip proving the DER conversion actually produces a usable
+    /// object lives in tests/native_bridge_e2e.rs — this pins the
+    /// storage + parse side without needing a session).
+    #[test]
+    fn register_transparent_rsa_public_key_parses_and_round_trips() {
+        let d = deps_with();
+        let r = register(&d, RegisterRequest {
+            secret_data_type: None,
+            object_type: ObjectType::PublicKey,
+            attributes: vec![Attribute::CryptographicUsageMask(UsageMask::VERIFY)],
+            managed_object: Some(KeyBlock {
+                key_format_type: KeyFormatType::TransparentRsaPublicKey,
+                cryptographic_algorithm: KmipAlgorithm::Rsa,
+                cryptographic_length: 1024,
+                key_value: crate::ops::test_rsa_fixture::ttlv_public_key_material(),
+                key_wrapping_data: None,
+            }),
+            protection_storage_masks: None,
+            certificate_payload: None,
+        }, "c").unwrap();
+        let rec = d.store.get(&r.uid).unwrap().unwrap();
+        assert_eq!(rec.key_format_type, Some(0x0B));
+        let stored = rec.key_material.expect("material stored");
+        assert!(!stored.is_empty(), "never store empty material");
+        assert_eq!(stored, crate::ops::test_rsa_fixture::ttlv_public_key_material());
+        let f = crate::kmip30::decode_transparent_rsa_public_key(&stored).unwrap();
+        assert_eq!(hex::encode(&f.modulus), crate::ops::test_rsa_fixture::MODULUS);
+        assert_eq!(hex::encode(&f.public_exponent), crate::ops::test_rsa_fixture::PUBLIC_EXPONENT);
+    }
+
     #[test]
     fn register_transparent_rsa_private_key_malformed_fails_0x10() {
         // Garbage that is not a TTLV KeyMaterial Structure must fail

--- a/kmip/src/ops/register_import_export.rs
+++ b/kmip/src/ops/register_import_export.rs
@@ -252,31 +252,52 @@ pub fn register(
                 // (PrivateKeyInfo). Both surface in `sign_rsa` via
                 // `RsaPrivateKey::from_pkcs8_der`. 0x0A was converted
                 // to PKCS#8 above.
-                let pkcs8_bytes: Option<Vec<u8>> = match fmt {
+                //
+                // Gap-remediation Phase D, Finding #3 — a malformed
+                // PKCS#1 body (fmt 3) or an unrecognized `fmt` value
+                // used to fall through to `None` here and the whole
+                // block silently did nothing: wire `Success`, no real
+                // engine object, violating this file's own "Register
+                // must NOT succeed-then-fail-at-use" invariant just as
+                // much as the discarded `Result`s below did. Now
+                // surfaces `KeyFormatTypeNotSupported` instead.
+                let pkcs8_bytes: std::result::Result<Vec<u8>, String> = match fmt {
                     3 => {
                         use rsa::pkcs1::DecodeRsaPrivateKey;
                         use rsa::pkcs8::EncodePrivateKey;
                         rsa::RsaPrivateKey::from_pkcs1_der(material)
-                            .ok()
-                            .and_then(|k| k.to_pkcs8_der().ok().map(|d| d.as_bytes().to_vec()))
+                            .map_err(|e| e.to_string())
+                            .and_then(|k| k.to_pkcs8_der()
+                                .map(|d| d.as_bytes().to_vec())
+                                .map_err(|e| e.to_string()))
                     }
-                    4 => Some(material.clone()),
-                    0x0A => transparent_rsa_pkcs8.clone(),
-                    _ => None,
+                    4 => Ok(material.clone()),
+                    0x0A => transparent_rsa_pkcs8.clone()
+                        .ok_or_else(|| "Transparent RSA Private Key material missing".to_string()),
+                    other => Err(format!("unsupported KeyFormatType 0x{other:02x} for RSA PrivateKey Register")),
                 };
-                if let Some(pkcs8) = pkcs8_bytes {
-                    let _ = softhsmrustv3::native::register_rsa_private_key_pkcs8(
-                        session, &pkcs8, &cka_id_bytes, "kmip-register",
-                    );
-                }
+                let pkcs8 = pkcs8_bytes.map_err(|e| fail_err(deps, correlation_id, "Register",
+                    KmipError::key_format_type_not_supported(format!(
+                        "RSA PrivateKey Register: {e}"
+                    ))))?;
+                softhsmrustv3::native::register_rsa_private_key_pkcs8(
+                    session, &pkcs8, &cka_id_bytes, "kmip-register",
+                ).map_err(|rv| fail_err(deps, correlation_id, "Register",
+                    super::helpers::ck_rv_to_kmip_error(rv, "Register:rsa-private-import")))?;
             }
             (ObjectType::PublicKey, crate::kmip30::KmipAlgorithm::Rsa) => {
                 // PKCS_1 RSAPublicKey or PKCS_8 SubjectPublicKeyInfo —
                 // store the DER as-is; `verify_rsa` extracts the
-                // modulus/exponent from CKA_VALUE.
-                let _ = softhsmrustv3::native::register_rsa_public_key_der(
+                // modulus/exponent from CKA_VALUE. Gap-remediation
+                // Phase D, Finding #3 — the engine now genuinely
+                // accepts both forms (see `register_rsa_public_key_der`
+                // in `rust/src/native/keygen.rs`) and this Result is no
+                // longer discarded, so a malformed DER honestly fails
+                // Register instead of succeeding with no engine object.
+                softhsmrustv3::native::register_rsa_public_key_der(
                     session, material, &cka_id_bytes, "kmip-register-pub",
-                );
+                ).map_err(|rv| fail_err(deps, correlation_id, "Register",
+                    super::helpers::ck_rv_to_kmip_error(rv, "Register:rsa-public-import")))?;
             }
             (ObjectType::SymmetricKey, alg)
                 if matches!(
@@ -288,9 +309,10 @@ pub fn register(
             {
                 // HMAC keys are raw bytes; the shim's MAC path reads
                 // them from CKA_VALUE.
-                let _ = softhsmrustv3::native::register_generic_secret_bytes(
+                softhsmrustv3::native::register_generic_secret_bytes(
                     session, material, &cka_id_bytes, "kmip-register-hmac",
-                );
+                ).map_err(|rv| fail_err(deps, correlation_id, "Register",
+                    super::helpers::ck_rv_to_kmip_error(rv, "Register:hmac-import")))?;
             }
             // K9 (compliance-audit B-6) — PQC families: ML-DSA /
             // ML-KEM / SLH-DSA raw FIPS 204/203/205 key material is

--- a/kmip/src/ops/register_import_export.rs
+++ b/kmip/src/ops/register_import_export.rs
@@ -519,6 +519,10 @@ pub fn register(
         certificate_value,
         certificate_length,
         certificate_subject_cn,
+        // Gap-remediation Phase C, Finding #8 — previously dropped at
+        // decode time; a later Get always echoed the Password default
+        // regardless of what was actually registered.
+        secret_data_type: req.secret_data_type,
         ..ObjectRecord::default()
     })?;
 
@@ -929,6 +933,7 @@ mod tests {
     fn register_persists_record_with_uid_and_key_bytes() {
         let d = deps_with();
         let resp = register(&d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::SymmetricKey,
             attributes: vec![
                 Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
@@ -951,6 +956,7 @@ mod tests {
     fn register_with_client_uid_rejects_duplicate() {
         let d = deps_with();
         let req = || RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::SymmetricKey,
             attributes: vec![
                 Attribute::UniqueIdentifier("urn:fixed".into()),
@@ -972,6 +978,7 @@ mod tests {
     fn register_records_the_real_protection_storage_mask() {
         let d = deps_with();
         let resp = register(&d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::SymmetricKey,
             attributes: vec![
                 Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
@@ -993,6 +1000,7 @@ mod tests {
         // Client requires Hardware (0x02) only — this server has no
         // hardware storage class, so it must refuse rather than lie.
         let err = register(&d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::SymmetricKey,
             attributes: vec![
                 Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
@@ -1011,6 +1019,7 @@ mod tests {
         let d = deps_with();
         // First create via Register.
         register(&d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::SymmetricKey,
             attributes: vec![
                 Attribute::UniqueIdentifier("u".into()),
@@ -1041,6 +1050,7 @@ mod tests {
     fn import_with_replace_overwrites_existing() {
         let d = deps_with();
         register(&d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::SymmetricKey,
             attributes: vec![
                 Attribute::UniqueIdentifier("u".into()),
@@ -1074,6 +1084,7 @@ mod tests {
     fn export_returns_attributes_and_key_material() {
         let d = deps_with();
         let r = register(&d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::SymmetricKey,
             attributes: vec![
                 Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
@@ -1102,6 +1113,7 @@ mod tests {
     fn export_on_destroyed_omits_key_material() {
         let d = deps_with();
         let r = register(&d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::SymmetricKey,
             attributes: vec![
                 Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
@@ -1130,6 +1142,7 @@ mod tests {
     fn register_persists_sensitive_and_extractable_from_template() {
         let d = deps_with();
         let r = register(&d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::SymmetricKey,
             attributes: vec![
                 Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
@@ -1158,6 +1171,7 @@ mod tests {
         if let Some(b) = sensitive { attributes.push(Attribute::Sensitive(b)); }
         if let Some(b) = extractable { attributes.push(Attribute::Extractable(b)); }
         register(d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::SymmetricKey,
             attributes,
             managed_object: Some(raw_aes128_kb()),
@@ -1308,6 +1322,7 @@ mod tests {
         kwd: crate::kmip30::KeyWrappingSpec,
     ) -> Result<RegisterResponse> {
         register(d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::SymmetricKey,
             attributes: vec![
                 Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
@@ -1420,6 +1435,7 @@ mod tests {
 
     fn register_transparent_rsa(d: &Deps) -> crate::error::Result<RegisterResponse> {
         register(d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::PrivateKey,
             attributes: vec![
                 Attribute::CryptographicUsageMask(UsageMask::DECRYPT),
@@ -1462,6 +1478,7 @@ mod tests {
         // land in the store as dead material.
         let d = deps_with();
         let err = register(&d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::PrivateKey,
             attributes: vec![Attribute::CryptographicUsageMask(UsageMask::DECRYPT)],
             managed_object: Some(KeyBlock {
@@ -1479,6 +1496,7 @@ mod tests {
 
     fn register_tsk(d: &Deps) -> String {
         register(d, RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::SymmetricKey,
             attributes: vec![
                 Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
@@ -1533,5 +1551,39 @@ mod tests {
             key_wrapping_specification: None,
         }, "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::KeyFormatTypeNotSupported);
+    }
+
+    /// Gap-remediation Phase C, Finding #8 — `SecretDataType` (Password
+    /// = 0x01, Seed = 0x02) must survive Register → Get instead of
+    /// always echoing the hardcoded Password default.
+    #[test]
+    fn register_secret_data_type_round_trips_through_get() {
+        let d = deps_with();
+        let resp = register(&d, RegisterRequest {
+            secret_data_type: Some(0x02), // Seed
+            object_type: ObjectType::SecretData,
+            attributes: vec![
+                Attribute::CryptographicUsageMask(UsageMask::empty()),
+            ],
+            managed_object: Some(KeyBlock {
+                key_format_type: KeyFormatType::Raw,
+                cryptographic_algorithm: KmipAlgorithm::Aes,
+                cryptographic_length: 0,
+                key_value: vec![0xAB; 32],
+                key_wrapping_data: None,
+            }),
+            protection_storage_masks: None,
+            certificate_payload: None,
+        }, "c").unwrap();
+
+        let rec = d.store.get(&resp.uid).unwrap().unwrap();
+        assert_eq!(rec.secret_data_type, Some(0x02));
+
+        let got = super::super::get::get(&d, crate::kmip30::GetRequest {
+            uid: resp.uid,
+            key_format_type: None,
+            key_wrapping_specification: None,
+        }, "c").unwrap();
+        assert_eq!(got.secret_data_type, Some(0x02));
     }
 }

--- a/kmip/src/ops/register_import_export.rs
+++ b/kmip/src/ops/register_import_export.rs
@@ -233,6 +233,45 @@ pub fn register(
         _ => None,
     };
 
+    // Gap-remediation Phase D/H (found via BL-M-8-30 conformance
+    // replay) — mirrors `transparent_rsa_pkcs8` above for the
+    // PUBLIC-key half. `decode_key_block`'s own comment already noted
+    // "the Register path can parse typed fields out of it" for every
+    // Transparent* form (citing BL-M-8 by name); only the private-key
+    // half was ever actually wired up. Re-encode Modulus/PublicExponent
+    // as real SubjectPublicKeyInfo DER so `register_rsa_public_key_der`
+    // (which only understands DER, per/register-side comment above)
+    // gets parseable bytes instead of the raw TTLV KeyMaterial Structure.
+    let transparent_rsa_public_der: Option<Vec<u8>> = match (req.object_type, kmip_algorithm, key_format_type) {
+        (ObjectType::PublicKey, crate::kmip30::KmipAlgorithm::Rsa, Some(0x0B)) => {
+            let material = key_material.as_deref().unwrap_or_default();
+            let der = crate::kmip30::decode_transparent_rsa_public_key(material)
+                .map_err(|e| e.to_string())
+                .and_then(|f| {
+                    use rsa::pkcs8::EncodePublicKey;
+                    use rsa::BigUint;
+                    rsa::RsaPublicKey::new(
+                        BigUint::from_bytes_be(&f.modulus),
+                        BigUint::from_bytes_be(&f.public_exponent),
+                    )
+                    .map_err(|e| e.to_string())
+                    .and_then(|k| {
+                        k.to_public_key_der()
+                            .map(|d| d.as_bytes().to_vec())
+                            .map_err(|e| e.to_string())
+                    })
+                })
+                .map_err(|e| {
+                    fail_err(deps, correlation_id, "Register",
+                        KmipError::key_format_type_not_supported(format!(
+                            "Transparent RSA Public Key material could not be parsed: {e}"
+                        )))
+                })?;
+            Some(der)
+        }
+        _ => None,
+    };
+
     // KMIP 3.0 §6.1.48 + §6.2 — when the client supplies an RSA
     // private key in PKCS#1 (KeyFormatType=0x03), PKCS#8 (0x04) or
     // Transparent RSA Private Key (0x0A) form, or PQC (ML-DSA /
@@ -286,16 +325,32 @@ pub fn register(
                     super::helpers::ck_rv_to_kmip_error(rv, "Register:rsa-private-import")))?;
             }
             (ObjectType::PublicKey, crate::kmip30::KmipAlgorithm::Rsa) => {
-                // PKCS_1 RSAPublicKey or PKCS_8 SubjectPublicKeyInfo —
-                // store the DER as-is; `verify_rsa` extracts the
-                // modulus/exponent from CKA_VALUE. Gap-remediation
-                // Phase D, Finding #3 — the engine now genuinely
-                // accepts both forms (see `register_rsa_public_key_der`
-                // in `rust/src/native/keygen.rs`) and this Result is no
-                // longer discarded, so a malformed DER honestly fails
-                // Register instead of succeeding with no engine object.
+                // PKCS_1 RSAPublicKey, PKCS_8 SubjectPublicKeyInfo, or
+                // Transparent RSA Public Key (0x0B, re-encoded to SPKI
+                // DER above) — `register_rsa_public_key_der` accepts
+                // both DER forms (Gap-remediation Phase D, Finding #3);
+                // an unrecognized `fmt` now honestly fails Register
+                // instead of feeding it non-DER bytes and silently
+                // producing no engine object (found via BL-M-8-30
+                // conformance replay — the same "succeeds with no real
+                // object" failure mode Finding #3 described, just one
+                // format this file's original text didn't name).
+                // PKCS_1 (3), PKCS_8 (4), and X_509 (5, SubjectPublicKeyInfo
+                // — same shape PKCS_8 uses for public keys) are all real
+                // DER `register_rsa_public_key_der`'s from_public_key_der →
+                // from_pkcs1_der fallback already parses directly.
+                let der: std::result::Result<&[u8], String> = match fmt {
+                    3 | 4 | 5 => Ok(material),
+                    0x0B => transparent_rsa_public_der.as_deref()
+                        .ok_or_else(|| "Transparent RSA Public Key material missing".to_string()),
+                    other => Err(format!("unsupported KeyFormatType 0x{other:02x} for RSA PublicKey Register")),
+                };
+                let der = der.map_err(|e| fail_err(deps, correlation_id, "Register",
+                    KmipError::key_format_type_not_supported(format!(
+                        "RSA PublicKey Register: {e}"
+                    ))))?;
                 softhsmrustv3::native::register_rsa_public_key_der(
-                    session, material, &cka_id_bytes, "kmip-register-pub",
+                    session, der, &cka_id_bytes, "kmip-register-pub",
                 ).map_err(|rv| fail_err(deps, correlation_id, "Register",
                     super::helpers::ck_rv_to_kmip_error(rv, "Register:rsa-public-import")))?;
             }
@@ -530,6 +585,7 @@ pub fn register(
         supersedes: None,
         name,
         alternative_name: x.alternative_name.clone(),
+        alternative_name_type: x.alternative_name_type,
         links,
         custom_attributes,
         object_groups: x.object_groups.clone(),
@@ -828,6 +884,9 @@ pub(crate) struct ExtractedAttrs {
     /// for an attribute the client explicitly provided (found via the
     /// OASIS TL-M-3 conformance transcript, Honest-Maximum Phase 2.1).
     pub alternative_name: Option<String>,
+    /// Gap-remediation Phase H, Finding #11 — sibling `Alternative Name
+    /// Type` (§4.5 Enumeration), previously discarded on decode.
+    pub alternative_name_type: Option<u32>,
 }
 
 pub(crate) fn extract_attrs(attrs: &[Attribute]) -> ExtractedAttrs {
@@ -841,6 +900,7 @@ pub(crate) fn extract_attrs(attrs: &[Attribute]) -> ExtractedAttrs {
         application_specific_information: None,
         object_groups: Vec::new(),
         alternative_name: None,
+        alternative_name_type: None,
     };
     for a in attrs {
         match a {
@@ -863,7 +923,10 @@ pub(crate) fn extract_attrs(attrs: &[Attribute]) -> ExtractedAttrs {
             Attribute::ApplicationSpecificInformation { namespace, data } => {
                 out.application_specific_information = Some((namespace.clone(), data.clone()));
             }
-            Attribute::AlternativeName(n) => out.alternative_name = Some(n.clone()),
+            Attribute::AlternativeName { value, name_type } => {
+                out.alternative_name = Some(value.clone());
+                out.alternative_name_type = Some(*name_type);
+            }
             // Multi-instance: accumulate every Object Group label so an
             // object Registered into several groups is locatable by any.
             Attribute::ObjectGroup(g) => {

--- a/kmip/src/ops/session_and_auth.rs
+++ b/kmip/src/ops/session_and_auth.rs
@@ -1,9 +1,12 @@
 //! KMIP 3.0 Group F: session / auth ops.
 //!
-//! All six ops carry minimal semantics in v0.1 — we acknowledge the
-//! request, allocate a UID where the spec requires one, and emit
-//! audit events. Genuine credential storage + ticket-based session
-//! enforcement is a Phase 12 (sandbox MVP) deliverable.
+//! CreateCredential/CreateGroup/CreateUser/Log acknowledge the request,
+//! allocate a UID where the spec requires one, and emit audit events.
+//! Login/Logout carry real semantics (Phase 1.4, K14): Login issues a
+//! genuine random ticket recorded in a live-session map (optionally
+//! gated on verified `AuthContext` identity when auth is configured),
+//! and Logout invalidates it — a stale/unknown ticket fails `Invalid
+//! Ticket` rather than a silent no-op success.
 //!
 //! Spec mapping:
 //!

--- a/kmip/src/policy/rule.rs
+++ b/kmip/src/policy/rule.rs
@@ -134,8 +134,13 @@ pub enum Rule {
     },
 
     /// `op ∈ ops` AND `(now - key.activated_at) > days` → Deny.
-    /// Phase 4.5 stub — needs Phase 6 object store to expose key timestamps.
-    /// Today this rule never fires; engine logs a warning at load.
+    /// `check_pass2` genuinely evaluates this against
+    /// `PolicyRequest::object_activation_date`, which 5 op handlers
+    /// (Decapsulate/Decrypt/Encapsulate/Encrypt/Sign) populate from the
+    /// stored object's real Activation Date. Only fires for ops that
+    /// target an already-activated key — `Create` and never-activated
+    /// objects have no activation date to age out (see the loader's
+    /// load-time warning for this rule).
     MaxKeyAgeDays {
         ops: Vec<String>,
         days: u32,

--- a/kmip/src/store/memory.rs
+++ b/kmip/src/store/memory.rs
@@ -148,6 +148,31 @@ mod tests {
         );
     }
 
+    /// Gap-remediation Phase H, Finding #12 — companion to
+    /// `SqliteStore`'s equivalent test; `MemoryStore::update` already
+    /// re-asserts these, this pins the guarantee so it can't silently
+    /// regress out from under the SQLite parity fix.
+    #[test]
+    fn update_does_not_let_caller_mutate_immutable_dates() {
+        let s = MemoryStore::new();
+        let mut original = rec("u");
+        original.original_creation_date = Some(OffsetDateTime::UNIX_EPOCH);
+        s.put(original).unwrap();
+
+        let mut mutated = rec("u");
+        mutated.initial_date = OffsetDateTime::UNIX_EPOCH + time::Duration::days(365);
+        mutated.original_creation_date = Some(OffsetDateTime::UNIX_EPOCH + time::Duration::days(365));
+        s.update(mutated).unwrap();
+
+        let r = s.get("u").unwrap().unwrap();
+        assert_eq!(r.initial_date, OffsetDateTime::UNIX_EPOCH, "Initial Date must not be caller-mutable");
+        assert_eq!(
+            r.original_creation_date,
+            Some(OffsetDateTime::UNIX_EPOCH),
+            "Original Creation Date must not be caller-mutable",
+        );
+    }
+
     #[test]
     fn update_requires_existing() {
         let s = MemoryStore::new();

--- a/kmip/src/store/sqlite.rs
+++ b/kmip/src/store/sqlite.rs
@@ -77,11 +77,23 @@ impl SqliteStore {
         // `busy_timeout` are per-connection (must be set every open);
         // `journal_mode=WAL` persists in the file. WAL is a no-op on `:memory:`
         // (it stays in memory), so this is safe for the in-memory test path too.
+        //
+        // Gap-remediation Phase A — `secure_delete = FAST` closes a real
+        // gap: without it, SQLite marks a deleted row's page free for
+        // reuse instead of overwriting it, so a Destroy'd object's
+        // `key_material` (see `ops/destroy.rs`, which now zeroizes the
+        // Rust-side buffer before this UPDATE ever reaches SQLite) could
+        // still be recoverable from a free page or the WAL until
+        // reused/checkpointed. `FAST` (vs `ON`) overwrites the actual
+        // deleted content without the extra I/O of zeroing all
+        // surrounding free space — the right tradeoff for a
+        // key-management store's write volume, still real security.
         conn.execute_batch(
             "PRAGMA journal_mode = WAL;
              PRAGMA synchronous = NORMAL;
              PRAGMA busy_timeout = 5000;
-             PRAGMA foreign_keys = ON;",
+             PRAGMA foreign_keys = ON;
+             PRAGMA secure_delete = FAST;",
         )
         .map_err(map_sqlite_err)?;
         Self::migrate(&mut conn)?;

--- a/kmip/src/store/sqlite.rs
+++ b/kmip/src/store/sqlite.rs
@@ -207,23 +207,40 @@ impl KeyStore for SqliteStore {
 
     fn update(&self, record: ObjectRecord) -> Result<()> {
         let conn = self.lock();
-        // Defence-in-depth: enforce the FSM at the store layer.
-        let current: Option<String> = conn
+        // Defence-in-depth: enforce the FSM at the store layer. Gap-
+        // remediation Phase H, Finding #12 — also fetch the existing
+        // row's full record (via the same `attributes_json` blob `get`/
+        // `row_to_record` treat as the source of truth) so
+        // `initial_date`/`original_creation_date` can be re-asserted
+        // below. `MemoryStore::update` already does this defence-in-
+        // depth re-assertion; `SqliteStore::update` previously only
+        // fetched `state` and wrote the incoming record's dates
+        // verbatim, silently accepting a caller-mutated Initial Date /
+        // Original Creation Date — both spec-immutable per §3/§11.
+        let current: Option<(String, Option<Vec<u8>>)> = conn
             .query_row(
-                "SELECT state FROM objects WHERE uid = ?1",
+                "SELECT state, attributes_json FROM objects WHERE uid = ?1",
                 params![record.uid],
-                |r| r.get(0),
+                |r| Ok((r.get(0)?, r.get(1)?)),
             )
             .map(Some)
             .or_else(|e| match e {
                 rusqlite::Error::QueryReturnedNoRows => Ok(None),
                 other => Err(map_sqlite_err(other)),
             })?;
-        let current_state =
+        let (current_state, current_json) =
             current.ok_or_else(|| KmipError::not_found(&record.uid))?;
         let from = state_from_str(&current_state)
             .ok_or_else(|| KmipError::internal(format!("unknown stored state {current_state:?}")))?;
         enforce_transition(from, record.state)?;
+
+        let mut record = record;
+        if let Some(blob) = &current_json {
+            if let Ok(existing) = serde_json::from_slice::<ObjectRecord>(blob) {
+                record.initial_date = existing.initial_date;
+                record.original_creation_date = existing.original_creation_date;
+            }
+        }
 
         let json = serde_json::to_vec(&record)
             .map_err(|e| KmipError::internal(format!("record serialise failed: {e}")))?;
@@ -605,6 +622,32 @@ mod tests {
         let r = store.get("u").unwrap().unwrap();
         assert_eq!(r.state, State::Active);
         assert!(r.activation_date.is_some());
+    }
+
+    /// Gap-remediation Phase H, Finding #12 — `Initial Date` and
+    /// `Original Creation Date` are spec-immutable (§3/§11);
+    /// `MemoryStore::update` already re-asserts them defensively,
+    /// `SqliteStore::update` previously wrote whatever the caller
+    /// passed in verbatim.
+    #[test]
+    fn update_does_not_let_caller_mutate_immutable_dates() {
+        let store = SqliteStore::in_memory().unwrap();
+        let mut original = rec("u", State::PreActive);
+        original.original_creation_date = Some(OffsetDateTime::UNIX_EPOCH);
+        store.put(original).unwrap();
+
+        let mut mutated = rec("u", State::PreActive);
+        mutated.initial_date = OffsetDateTime::UNIX_EPOCH + time::Duration::days(365);
+        mutated.original_creation_date = Some(OffsetDateTime::UNIX_EPOCH + time::Duration::days(365));
+        store.update(mutated).unwrap();
+
+        let r = store.get("u").unwrap().unwrap();
+        assert_eq!(r.initial_date, OffsetDateTime::UNIX_EPOCH, "Initial Date must not be caller-mutable");
+        assert_eq!(
+            r.original_creation_date,
+            Some(OffsetDateTime::UNIX_EPOCH),
+            "Original Creation Date must not be caller-mutable",
+        );
     }
 
     #[test]

--- a/kmip/src/store/traits.rs
+++ b/kmip/src/store/traits.rs
@@ -200,6 +200,13 @@ pub struct ObjectRecord {
     /// (last 8 hex chars of the UUID portion). Generated lazily.
     pub short_unique_identifier: Option<String>,
     pub alternative_name: Option<String>,
+    /// KMIP 3.0 §4.5 — `Alternative Name Type` (Enumeration). Gap-
+    /// remediation Phase H, Finding #11 — previously hardcoded to
+    /// `Uninterpreted Text String` (1) on encode regardless of what the
+    /// client set; now genuinely round-trips. `None` (e.g. an object
+    /// with no AlternativeName at all) renders the attribute absent,
+    /// same as before.
+    pub alternative_name_type: Option<u32>,
     pub comment: Option<String>,
     pub description: Option<String>,
     pub contact_information: Option<String>,
@@ -368,6 +375,7 @@ impl From<BaselineDefaults> for ObjectRecord {
             rotate_automatic: None,
             short_unique_identifier: None,
             alternative_name: None,
+            alternative_name_type: None,
             comment: None,
             description: None,
             contact_information: None,

--- a/kmip/tests/native_bridge_e2e.rs
+++ b/kmip/tests/native_bridge_e2e.rs
@@ -2628,3 +2628,117 @@ fn k9_id_placeholder_resolves_after_join_split_key() {
 
     let _ = softhsmrustv3::native::session::finalize();
 }
+
+/// Gap-remediation Phase D/H — found via BL-M-8-30 conformance replay
+/// (not originally called out by Finding #3's text): `TransparentRSAPublicKey`
+/// Register fed the raw TTLV `KeyMaterial` Structure straight to
+/// `register_rsa_public_key_der` (which expects real DER), so it always
+/// failed internally — silently while Finding #3's discarded-`Result`
+/// bug was in place, loudly (breaking BL-M-8) once that bug was fixed.
+/// Proves the Transparent form now produces a genuinely usable engine
+/// object: Register a real RSA key pair's private half in PKCS#8 form
+/// and public half in `TransparentRSAPublicKey` form (raw Modulus +
+/// PublicExponent BigIntegers, §6.2.1), then Sign with the private key
+/// and SignatureVerify with the Transparent-registered public key.
+#[test]
+fn k3_register_transparent_rsa_public_key_produces_usable_engine_object() {
+    use pqctoday_kmip::codec::{encode, Tag, TtlvFrame, Value};
+    use pqctoday_kmip::kmip30::{KeyBlock, KeyFormatType, RegisterRequest};
+    use pqctoday_kmip::ops::register_import_export::register;
+    use rsa::pkcs8::EncodePrivateKey;
+    use rsa::traits::PublicKeyParts;
+
+    let _guard = engine_test_lock();
+    let deps = build_deps_with_real_engine();
+
+    // KMIP §9.2.4 — BigInteger byte length must already be a multiple
+    // of 8 when handed to the codec; it does not auto-pad.
+    fn pad_to_multiple_of_8(mut bytes: Vec<u8>) -> Vec<u8> {
+        let pad = (8 - bytes.len() % 8) % 8;
+        let mut out = vec![0u8; pad];
+        out.append(&mut bytes);
+        out
+    }
+
+    let priv_key = rsa::RsaPrivateKey::new(&mut rand::rngs::OsRng, 2048)
+        .expect("generate RSA-2048 key");
+    let pub_key = priv_key.to_public_key();
+    let priv_pkcs8 = priv_key.to_pkcs8_der().expect("encode PKCS#8 private").as_bytes().to_vec();
+    let modulus_bits = (pub_key.n().to_bytes_be().len() as u32) * 8;
+    let modulus_bytes = pad_to_multiple_of_8(pub_key.n().to_bytes_be());
+    let exponent_bytes = pad_to_multiple_of_8(pub_key.e().to_bytes_be());
+
+    // §6.2.1 `KeyMaterial` Structure for TransparentRSAPublicKey:
+    // just Modulus (0x420052) + Public Exponent (0x42006c) BigIntegers.
+    const TAG_KEY_MATERIAL: u32 = 0x42_0043;
+    const TAG_MODULUS: u32 = 0x42_0052;
+    const TAG_PUBLIC_EXPONENT: u32 = 0x42_006c;
+    let key_material_frame = TtlvFrame::new(
+        Tag(TAG_KEY_MATERIAL),
+        Value::Structure(vec![
+            TtlvFrame::new(Tag(TAG_MODULUS), Value::BigInteger(modulus_bytes)),
+            TtlvFrame::new(Tag(TAG_PUBLIC_EXPONENT), Value::BigInteger(exponent_bytes)),
+        ]),
+    );
+    let mut ttlv_key_material = bytes::BytesMut::new();
+    encode(&key_material_frame, &mut ttlv_key_material);
+
+    let register_rsa = |object_type, format, bytes: Vec<u8>, usage| {
+        register(
+            &deps,
+            RegisterRequest {
+                secret_data_type: None,
+                object_type,
+                attributes: vec![
+                    Attribute::CryptographicAlgorithm(KmipAlgorithm::Rsa),
+                    Attribute::CryptographicLength(modulus_bits),
+                    Attribute::CryptographicUsageMask(usage),
+                    Attribute::ActivationDate(OffsetDateTime::now_utc().unix_timestamp() - 3600),
+                ],
+                managed_object: Some(KeyBlock {
+                    key_format_type: format,
+                    cryptographic_algorithm: KmipAlgorithm::Rsa,
+                    cryptographic_length: modulus_bits,
+                    key_value: bytes,
+                    key_wrapping_data: None,
+                }),
+                protection_storage_masks: None,
+                certificate_payload: None,
+            },
+            "k3-register-transparent",
+        )
+        .map(|r| r.uid)
+    };
+
+    let priv_uid = register_rsa(ObjectType::PrivateKey, KeyFormatType::Pkcs8, priv_pkcs8, UsageMask::SIGN)
+        .expect("Register RSA private key (PKCS#8)");
+    let pub_uid = register_rsa(
+        ObjectType::PublicKey,
+        KeyFormatType::TransparentRsaPublicKey,
+        ttlv_key_material.to_vec(),
+        UsageMask::VERIFY,
+    )
+    .expect("Register RSA public key (TransparentRSAPublicKey) must succeed with a real engine object");
+
+    let message = b"BL-M-8: TransparentRSAPublicKey Register must be genuinely usable".to_vec();
+    let sig = sign(
+        &deps,
+        SignRequest { uid: priv_uid, data: message.clone(), cryptographic_parameters: None },
+        "k3-sign-transparent",
+    )
+    .expect("Sign with PKCS#8-registered RSA private key");
+    let verified = signature_verify(
+        &deps,
+        SignatureVerifyRequest {
+            uid: pub_uid,
+            data: message,
+            signature: sig.signature,
+            cryptographic_parameters: None,
+        },
+        "k3-verify-transparent",
+    )
+    .expect("SignatureVerify against a TransparentRSAPublicKey-registered public key");
+    assert_eq!(verified.validity, SignatureValidity::Valid);
+
+    let _ = softhsmrustv3::native::session::finalize();
+}

--- a/kmip/tests/native_bridge_e2e.rs
+++ b/kmip/tests/native_bridge_e2e.rs
@@ -2344,3 +2344,147 @@ fn create_split_key_then_join_covers_every_11_54_method_via_real_engine() {
 
     let _ = softhsmrustv3::native::session::finalize();
 }
+
+/// Gap-remediation Phase D, Finding #3 — `register_rsa_public_key_der`
+/// previously accepted PKCS#1 (`RSAPublicKey`) DER only, despite the
+/// KMIP-layer Register handler's own doc comment claiming PKCS#8
+/// (SubjectPublicKeyInfo) support too. A PKCS#8-form Register used to
+/// return wire `Success` with no real engine object (the `Result` was
+/// discarded), so a later `SignatureVerify` failed with an unrelated
+/// "not found" error instead of `Register` honestly rejecting or
+/// genuinely supporting the format. Proves both DER forms now really
+/// work end-to-end: Register (PrivateKey, PKCS#8) → Register
+/// (PublicKey, PKCS#8) → Sign → SignatureVerify, and separately Register
+/// (PublicKey, PKCS#1) → SignatureVerify against the same signature.
+#[test]
+fn k3_register_rsa_public_key_accepts_both_pkcs1_and_pkcs8_der() {
+    use pqctoday_kmip::kmip30::{KeyBlock, KeyFormatType, RegisterRequest};
+    use pqctoday_kmip::ops::register_import_export::register;
+    use rsa::pkcs1::EncodeRsaPublicKey;
+    use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey};
+    use rsa::traits::PublicKeyParts;
+
+    let _guard = engine_test_lock();
+    let deps = build_deps_with_real_engine();
+
+    let priv_key = rsa::RsaPrivateKey::new(&mut rand::rngs::OsRng, 2048)
+        .expect("generate RSA-2048 key");
+    let pub_key = priv_key.to_public_key();
+    let priv_pkcs8 = priv_key.to_pkcs8_der().expect("encode PKCS#8 private").as_bytes().to_vec();
+    let pub_pkcs8 = pub_key.to_public_key_der().expect("encode PKCS#8 SPKI public").as_bytes().to_vec();
+    let pub_pkcs1 = pub_key.to_pkcs1_der().expect("encode PKCS#1 public").as_bytes().to_vec();
+    let modulus_bits = pub_key.n().bits() as u32;
+
+    let register_rsa = |object_type, format, bytes: Vec<u8>, usage| {
+        register(
+            &deps,
+            RegisterRequest {
+                secret_data_type: None,
+                object_type,
+                attributes: vec![
+                    Attribute::CryptographicAlgorithm(KmipAlgorithm::Rsa),
+                    Attribute::CryptographicLength(modulus_bits),
+                    Attribute::CryptographicUsageMask(usage),
+                    Attribute::ActivationDate(OffsetDateTime::now_utc().unix_timestamp() - 3600),
+                ],
+                managed_object: Some(KeyBlock {
+                    key_format_type: format,
+                    cryptographic_algorithm: KmipAlgorithm::Rsa,
+                    cryptographic_length: modulus_bits,
+                    key_value: bytes,
+                    key_wrapping_data: None,
+                }),
+                protection_storage_masks: None,
+                certificate_payload: None,
+            },
+            "k3-register",
+        )
+        .map(|r| r.uid)
+    };
+
+    let priv_uid = register_rsa(ObjectType::PrivateKey, KeyFormatType::Pkcs8, priv_pkcs8, UsageMask::SIGN)
+        .expect("Register RSA private key (PKCS#8) must succeed with a real engine object");
+
+    let message = b"K3: PKCS#8 RSA public key Register must be genuinely usable".to_vec();
+    let sig = sign(
+        &deps,
+        SignRequest { uid: priv_uid, data: message.clone(), cryptographic_parameters: None },
+        "k3-sign",
+    )
+    .expect("Sign with PKCS#8-registered RSA private key");
+
+    // PKCS#8 (SubjectPublicKeyInfo) form — the case that previously
+    // silently produced no engine object.
+    let pub_uid_pkcs8 = register_rsa(ObjectType::PublicKey, KeyFormatType::Pkcs8, pub_pkcs8, UsageMask::VERIFY)
+        .expect("Register RSA public key (PKCS#8) must succeed with a real engine object");
+    let verified = signature_verify(
+        &deps,
+        SignatureVerifyRequest {
+            uid: pub_uid_pkcs8,
+            data: message.clone(),
+            signature: sig.signature.clone(),
+            cryptographic_parameters: None,
+        },
+        "k3-verify-pkcs8",
+    )
+    .expect("SignatureVerify against a PKCS#8-registered RSA public key");
+    assert_eq!(verified.validity, SignatureValidity::Valid);
+
+    // PKCS#1 (RSAPublicKey) form — the pre-existing, already-working case
+    // — must keep working after adding PKCS#8 support alongside it.
+    let pub_uid_pkcs1 = register_rsa(ObjectType::PublicKey, KeyFormatType::Pkcs1, pub_pkcs1, UsageMask::VERIFY)
+        .expect("Register RSA public key (PKCS#1) must still succeed");
+    let verified = signature_verify(
+        &deps,
+        SignatureVerifyRequest {
+            uid: pub_uid_pkcs1,
+            data: message,
+            signature: sig.signature,
+            cryptographic_parameters: None,
+        },
+        "k3-verify-pkcs1",
+    )
+    .expect("SignatureVerify against a PKCS#1-registered RSA public key");
+    assert_eq!(verified.validity, SignatureValidity::Valid);
+
+    let _ = softhsmrustv3::native::session::finalize();
+}
+
+/// Gap-remediation Phase D, Finding #3 — an unrecognized/malformed RSA
+/// PrivateKey `KeyFormatType` at Register time must fail Register
+/// honestly instead of silently succeeding with no engine object.
+#[test]
+fn k3_register_rsa_private_key_malformed_pkcs1_fails_register_not_silently() {
+    use pqctoday_kmip::kmip30::{KeyBlock, KeyFormatType, RegisterRequest};
+    use pqctoday_kmip::ops::register_import_export::register;
+
+    let _guard = engine_test_lock();
+    let deps = build_deps_with_real_engine();
+
+    let err = register(
+        &deps,
+        RegisterRequest {
+            secret_data_type: None,
+            object_type: ObjectType::PrivateKey,
+            attributes: vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::Rsa),
+                Attribute::CryptographicLength(2048),
+                Attribute::CryptographicUsageMask(UsageMask::SIGN),
+            ],
+            managed_object: Some(KeyBlock {
+                key_format_type: KeyFormatType::Pkcs1,
+                cryptographic_algorithm: KmipAlgorithm::Rsa,
+                cryptographic_length: 2048,
+                key_value: vec![0xFF; 32], // not a valid PKCS#1 RSAPrivateKey DER
+                key_wrapping_data: None,
+            }),
+            protection_storage_masks: None,
+            certificate_payload: None,
+        },
+        "k3-register-malformed",
+    )
+    .unwrap_err();
+    assert_eq!(err.result_reason(), pqctoday_kmip::error::ResultReason::KeyFormatTypeNotSupported);
+
+    let _ = softhsmrustv3::native::session::finalize();
+}

--- a/kmip/tests/native_bridge_e2e.rs
+++ b/kmip/tests/native_bridge_e2e.rs
@@ -2488,3 +2488,143 @@ fn k3_register_rsa_private_key_malformed_pkcs1_fails_register_not_silently() {
 
     let _ = softhsmrustv3::native::session::finalize();
 }
+
+/// Gap-remediation Phase G, Finding #9 — `newly_created_uids` didn't
+/// match `CreateSplitKey`'s response, so a batch `Undo` after it
+/// succeeded used to leak every minted Split Key part instead of
+/// rolling them back. 2-item batch: item 1 = CreateSplitKey (mints 3
+/// parts via XOR), item 2 = a deliberately-failing Destroy on a UID
+/// that was never created, mode = Undo.
+#[test]
+fn k9_undo_rolls_back_create_split_key_parts() {
+    use pqctoday_kmip::dispatcher::dispatch;
+    use pqctoday_kmip::kmip30::{
+        BatchErrorContinuationOption, CreateSplitKeyRequest, DestroyRequest, ObjectType, Operation,
+        RequestBatchItem, RequestHeader, RequestMessage, RequestPayload, ResultStatus,
+    };
+
+    let _guard = engine_test_lock();
+    let deps = build_deps_with_real_engine();
+
+    let msg = RequestMessage {
+        header: RequestHeader {
+            batch_error_continuation_option: Some(BatchErrorContinuationOption::Undo),
+            ..RequestHeader::v3()
+        },
+        batch_items: vec![
+            RequestBatchItem {
+                operation: Operation::CreateSplitKey,
+                payload: RequestPayload::CreateSplitKey(CreateSplitKeyRequest {
+                    object_type: ObjectType::SecretData,
+                    uid: None,
+                    split_key_parts: 3,
+                    split_key_threshold: 3,
+                    split_key_method: 1, // XOR
+                    prime_field_size: None,
+                    attributes: vec![
+                        Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
+                        Attribute::CryptographicLength(256),
+                    ],
+                    protection_storage_masks: None,
+                }),
+            },
+            RequestBatchItem {
+                operation: Operation::Destroy,
+                payload: RequestPayload::Destroy(DestroyRequest { uid: "urn:ghost".into() }),
+            },
+        ],
+    };
+
+    let resp = dispatch(&deps, msg);
+    assert_eq!(resp.batch_items.len(), 2);
+    assert_eq!(
+        resp.batch_items[0].result_status,
+        ResultStatus::OperationUndone,
+        "CreateSplitKey must be relabelled OperationUndone after the Undo wave",
+    );
+    let part_uids = match &resp.batch_items[0].payload {
+        Some(pqctoday_kmip::kmip30::ResponsePayload::CreateSplitKey(r)) => r.uids.clone(),
+        other => panic!("expected CreateSplitKey response payload, got {other:?}"),
+    };
+    assert_eq!(part_uids.len(), 3);
+    for uid in &part_uids {
+        assert!(
+            deps.store.get(uid).unwrap().is_none(),
+            "Undo must genuinely delete split-key part {uid}, not just relabel the response",
+        );
+    }
+    let _ = softhsmrustv3::native::session::finalize();
+}
+
+/// Gap-remediation Phase G, Finding #9 — `update_id_placeholder` didn't
+/// match `JoinSplitKey`'s response either, so a batch item chained via
+/// `$IDPlaceholder` right after a JoinSplitKey used to fail with a
+/// spurious "ID Placeholder not set" instead of resolving to the
+/// reconstructed object's real UID.
+#[test]
+fn k9_id_placeholder_resolves_after_join_split_key() {
+    use pqctoday_kmip::dispatcher::{dispatch, ID_PLACEHOLDER_SENTINEL};
+    use pqctoday_kmip::kmip30::{
+        GetRequest, JoinSplitKeyRequest, ObjectType, Operation, RequestBatchItem, RequestHeader,
+        RequestMessage, RequestPayload, ResultStatus,
+    };
+    use pqctoday_kmip::ops::split_key::create_split_key;
+    use pqctoday_kmip::kmip30::CreateSplitKeyRequest;
+
+    let _guard = engine_test_lock();
+    let deps = build_deps_with_real_engine();
+
+    let create_resp = create_split_key(
+        &deps,
+        CreateSplitKeyRequest {
+            object_type: ObjectType::SecretData,
+            uid: None,
+            split_key_parts: 3,
+            split_key_threshold: 3,
+            split_key_method: 1, // XOR
+            prime_field_size: None,
+            attributes: vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
+                Attribute::CryptographicLength(256),
+            ],
+            protection_storage_masks: None,
+        },
+        "k9-precreate-parts",
+    )
+    .expect("Create Split Key");
+
+    let msg = RequestMessage {
+        header: RequestHeader::v3(),
+        batch_items: vec![
+            RequestBatchItem {
+                operation: Operation::JoinSplitKey,
+                payload: RequestPayload::JoinSplitKey(JoinSplitKeyRequest {
+                    object_type: ObjectType::SecretData,
+                    uids: create_resp.uids.clone(),
+                    secret_data_type: None,
+                    attributes: vec![],
+                    protection_storage_masks: None,
+                }),
+            },
+            RequestBatchItem {
+                operation: Operation::Get,
+                payload: RequestPayload::Get(GetRequest {
+                    uid: ID_PLACEHOLDER_SENTINEL.to_string(),
+                    key_format_type: None,
+                    key_wrapping_specification: None,
+                }),
+            },
+        ],
+    };
+
+    let resp = dispatch(&deps, msg);
+    assert_eq!(resp.batch_items.len(), 2);
+    assert_eq!(resp.batch_items[0].result_status, ResultStatus::Success);
+    assert_eq!(
+        resp.batch_items[1].result_status,
+        ResultStatus::Success,
+        "Get with IDPlaceholder must resolve to JoinSplitKey's reconstructed UID",
+    );
+
+    let _ = softhsmrustv3::native::session::finalize();
+}

--- a/kmip/tests/native_bridge_e2e.rs
+++ b/kmip/tests/native_bridge_e2e.rs
@@ -572,6 +572,7 @@ fn register_pqc(
     register(
         deps,
         RegisterRequest {
+            secret_data_type: None,
             object_type,
             attributes: vec![
                 Attribute::CryptographicAlgorithm(alg),
@@ -846,6 +847,7 @@ fn k9_register_pqc_length_mismatch_fails_invalid_attribute_value() {
     let err = register(
         &deps,
         RegisterRequest {
+            secret_data_type: None,
             object_type: ObjectType::PrivateKey,
             attributes: vec![
                 Attribute::CryptographicAlgorithm(KmipAlgorithm::MlDsa65),
@@ -1220,6 +1222,7 @@ fn k17_register_wrapped_hmac_key_then_mac_against_real_engine() {
         let uid = register(
             &deps,
             RegisterRequest {
+            secret_data_type: None,
                 object_type: ObjectType::SymmetricKey,
                 attributes: vec![
                     Attribute::CryptographicAlgorithm(alg),
@@ -2042,6 +2045,7 @@ fn hss_register_sign_verify_against_real_engine() {
         register(
             &deps,
             RegisterRequest {
+            secret_data_type: None,
                 object_type,
                 attributes: vec![
                     Attribute::CryptographicAlgorithm(KmipAlgorithm::Hss),

--- a/kmip/tests/openssl_kem_interop.rs
+++ b/kmip/tests/openssl_kem_interop.rs
@@ -121,6 +121,7 @@ fn register_key(
     register(
         d,
         RegisterRequest {
+            secret_data_type: None,
             object_type,
             attributes: vec![
                 Attribute::CryptographicAlgorithm(alg),

--- a/kmip/tests/p2_5_mlkem_dispatcher_xts.rs
+++ b/kmip/tests/p2_5_mlkem_dispatcher_xts.rs
@@ -107,6 +107,7 @@ fn register_pqc_via_dispatcher(
         batch_items: vec![RequestBatchItem {
             operation: Operation::Register,
             payload: RequestPayload::Register(RegisterRequest {
+            secret_data_type: None,
                 object_type,
                 attributes: vec![
                     Attribute::CryptographicAlgorithm(alg),
@@ -450,6 +451,7 @@ fn register_aes_via_dispatcher(deps: &Deps, key: Vec<u8>) -> String {
         batch_items: vec![RequestBatchItem {
             operation: Operation::Register,
             payload: RequestPayload::Register(RegisterRequest {
+            secret_data_type: None,
                 object_type: ObjectType::SymmetricKey,
                 attributes: vec![
                     Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1660,7 +1660,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "softhsmrustv3"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softhsmrustv3"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 description = "A native Rust WebAssembly clone of SoftHSMv3"
 

--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -690,9 +690,12 @@ pub fn C_GetMechanismList(slot_id: u32, p_mechanism_list: *mut u32, pul_count: *
     CKR_OK
 }
 
-// ── Multi-part operation stubs (PKCS#11 v3.2 compliance) ────────────────────
-// These return CKR_FUNCTION_NOT_SUPPORTED as the Rust engine only supports
-// single-shot operations. DigestUpdate/DigestFinal are fully implemented above.
+// C_*Update/C_*Final multi-part Sign/Verify/Encrypt/Decrypt/Digest flows are
+// all genuinely implemented in ffi.rs (real per-session accumulator state,
+// e.g. SIGN_MULTIPART_ACC), not stubbed. CKR_FUNCTION_NOT_SUPPORTED below
+// remains the spec-legal answer for the handful of PKCS#11 v3.2 functions a
+// compliant library may decline outright (§11.17) — it is not a marker for
+// "multi-part isn't implemented."
 
 pub const CKR_FUNCTION_NOT_SUPPORTED: u32 = 0x0000_0054;
 pub const CKR_FUNCTION_NOT_PARALLEL: u32 = 0x0000_0051;

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1198,9 +1198,15 @@ pub fn C_GenerateKeyPair(
             CKM_SLH_DSA_KEY_PAIR_GEN => Some(CKK_SLH_DSA),
             CKM_RSA_PKCS_KEY_PAIR_GEN => Some(CKK_RSA),
             CKM_EC_KEY_PAIR_GEN => Some(CKK_EC),
-            // Stateful HBS keygen is not implemented, but the keytype-vs-mech
-            // consistency rule (V4) still applies up-front: a contradictory
-            // CKA_KEY_TYPE is CKR_TEMPLATE_INCONSISTENT before any keygen work.
+            // HSS, XMSS, and XMSS-MT keygen are all implemented below
+            // (real LMS/LM-OTS / XMSS tree generation), and this FFI
+            // layer's own C_Sign/C_Verify sign/verify both mechanisms
+            // for real too. Only the newer typed `native::sign` module
+            // hasn't been extended past HSS to XMSS/XMSS-MT yet (see
+            // that module's doc comment) — this FFI path is unaffected.
+            // The keytype-vs-mech consistency rule (V4) still applies
+            // up-front for all three here: a contradictory CKA_KEY_TYPE
+            // is CKR_TEMPLATE_INCONSISTENT before any keygen work runs.
             CKM_HSS_KEY_PAIR_GEN => Some(CKK_HSS),
             CKM_XMSS_KEY_PAIR_GEN => Some(CKK_XMSS),
             CKM_XMSSMT_KEY_PAIR_GEN => Some(CKK_XMSSMT),

--- a/rust/src/native/encrypt.rs
+++ b/rust/src/native/encrypt.rs
@@ -554,103 +554,51 @@ fn classic_mceliece_decapsulate(private_key_handle: u32, ciphertext: &[u8]) -> R
 ///   from the KMIP `Register` op).
 ///
 /// Other modes return `CKR_MECHANISM_INVALID`.
+/// Gap-remediation Phase F, Finding #4 — previously hardcoded empty AAD
+/// (AES-GCM/ChaCha20-Poly1305) and the SHA-256/MGF1-SHA-256/no-label
+/// OAEP default, unconditionally, for every engine-resident (Create/
+/// CreateKeyPair'd) key — those client-supplied values only reached the
+/// engine on the Register'd-key (raw-material) path via
+/// [`encrypt_with_key_bytes`]. Now resolves the key bytes exactly as
+/// before (`check_flag` + `get_object_value`) and delegates to
+/// [`encrypt_with_key_bytes`] for the actual mechanism dispatch, so both
+/// paths run the identical match body instead of two copies that used
+/// to silently drift apart.
 pub fn encrypt(
     _session: u32,
     key_handle: u32,
     mechanism: u32,
     plaintext: &[u8],
     iv: Option<&[u8]>,
+    oaep: Option<&OaepParams>,
+    aad: &[u8],
+    tag_len: Option<usize>,
 ) -> Result<Vec<u8>, CkRv> {
     if !check_flag(key_handle, CKA_ENCRYPT) {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
     let key_bytes = get_object_value(key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
-
-    match mechanism {
-        CKM_AES_GCM => {
-            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
-            // Handle-based encrypt has no AAD plumbing yet — use empty.
-            // KMIP callers that need AEAD with AAD go through
-            // `encrypt_with_key_bytes` instead.
-            aes_gcm_encrypt(&key_bytes, iv, plaintext, &[], None)
-        }
-        CKM_AES_ECB => aes_ecb_encrypt(&key_bytes, plaintext),
-        CKM_AES_CBC => {
-            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
-            aes_cbc_encrypt(&key_bytes, iv, plaintext)
-        }
-        CKM_AES_CBC_PAD => {
-            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
-            aes_cbc_pad_encrypt(&key_bytes, iv, plaintext)
-        }
-        CKM_AES_CTR => {
-            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
-            aes_ctr_apply(&key_bytes, iv, plaintext)
-        }
-        CKM_CHACHA20 => {
-            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
-            chacha20_encrypt(&key_bytes, iv, plaintext)
-        }
-        CKM_CHACHA20_POLY1305 => {
-            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
-            chacha20_poly1305_encrypt(&key_bytes, iv, plaintext, &[])
-        }
-        CKM_RSA_PKCS_OAEP => {
-            // Handle-based path doesn't carry parameters yet; defaults
-            // to SHA-256/MGF1-SHA-256/no-label (the Baseline default).
-            rsa_oaep_encrypt(&key_bytes, plaintext, &OaepParams::sha256_default())
-        }
-        _ => Err(CKR_MECHANISM_INVALID),
-    }
+    encrypt_with_key_bytes(&key_bytes, mechanism, plaintext, iv, oaep, aad, tag_len)
 }
 
-/// Classical decrypt. See [`encrypt`] for the mechanism table.
+/// Classical decrypt. See [`encrypt`] for the mechanism table and the
+/// Gap-remediation Phase F note on why this now delegates to
+/// [`decrypt_with_key_bytes`].
 pub fn decrypt(
     _session: u32,
     key_handle: u32,
     mechanism: u32,
     ciphertext: &[u8],
     iv: Option<&[u8]>,
+    oaep: Option<&OaepParams>,
+    aad: &[u8],
+    tag_len: Option<usize>,
 ) -> Result<Vec<u8>, CkRv> {
     if !check_flag(key_handle, CKA_DECRYPT) {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
     let key_bytes = get_object_value(key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
-
-    match mechanism {
-        CKM_AES_GCM => {
-            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
-            aes_gcm_decrypt(&key_bytes, iv, ciphertext, &[], None)
-        }
-        CKM_AES_ECB => aes_ecb_decrypt(&key_bytes, ciphertext),
-        CKM_AES_CBC => {
-            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
-            aes_cbc_decrypt(&key_bytes, iv, ciphertext)
-        }
-        CKM_AES_CBC_PAD => {
-            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
-            aes_cbc_pad_decrypt(&key_bytes, iv, ciphertext)
-        }
-        CKM_AES_CTR => {
-            // CTR is self-inverse — same keystream XOR for both directions.
-            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
-            aes_ctr_apply(&key_bytes, iv, ciphertext)
-        }
-        CKM_CHACHA20 => {
-            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
-            // ChaCha20 is symmetric / self-inverse — same primitive
-            // for encrypt and decrypt.
-            chacha20_encrypt(&key_bytes, iv, ciphertext)
-        }
-        CKM_CHACHA20_POLY1305 => {
-            let iv = iv.ok_or(CKR_ARGUMENTS_BAD)?;
-            chacha20_poly1305_decrypt(&key_bytes, iv, ciphertext, &[])
-        }
-        CKM_RSA_PKCS_OAEP => {
-            rsa_oaep_decrypt(&key_bytes, ciphertext, &OaepParams::sha256_default())
-        }
-        _ => Err(CKR_MECHANISM_INVALID),
-    }
+    decrypt_with_key_bytes(&key_bytes, mechanism, ciphertext, iv, oaep, aad, tag_len)
 }
 
 /// OAEP padding parameters per PKCS#11 v3.2 §6.13 (`CK_RSA_PKCS_OAEP_PARAMS`).
@@ -800,7 +748,36 @@ fn rsa_public_key_from_any_der(bytes: &[u8]) -> Result<rsa::RsaPublicKey, CkRv> 
     use rsa::pkcs8::DecodePublicKey;
     rsa::RsaPublicKey::from_public_key_der(bytes)
         .or_else(|_| rsa::RsaPublicKey::from_pkcs1_der(bytes))
+        .or_else(|_| rsa_public_key_from_packed_native(bytes))
         .map_err(|_| CKR_KEY_TYPE_INCONSISTENT)
+}
+
+/// Gap-remediation Phase F, Finding #4 (T0 discovery) — a
+/// `generate_rsa_keypair`'d public key's `CKA_VALUE` is NOT DER at all;
+/// it's this engine's own internal packed `[n_len:4LE][n_bytes][e_bytes]`
+/// format (see `generate_rsa_keypair`'s comment: "Format mirrors
+/// ffi.rs"). `ffi.rs`'s own `CKM_RSA_PKCS_OAEP` C_Encrypt path already
+/// unpacks this exact format independently (it never calls this
+/// function) — this mirrors that unpacking so the native handle-based
+/// `encrypt()`, once delegating here via `encrypt_with_key_bytes`, can
+/// finally RSA-OAEP-encrypt with an engine-GENERATED key too, not just
+/// a `Register`'d one. Before this, `rsa_public_key_from_any_der`
+/// rejected the packed bytes outright (`Err(InvalidPkcs1)` /
+/// `Err(InvalidPkcs8)`) and RSA-OAEP Encrypt against any
+/// CreateKeyPair'd RSA key handle always failed — a pre-existing gap
+/// this fix's own new test (`rsa_oaep_engine_handle_honors_explicit_hash_override`)
+/// caught, not something Finding #4's text originally called out.
+fn rsa_public_key_from_packed_native(bytes: &[u8]) -> Result<rsa::RsaPublicKey, rsa::Error> {
+    if bytes.len() < 4 {
+        return Err(rsa::Error::Internal);
+    }
+    let n_len = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    if bytes.len() < 4 + n_len + 1 {
+        return Err(rsa::Error::Internal);
+    }
+    let n = rsa::BigUint::from_bytes_be(&bytes[4..4 + n_len]);
+    let e = rsa::BigUint::from_bytes_be(&bytes[4 + n_len..]);
+    rsa::RsaPublicKey::new(n, e)
 }
 
 /// Parse an RSA private key from either PKCS#8 PrivateKeyInfo (KMIP

--- a/rust/src/native/keygen.rs
+++ b/rust/src/native/keygen.rs
@@ -2563,10 +2563,85 @@ mod tests {
         let handle = generate_aes_key(session, 256, b"\x01", "aes-gcm").unwrap();
         let iv = vec![0x42u8; 12];
         let plaintext = b"the quick brown fox";
-        let ciphertext = encrypt(session, handle, CKM_AES_GCM, plaintext, Some(&iv)).unwrap();
+        let ciphertext =
+            encrypt(session, handle, CKM_AES_GCM, plaintext, Some(&iv), None, &[], None).unwrap();
         // AES-GCM ciphertext = plaintext.len() + 16-byte tag.
         assert_eq!(ciphertext.len(), plaintext.len() + 16);
-        let recovered = decrypt(session, handle, CKM_AES_GCM, &ciphertext, Some(&iv)).unwrap();
+        let recovered =
+            decrypt(session, handle, CKM_AES_GCM, &ciphertext, Some(&iv), None, &[], None).unwrap();
+        assert_eq!(recovered, plaintext);
+        close_session(session).unwrap();
+    }
+
+    /// Gap-remediation Phase F, Finding #4 — the handle-based `encrypt`/
+    /// `decrypt` previously hardcoded empty AAD unconditionally; real
+    /// client-supplied AAD must now genuinely authenticate the
+    /// ciphertext (round-trips when matched, fails when tampered),
+    /// exactly like the raw-bytes `encrypt_with_key_bytes` path already
+    /// did.
+    #[test]
+    fn aes_256_gcm_engine_handle_honors_real_aad() {
+        use crate::native::encrypt::{decrypt, encrypt};
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let handle = generate_aes_key(session, 256, b"\x01", "aes-gcm-aad").unwrap();
+        let iv = vec![0x24u8; 12];
+        let plaintext = b"Phase F: real AAD must genuinely authenticate";
+        let aad = b"associated-data-not-encrypted";
+
+        let ciphertext =
+            encrypt(session, handle, CKM_AES_GCM, plaintext, Some(&iv), None, aad, None).unwrap();
+        let recovered =
+            decrypt(session, handle, CKM_AES_GCM, &ciphertext, Some(&iv), None, aad, None).unwrap();
+        assert_eq!(recovered, plaintext, "decrypt with the matching AAD must recover the plaintext");
+
+        let err = decrypt(
+            session, handle, CKM_AES_GCM, &ciphertext, Some(&iv), None, b"wrong-aad", None,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err, CKR_ENCRYPTED_DATA_INVALID,
+            "decrypt with mismatched AAD must fail authentication, not silently succeed",
+        );
+        close_session(session).unwrap();
+    }
+
+    /// Gap-remediation Phase F, Finding #4 — the handle-based `encrypt`/
+    /// `decrypt` previously hardcoded SHA-256/MGF1-SHA-256 for RSA-OAEP
+    /// unconditionally. Proves an explicit non-default hash (SHA-384) is
+    /// genuinely used, not silently ignored: encrypting with SHA-384 and
+    /// decrypting with the SHA-256 default must fail (wrong padding
+    /// hash), while decrypting with SHA-384 explicitly must recover the
+    /// plaintext.
+    #[test]
+    fn rsa_oaep_engine_handle_honors_explicit_hash_override() {
+        use crate::native::encrypt::{decrypt, encrypt, OaepHash, OaepParams};
+        let _guard = test_lock::acquire();
+        let session = fresh_session();
+        let (pub_handle, priv_handle) =
+            generate_rsa_keypair(session, 2048, b"\x01", "rsa-oaep-hash").unwrap();
+        let plaintext = b"Phase F: OAEP hash override must be real";
+
+        let sha384 = OaepParams { hash: Some(OaepHash::Sha384), mgf_hash: Some(OaepHash::Sha384), label: None };
+        let ciphertext = encrypt(
+            session, pub_handle, CKM_RSA_PKCS_OAEP, plaintext, None, Some(&sha384), &[], None,
+        )
+        .unwrap();
+
+        // SHA-256 default (no override) must NOT decrypt SHA-384-OAEP
+        // ciphertext — proves encrypt genuinely used SHA-384, not a
+        // silently-ignored parameter.
+        let default_err = decrypt(
+            session, priv_handle, CKM_RSA_PKCS_OAEP, &ciphertext, None, None, &[], None,
+        )
+        .unwrap_err();
+        assert_eq!(default_err, CKR_ENCRYPTED_DATA_INVALID);
+
+        // The matching SHA-384 override on decrypt recovers the plaintext.
+        let recovered = decrypt(
+            session, priv_handle, CKM_RSA_PKCS_OAEP, &ciphertext, None, Some(&sha384), &[], None,
+        )
+        .unwrap();
         assert_eq!(recovered, plaintext);
         close_session(session).unwrap();
     }
@@ -2580,9 +2655,11 @@ mod tests {
         let session = fresh_session();
         let handle = generate_aes_key(session, 256, b"\x01", "tamper").unwrap();
         let iv = vec![0u8; 12];
-        let mut ct = encrypt(session, handle, CKM_AES_GCM, b"hello", Some(&iv)).unwrap();
+        let mut ct =
+            encrypt(session, handle, CKM_AES_GCM, b"hello", Some(&iv), None, &[], None).unwrap();
         ct[0] ^= 0xFF;
-        let err = decrypt(session, handle, CKM_AES_GCM, &ct, Some(&iv)).unwrap_err();
+        let err =
+            decrypt(session, handle, CKM_AES_GCM, &ct, Some(&iv), None, &[], None).unwrap_err();
         assert_eq!(err, CKR_ENCRYPTED_DATA_INVALID);
         close_session(session).unwrap();
     }

--- a/rust/src/native/keygen.rs
+++ b/rust/src/native/keygen.rs
@@ -1010,13 +1010,22 @@ pub fn register_rsa_private_key_pkcs8(
     Ok(alloc_in_session_slot(_session, attrs))
 }
 
-/// Register an existing RSA public key supplied as PKCS#1 (RSAPublicKey)
-/// DER bytes — `SEQUENCE { modulus, publicExponent }`. Parses the DER
-/// to extract `n` and `e`, stored as `CKA_MODULUS` + `CKA_PUBLIC_EXPONENT`
-/// (the form `verify_rsa` reads via `get_rsa_public_components`).
+/// Register an existing RSA public key supplied as either PKCS#1
+/// (RSAPublicKey, `SEQUENCE { modulus, publicExponent }`) or PKCS#8
+/// (SubjectPublicKeyInfo) DER bytes. Parses the DER to extract `n` and
+/// `e`, stored as `CKA_MODULUS` + `CKA_PUBLIC_EXPONENT` (the form
+/// `verify_rsa` reads via `get_rsa_public_components`).
 ///
 /// Used by KMIP Register when the client provides an RSA PublicKey.
 /// CS-AC-M-2 exercises this path against a SignatureVerify op.
+///
+/// Gap-remediation Phase D, Finding #3 — this previously accepted PKCS#1
+/// only, despite the KMIP-layer caller's own doc comment claiming PKCS#8
+/// support too; a PKCS#8-form Register call would fail here and the KMIP
+/// layer discarded the `Result`, so the client saw a wire `Success` with
+/// no real engine object. Same `from_public_key_der` → `from_pkcs1_der`
+/// fallback order `rsa_public_key_from_any_der` (`native/encrypt.rs`)
+/// already uses for the analogous Encrypt/Decrypt DER-parsing path.
 pub fn register_rsa_public_key_der(
     _session: u32,
     der: &[u8],
@@ -1028,8 +1037,11 @@ pub fn register_rsa_public_key_der(
         CKA_PUBLIC_EXPONENT, CKA_VALUE, CKA_VERIFY, CKK_RSA, CKO_PUBLIC_KEY,
     };
     use rsa::pkcs1::DecodeRsaPublicKey;
+    use rsa::pkcs8::DecodePublicKey;
     use rsa::traits::PublicKeyParts;
-    let pk = rsa::RsaPublicKey::from_pkcs1_der(der).map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
+    let pk = rsa::RsaPublicKey::from_public_key_der(der)
+        .or_else(|_| rsa::RsaPublicKey::from_pkcs1_der(der))
+        .map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
     let n_bytes = pk.n().to_bytes_be();
     let e_bytes = pk.e().to_bytes_be();
     let bits = (n_bytes.len() as u32) * 8;

--- a/rust/src/native/sign.rs
+++ b/rust/src/native/sign.rs
@@ -6,11 +6,12 @@
 //! the right typed primitive. Returns the signature as `Vec<u8>` (no
 //! caller-allocated output buffer).
 //!
-//! Mirrors the dispatch logic in `ffi::C_Sign` / `ffi::C_Verify` exactly,
-//! minus the wasm32 pointer marshalling and the stateful HSS / XMSS / LMS
-//! paths (those require coordinated `CKA_STATEFUL_KEY_STATE` updates
-//! that don't map cleanly to the Result<Vec<u8>, _> shape; KMIP doesn't
-//! need them per Phase 4.5 FIPS-only scope).
+//! Mirrors the dispatch logic in `ffi::C_Sign` / `ffi::C_Verify`, minus
+//! the wasm32 pointer marshalling. Stateful HSS sign/verify IS
+//! implemented here (leaf-index advancement + tamper detection covered
+//! by this module's own tests); XMSS/XMSS-MT sign/verify is not — an
+//! XMSS key handle correctly falls through to `CKR_MECHANISM_INVALID`
+//! rather than mis-signing.
 //!
 //! See [`super`] for the typed-vs-FFI architectural relationship.
 


### PR DESCRIPTION
## Summary

Follow-up audit of the `HONEST_MAXIMUM_PLAN.md` work in v0.12.0: a dedicated pass over the PKCS#11 (`rust/`) and KMIP (`kmip/`) crates looking specifically for stub/placeholder code and silently-dropped errors. Found 13 real gaps, documented and fixed phase by phase in `kmip/docs/GAP_REMEDIATION_PLAN.md`, plus 2 more bugs the fix work itself surfaced along the way (found via re-running the OASIS conformance corpus while verifying later phases).

- **Phase A** — `Destroy` genuinely scrubs key material (zeroize + SQLite `secure_delete`)
- **Phase B** — `SetAttribute`/`ModifyAttribute`/`DeleteAttribute` no longer silently drop attributes; `UsageLimits` guard condition enforced
- **Phase C** — 3 wire-encoding round-trip gaps (attribute-name table, `CryptographicParameters` fields, `SecretDataType`)
- **Phase D** — `Register` RSA public/private key honesty (no discarded engine-import errors; PKCS#8 support)
- **Phase E** — `CreateKeyPair` persists `CryptographicParameters`; rejects false `QuantumSafe` claims
- **Phase F** — `Encrypt`/`Decrypt` pass real AAD/OAEP-hash through for engine-generated keys
- **Phase G** — batch `Undo`/`$IDPlaceholder` now cover `Encapsulate`/`Decapsulate`/`CreateSplitKey`/`JoinSplitKey`
- **Phase H** — `Locate` filters (length/usage-mask/UID), `AlternativeName` type round-trip, SQLite date immutability
- **Phase I** — 9 stale code comments corrected; syslog audit sink now logs+counts dropped events

One regression was caught and fixed **during** this work: verifying Phase H via the full OASIS conformance replay turned up that Phase D's fix had exposed a pre-existing bug (Transparent RSA Public Key registration never worked). Fixed; corpus is back to 97/0/5 (matches documented baseline).

Also included: `CHANGELOG.md` entry, version bump to v0.13.0 (both crates in lockstep), and doc updates (`kmip/docs/CONFORMANCE_REPORT.md`, `README.md`, `CLAUDE.md`) reflecting this work.

## Test plan

- [x] Full `kmip` crate test suite green (584 lib tests + all integration suites)
- [x] Full `rust` crate test suite green (293 lib tests, incl. `classic_mceliece_6688128` under `RUST_MIN_STACK`)
- [x] OASIS mandatory conformance corpus replay: 97 PASS / 0 FAIL / 5 SKIP_DEPRECATED (verified via `conformance/assert_replay_report.py`, not just eyeballed)
- [x] Every phase carries new regression tests (unit + real-engine e2e where the bug required a live PKCS#11 session to reproduce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)