### PR TITLE
CI: mark real Classic McEliece keygen tests #[ignore]

### DIFF
--- a/kmip/tests/frodokem_mceliece_e2e.rs
+++ b/kmip/tests/frodokem_mceliece_e2e.rs
@@ -156,7 +156,12 @@ fn frodokem_1344_shake_round_trip() {
 // only (implementation plan Phase 0.5). Keygen is slow in debug builds
 // (Goppa code generation) — run with --release for a fast pass. ─────────
 
+/// `#[ignore]`: a single mceliece6688128 keygen (Goppa code generation)
+/// takes minutes in an unoptimized debug build — too slow for every CI
+/// run. Run manually with `cargo test --release -- --ignored
+/// classic_mceliece_6688128_round_trip` (release mode is fast).
 #[test]
+#[ignore = "mceliece6688128 keygen is minutes-slow in debug builds — see doc comment"]
 fn classic_mceliece_6688128_round_trip() {
     round_trip(KmipAlgorithm::ClassicMcEliece6688128, 32);
 }

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -11726,7 +11726,12 @@ mod pqc_vendor_kem_ffi_tests {
         );
     }
 
+    /// `#[ignore]`: a single mceliece6688128 keygen (Goppa code generation)
+    /// takes minutes in an unoptimized debug build — too slow for every CI
+    /// run. Run manually with `cargo test --release -- --ignored
+    /// classic_mceliece_6688128_round_trip` (release mode is fast).
     #[test]
+    #[ignore = "mceliece6688128 keygen is minutes-slow in debug builds — see doc comment"]
     fn classic_mceliece_6688128_round_trip() {
         round_trip(
             CKM_PQCTODAY_CLASSIC_MCELIECE_KEY_PAIR_GEN,
@@ -11833,7 +11838,12 @@ mod pqc_vendor_kem_ffi_tests {
     /// S5-equivalent (mirrors `encap_decap_on_aes_key_key_type_inconsistent`
     /// for ML-KEM) — encapsulate/decapsulate on a key of the wrong PQC
     /// vendor KEM family → CKR_KEY_TYPE_INCONSISTENT, not a crypto attempt.
+    ///
+    /// `#[ignore]`: builds a real mceliece6688128 keypair first — minutes-slow
+    /// in an unoptimized debug build. Run manually with `cargo test --release
+    /// -- --ignored encapsulate_on_wrong_key_family` (release mode is fast).
     #[test]
+    #[ignore = "mceliece6688128 keygen is minutes-slow in debug builds — see doc comment"]
     fn encapsulate_on_wrong_key_family_key_type_inconsistent() {
         let _guard = test_lock::acquire();
         setup();
@@ -11882,7 +11892,13 @@ mod pqc_vendor_kem_ffi_tests {
 
     /// §5.18.9-equivalent — a ciphertext of the wrong length for the vendor
     /// KEM's parameter set → CKR_ENCRYPTED_DATA_INVALID.
+    ///
+    /// `#[ignore]`: builds a real mceliece6688128 keypair first — minutes-slow
+    /// in an unoptimized debug build. Run manually with `cargo test --release
+    /// -- --ignored pqc_vendor_kem_ffi_tests::decapsulate_wrong_ciphertext_len`
+    /// (release mode is fast).
     #[test]
+    #[ignore = "mceliece6688128 keygen is minutes-slow in debug builds — see doc comment"]
     fn decapsulate_wrong_ciphertext_len_encrypted_data_invalid() {
         let _guard = test_lock::acquire();
         setup();

--- a/rust/src/native/encrypt.rs
+++ b/rust/src/native/encrypt.rs
@@ -1358,7 +1358,13 @@ mod tests {
     /// `mceliece-spec-20221023.pdf` §6.2 — verified against
     /// `classic-mceliece-rust` v3.1.0, liboqs, and the spec text directly),
     /// ss = 32 bytes.
+    ///
+    /// `#[ignore]`: a single mceliece6688128 keygen (Goppa code generation)
+    /// takes minutes in an unoptimized debug build — too slow for every CI
+    /// run. Run manually with `cargo test --release -- --ignored
+    /// classic_mceliece_6688128_encap_decap` (release mode is fast).
     #[test]
+    #[ignore = "mceliece6688128 keygen is minutes-slow in debug builds — see doc comment"]
     fn classic_mceliece_6688128_encap_decap_round_trip() {
         let _guard = test_lock::acquire();
         let session = fresh_session();

--- a/rust/src/native/keygen.rs
+++ b/rust/src/native/keygen.rs
@@ -2180,7 +2180,13 @@ mod tests {
     /// pick, §2.4.2) — pk = 1,044,992 bytes, sk = 13,932 bytes, verified
     /// directly against `classic-mceliece-rust` v2.0.2's
     /// `CRYPTO_PUBLICKEYBYTES`/`CRYPTO_SECRETKEYBYTES` for this variant.
+    ///
+    /// `#[ignore]`: a single mceliece6688128 keygen (Goppa code generation)
+    /// takes minutes in an unoptimized debug build — too slow for every CI
+    /// run. Run manually with `cargo test --release -- --ignored
+    /// classic_mceliece_6688128_keygen` (release mode is fast).
     #[test]
+    #[ignore = "mceliece6688128 keygen is minutes-slow in debug builds — see doc comment"]
     fn classic_mceliece_6688128_keygen_produces_expected_length() {
         let _guard = test_lock::acquire();
         let session = fresh_session();


### PR DESCRIPTION
## Summary
- Six tests across `rust/` and `kmip/` each build a real `mceliece6688128` keypair (Goppa code generation) — minutes-slow in an unoptimized debug build, and the dominant cost in every "Rust Tests" CI run.
- The two most expensive (20-trial cross-validation against liboqs) were already `#[ignore]`d; this adds `#[ignore]` to the remaining single-keygen tests, consistent with that existing convention.
- No coverage lost — every ignored test still exists, is documented with a doc comment explaining why, and can be run manually via `cargo test --release -- --ignored <name>` (release mode is fast).

Tests ignored:
- `rust/src/native/keygen.rs::classic_mceliece_6688128_keygen_produces_expected_length`
- `rust/src/native/encrypt.rs::classic_mceliece_6688128_encap_decap_round_trip`
- `rust/src/ffi.rs::pqc_vendor_kem_ffi_tests::classic_mceliece_6688128_round_trip`
- `rust/src/ffi.rs::pqc_vendor_kem_ffi_tests::encapsulate_on_wrong_key_family_key_type_inconsistent`
- `rust/src/ffi.rs::pqc_vendor_kem_ffi_tests::decapsulate_wrong_ciphertext_len_encrypted_data_invalid`
- `kmip/tests/frodokem_mceliece_e2e.rs::classic_mceliece_6688128_round_trip`

## Test plan
- [x] `cd rust && RUST_MIN_STACK=134217728 cargo test` — 288 passed, 0 failed, 9 ignored, finished in 170s (down from 611s)
- [x] `cd kmip && RUST_MIN_STACK=134217728 cargo test --quiet` — 584 passed, 0 failed, finished in ~2 min total
- [x] Individually timed each newly-ignored test before ignoring it to confirm it was genuinely the slow one (83s–125s each)
- [x] CI will run all workflow gates on this PR