### PR TITLE
wasm: fix build against current core types, expose RngSeedMode, doc the honest-maximum additions

### DIFF
--- a/kmip/docs/CACP_GUIDE.md
+++ b/kmip/docs/CACP_GUIDE.md
@@ -294,7 +294,45 @@ Sources: [KMIP 3.0 CSD01](https://docs.oasis-open.org/kmip/kmip-spec/v3.0/csd01/
 [KMIP 2.1 OS announcement](https://www.oasis-open.org/2020/12/18/key-management-interoperability-protocol-specification-and-key-management-interoperability-protocol-profiles-oasis-standards-published/) ·
 vendored `kmip-spec-v3.0-wd19-clean.pdf` (Table 552) + `kmip-spec-v3.0.html`.
 
-## 5. FAQ / pitfalls
+## 5. Engine 0.12/0.13 — the "honest maximum" additions (verified 2026-07-09)
+
+Two engine releases closed the gap between what the server *advertises* and
+what it *does*. Everything below is real in the in-browser playground too,
+and each has a hands-on surface:
+
+- **Split keys (§6.1.12 / §6.1.31).** `Create Split Key` divides a key into
+  N share objects where any M (the threshold) reconstruct it via
+  `Join Split Key`; below-threshold joins are refused with the shortfall
+  named. All four §11.54 methods are implemented (XOR requires N == M;
+  the three polynomial methods are true Shamir M-of-N). Try it: Learn
+  walkthrough 7, or the Commands tab's Object Lifecycle category.
+- **Asynchronous processing (§8.1.2, §6.1.43/5/44/46).** A request carrying
+  `Asynchronous Indicator = Mandatory` is enqueued as a real job — the
+  response is `OperationPending` + a correlation value; `Poll` returns the
+  identical payload the synchronous op would have; `Cancel` handles its
+  race honestly; `Query Asynchronous Requests` lists what's in flight. Try
+  it: Learn walkthrough 8, or the Commands tab's Asynchronous Processing
+  category (enqueue via Hash's "Run asynchronously" toggle).
+- **Honest Query.** The advertised-operations list is audited down to
+  what genuinely runs: 62 of the 66 KMIP 3.0 operations. The four that
+  don't (Notify/Put — server-to-client scope boundary; DelegatedLogin/
+  Re-Provision — no handler) are no longer advertised at all.
+- **13 honesty fixes (0.13.0).** Destroy zeroizes material and securely
+  deletes it from storage; Set/Modify/Delete/AdjustAttribute never again
+  answer Success while persisting nothing (read-only sets are refused);
+  Locate really filters by length/usage-mask/UID; batch `Undo` and
+  `$IDPlaceholder` now cover the UID-minting Encapsulate/Decapsulate/
+  split-key ops; Register refuses malformed keys at registration; a
+  granted usage allocation can't be silently re-budgeted (§4.69). Try it:
+  Learn walkthrough 9, and the Batch tab's "Rollback reaches Encapsulate"
+  recipe.
+- **Conformance baseline.** The native CI gate pins an exact 97 PASS /
+  5 deprecated-skip on the 102 OASIS tests. The playground's Corpus Replay
+  matches it except six honestly-labelled wasm-seam skips (three need the
+  native TLS listener's MaximumResponseSize enforcement; three need the
+  per-test RNG-seed mode the wasm binding doesn't expose).
+
+## 6. FAQ / pitfalls
 
 - **"The policy allows the algorithm but the workbench says Deny."** Check
   the deny *reason* first (rule index + reason string are shown). Most

--- a/scripts/build-kmip-wasm.sh
+++ b/scripts/build-kmip-wasm.sh
@@ -59,7 +59,10 @@ else
     docker exec "$RUST_CONTAINER" rustup target add wasm32-unknown-unknown
     docker exec "$RUST_CONTAINER" sh -c "command -v wasm-bindgen >/dev/null 2>&1 || cargo install wasm-bindgen-cli --version $WASM_BINDGEN_VERSION"
   fi
-  run() { docker exec -e RUSTFLAGS="$RUSTFLAGS" "$RUST_CONTAINER" sh -c "cd /ag/pqctoday-hsm/wasm && $*"; }
+  # The container mounts the parent of $ROOT at /ag, so derive the repo dir
+  # from $ROOT instead of hardcoding it — a `git worktree` checkout (e.g.
+  # pqctoday-hsm-kmip-honest-maximum) builds ITS OWN tree, not the main one.
+  run() { docker exec -e RUSTFLAGS="$RUSTFLAGS" "$RUST_CONTAINER" sh -c "cd /ag/$(basename "$ROOT")/wasm && $*"; }
   CARGO_TARGET_ROOT="/cargo-target"
 fi
 
@@ -103,7 +106,42 @@ cp "$ROOT"/kmip/policies/*.yaml "$HUB_POLICY_DIR/"
 # version matching the staged policies/engine.
 cp "$ROOT"/kmip/docs/CACP_GUIDE.md "$HUB_POLICY_DIR/"
 
+# ── 5. Stage the conformance corpus (Corpus Replay tab) ─────────────────────
+# The OASIS + PQC-interop XML fixtures the playground replays live in-browser,
+# plus the manifest.json the tab's loader fetches first. Re-staged on every
+# build so the browser replay can never drift from the engine's own corpus.
+HUB_CORPUS_DIR="$HUB/public/kmip-corpus"
+CONF="$ROOT/kmip/conformance"
+echo "[kmip-wasm] staging conformance corpus into $HUB_CORPUS_DIR"
+mkdir -p "$HUB_CORPUS_DIR/oasis/mandatory" "$HUB_CORPUS_DIR/oasis/optional" "$HUB_CORPUS_DIR/pqc"
+cp "$CONF"/oasis_corpus/mandatory/*.xml "$HUB_CORPUS_DIR/oasis/mandatory/"
+cp "$CONF"/oasis_corpus/optional/*.xml  "$HUB_CORPUS_DIR/oasis/optional/"
+cp "$CONF"/pqc_corpus/*.xml             "$HUB_CORPUS_DIR/pqc/"
+python3 - "$HUB_CORPUS_DIR" <<'PY'
+import json, os, sys
+root = sys.argv[1]
+tests = []
+def add(rel_dir, tier, category):
+    d = os.path.join(root, rel_dir)
+    for name in sorted(os.listdir(d)):
+        if not name.endswith('.xml'):
+            continue
+        # e.g. "CS-AC-M-1-30.xml" → "CS-AC" (profile prefix before -M-/-O-)
+        cat = category or name.split('-M-')[0].split('-O-')[0]
+        tests.append({'file': f'{rel_dir}/{name}', 'tier': tier, 'category': cat, 'name': name})
+add('oasis/mandatory', 'mandatory', None)
+add('oasis/optional', 'optional', None)
+add('pqc', 'pqc', 'PQC Interop')
+manifest = {'generated_by': 'scripts/build-kmip-wasm.sh (corpus staging step)',
+            'count': len(tests), 'tests': tests}
+with open(os.path.join(root, 'manifest.json'), 'w') as f:
+    json.dump(manifest, f, indent=2)
+    f.write('\n')
+print(f"[kmip-wasm]   manifest.json: {len(tests)} corpus tests")
+PY
+
 echo ""
 echo "[kmip-wasm] done."
 echo "  hub shim:   $HUB_SHIM_DIR/pqctoday_kmip_wasm.js"
 echo "  hub binary: $HUB_WASM_DIR/pqctoday_kmip_wasm_bg.wasm"
+echo "  hub corpus: $HUB_CORPUS_DIR/manifest.json"

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "pqctoday-kmip"
-version = "0.8.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1346,6 +1346,7 @@ dependencies = [
  "uuid",
  "x509-cert",
  "x509-parser",
+ "zeroize",
 ]
 
 [[package]]
@@ -1704,7 +1705,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "softhsmrustv3"
-version = "0.8.0"
+version = "0.13.1"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -1730,6 +1731,7 @@ dependencies = [
  "k256",
  "lazy_static",
  "ml-kem",
+ "num-bigint",
  "p256",
  "p384",
  "p521",

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -36,6 +36,7 @@ use pqctoday_kmip::dispatcher::{dispatch, one_off_request};
 use pqctoday_kmip::kmip30::{
     decode_request_message, encode_request_message, encode_response_message, ActivateRequest,
     Attribute, BatchErrorContinuationOption, CreateKeyPairRequest, CreateRequest,
+    CustomAttributeValue,
     DecapsulateRequest, DecryptRequest, DestroyRequest, EncapsulateRequest, EncryptRequest,
     GetRequest, KmipAlgorithm, LocateRequest, ObjectType, QueryFunction, QueryRequest,
     ReKeyKeyPairRequest, ReKeyRequest, RequestBatchItem, RequestHeader, RequestMessage,
@@ -43,7 +44,7 @@ use pqctoday_kmip::kmip30::{
     ResultStatus, RevocationReason, RevokeRequest, SignRequest, SignatureVerifyRequest, UsageMask,
     WireError,
 };
-use pqctoday_kmip::ops::{Deps, DepsConfig};
+use pqctoday_kmip::ops::{Deps, DepsConfig, RngSeedMode};
 use pqctoday_kmip::policy::Engine;
 use pqctoday_kmip::store::MemoryStore;
 
@@ -89,13 +90,32 @@ impl KmipPlayground {
     /// (its own doc comment) that brings a new slot online before
     /// `C_InitToken` will accept it; skipping this for a non-zero slot
     /// fails with `CKR_SLOT_ID_INVALID` (confirmed empirically).
+    /// `rng_seed_mode` — the server's §6.1.55 RNG Seed policy choice
+    /// (`RngSeedMode`): `"full-consume"` (default) / `"partial-consume"` /
+    /// `"ignore"` / `"deny"`. Server-chosen and mutually exclusive per the
+    /// spec, so it's a CONSTRUCTOR parameter, not per-request — exposed so
+    /// the in-browser OASIS corpus replay can boot each CS-RNG-O variant
+    /// test on an engine pinned to that test's mode, exactly as the native
+    /// harness constructs per-test `Deps`.
     #[wasm_bindgen(constructor)]
-    pub fn new(slot: Option<u32>) -> Result<KmipPlayground, JsError> {
+    pub fn new(slot: Option<u32>, rng_seed_mode: Option<String>) -> Result<KmipPlayground, JsError> {
         console_error_panic_hook::set_once();
         let slot = slot.unwrap_or(0);
         if slot != 0 {
             softhsmrustv3::state::ensure_slot(slot);
         }
+
+        let rng_seed_mode = match rng_seed_mode.as_deref() {
+            None | Some("full-consume") => RngSeedMode::FullConsume,
+            Some("partial-consume") => RngSeedMode::PartialConsume,
+            Some("ignore") => RngSeedMode::Ignore,
+            Some("deny") => RngSeedMode::Deny,
+            Some(other) => {
+                return Err(JsError::new(&format!(
+                    "unknown rng_seed_mode '{other}' — expected full-consume | partial-consume | ignore | deny"
+                )))
+            }
+        };
 
         // Plane 3 — bootstrap the engine token + user session (real crypto).
         let session = softhsmrustv3::native::session::bootstrap_default_token(
@@ -120,8 +140,8 @@ impl KmipPlayground {
 
         // Plane 2 — volatile object store.
         let store = Arc::new(MemoryStore::new());
-        let deps = Deps::new(engine, store, sink, DepsConfig::default())
-            .with_engine_session(session);
+        let config = DepsConfig { rng_seed_mode, ..DepsConfig::default() };
+        let deps = Deps::new(engine, store, sink, config).with_engine_session(session);
 
         Ok(KmipPlayground { deps, ring })
     }
@@ -667,7 +687,7 @@ fn custom_attrs_from_spec(spec: &Json) -> Vec<Attribute> {
             o.iter()
                 .map(|(k, v)| Attribute::Custom {
                     name: k.strip_prefix("x-").unwrap_or(k).to_string(),
-                    value: v.as_str().unwrap_or_default().to_string(),
+                    value: CustomAttributeValue::Text(v.as_str().unwrap_or_default().to_string()),
                 })
                 .collect()
         })
@@ -1079,6 +1099,7 @@ fn wire_error_response(err: &WireError) -> ResponseMessage {
             result_status: ResultStatus::OperationFailed,
             result_reason: Some(reason as u32),
             result_message: Some(format!("KMIP wire decode failed: {err}")),
+            asynchronous_correlation_value: None,
             payload: None,
         }],
     }


### PR DESCRIPTION
## Summary
- The `wasm/` crate (the in-browser KMIP engine the hub playground vendors) wasn't covered by this repo's own CI, so it silently drifted out of sync with core-type changes in 0.13.0 — this fixes the compile break (`ResponseBatchItem.asynchronous_correlation_value`, `Attribute::Custom`'s value now `CustomAttributeValue`).
- Exposes the server's §6.1.55 RNG Seed behavior (`RngSeedMode`) as a `KmipPlayground` constructor parameter, so an in-browser OASIS conformance replay can boot each CS-RNG-O test variant on an engine pinned to the mode it expects — same approach the native harness uses per-test.
- `build-kmip-wasm.sh`: derives the container path from `$ROOT` so it works from a git worktree, and restores the corpus-staging step that copies OASIS/PQC fixtures + regenerates `manifest.json` into the hub — this step existed at some point but was lost; regenerates the current manifest byte-identically, confirming no drift.
- `CACP_GUIDE.md` gains a §5 documenting the 0.12/0.13 "honest maximum" additions (split keys, async processing, honest Query, the 13 honesty fixes) with pointers into the hub playground's Learn walkthroughs and Commands categories.

## Test plan
- [x] `cargo build --release --target wasm32-unknown-unknown` succeeds
- [x] `cargo test --release` (wasm crate) — 2/2 pass (TTLV corpus round-trip fixtures)
- [x] `wasm/smoke/smoke.cjs` — full KMIP+PKCS#11 round trip in Node, PASS
- [x] Manifest regeneration via the restored corpus-staging step is byte-identical to the currently-checked-in `manifest.json` in the hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)