### PR TITLE
fix(kmip-wasm): gate the wasm32 certificate-projection call site correctly

### DIFF
--- a/kmip/src/ops/cert_projection.rs
+++ b/kmip/src/ops/cert_projection.rs
@@ -1,0 +1,79 @@
+//! PKCS#11 v3.2 §4.6 — mirror a KMIP-managed certificate onto the engine as a
+//! `CKO_CERTIFICATE` object, so a raw PKCS#11 client (strongSwan, the OpenSSL
+//! provider) can find what KMIP issued/registered/imported.
+//!
+//! Split out of `certify.rs` (2026-07) — that module is `#[cfg(feature =
+//! "native")]`-gated because its actual Certify/Re-certify issuance logic
+//! depends on rcgen/aws_lc_rs, which don't cross-compile to wasm32. This one
+//! function doesn't: it only touches `der_x509` (pure Rust, x509-parser) and
+//! `softhsmrustv3::native`, both wasm32-safe, but `register_import_export.rs`
+//! (Register/Import — ordinary KMIP ops, very much needed in the wasm build)
+//! called it unconditionally, which made the wasm32 build fail to compile the
+//! moment certificate support existed at all. Living in its own always-compiled
+//! module lets `certify.rs` stay native-only while Register/Import work in
+//! every build.
+
+use super::deps::Deps;
+
+/// KMIP remains authoritative for the certificate's lifecycle; this is a
+/// best-effort projection — a failure here doesn't fail the KMIP operation
+/// (same posture as the `CKA_ALLOWED_MECHANISMS` auto-restrict), since the
+/// certificate is already correctly and durably stored in the KMIP record
+/// either way. No engine session (e.g. crate unit tests) is a silent,
+/// unaudited no-op — the common, expected case, not worth an audit event.
+///
+/// An engine session present but no Subject extracted
+/// (`der_x509::extract_subject_der` returning empty) emits a
+/// `Pkcs11Call`-shaped audit event instead of silently vanishing, so an
+/// operator can tell this specific certificate's PKCS#11-side mirror never
+/// materialized. In practice this only happens for genuinely unparseable
+/// DER — a certificate that parses at all always yields a non-empty raw
+/// Subject encoding (even an empty RDNSequence DER-encodes to a 2-byte
+/// `30 00`, never zero bytes), so `register()`'s own parseability guard
+/// means ordinary client-supplied DER can no longer reach this branch at
+/// all; it remains a safety net for the server-generated paths
+/// (`bootstrap_ca_certificate`, `Certify`, `Re-certify`), where hitting it
+/// would indicate a real bug upstream.
+pub(crate) fn project_certificate_to_engine(
+    deps: &Deps,
+    correlation_id: &str,
+    op: &str,
+    uid: &str,
+    cert_der: &[u8],
+    cka_id: &[u8],
+    category: u32,
+) {
+    let Some(session) = deps.engine_session else {
+        return;
+    };
+    let subject = super::der_x509::extract_subject_der(cert_der).unwrap_or_default();
+    if subject.is_empty() {
+        // No Subject extracted — nothing sane to project; KMIP's own copy
+        // is still correct and unaffected. Worth flagging (unlike the "no
+        // engine session" case above): in practice this means the DER
+        // didn't parse at all (see this function's doc comment) — an
+        // operator should be able to tell this certificate's engine
+        // mirror silently never appeared.
+        super::helpers::emit_pkcs11(
+            deps,
+            correlation_id,
+            &format!("cert_projection::project_certificate_to_engine({op})"),
+            None,
+            0xFFFF_FFFF,
+            &format!("skipped: no Subject extracted from {}-byte DER for {uid:?}", cert_der.len()),
+        );
+        return;
+    }
+    let issuer = super::der_x509::extract_issuer_der(cert_der).unwrap_or_default();
+    let serial = super::der_x509::extract_serial_number(cert_der).unwrap_or_default();
+    let r = softhsmrustv3::native::register_certificate(
+        session, cert_der, &subject, &issuer, &serial, category, cka_id, "kmip-cert",
+    );
+    super::helpers::emit_pkcs11_result(
+        deps,
+        correlation_id,
+        &format!("native::register_certificate({op})"),
+        None,
+        &r,
+    );
+}

--- a/kmip/src/ops/certify.rs
+++ b/kmip/src/ops/certify.rs
@@ -1012,61 +1012,9 @@ fn store_certificate(
 /// either way. No engine session (e.g. crate unit tests) is a silent,
 /// unaudited no-op — the common, expected case, not worth an audit event.
 ///
-/// WP-7 remediation: an engine session present but no Subject extracted
-/// (`der_x509::extract_subject_der` returning empty) now emits a
-/// `Pkcs11Call`-shaped audit event instead of silently vanishing, so an
-/// operator can tell this specific certificate's PKCS#11-side mirror
-/// never materialized. In practice this only happens for genuinely
-/// unparseable DER — a certificate that parses at all always yields a
-/// non-empty raw Subject encoding (even an empty RDNSequence DER-encodes
-/// to a 2-byte `30 00`, never zero bytes), so `register()`'s own
-/// parseability guard means ordinary client-supplied DER can no longer
-/// reach this branch at all; it remains a safety net for the
-/// server-generated paths (`bootstrap_ca_certificate`, `Certify`,
-/// `Re-certify`), where hitting it would indicate a real bug upstream.
-pub(crate) fn project_certificate_to_engine(
-    deps: &Deps,
-    correlation_id: &str,
-    op: &str,
-    uid: &str,
-    cert_der: &[u8],
-    cka_id: &[u8],
-    category: u32,
-) {
-    let Some(session) = deps.engine_session else {
-        return;
-    };
-    let subject = super::der_x509::extract_subject_der(cert_der).unwrap_or_default();
-    if subject.is_empty() {
-        // No Subject extracted — nothing sane to project; KMIP's own copy
-        // is still correct and unaffected. Worth flagging (unlike the "no
-        // engine session" case above): in practice this means the DER
-        // didn't parse at all (see this function's doc comment) — an
-        // operator should be able to tell this certificate's engine
-        // mirror silently never appeared.
-        super::helpers::emit_pkcs11(
-            deps,
-            correlation_id,
-            &format!("certify::project_certificate_to_engine({op})"),
-            None,
-            0xFFFF_FFFF,
-            &format!("skipped: no Subject extracted from {}-byte DER for {uid:?}", cert_der.len()),
-        );
-        return;
-    }
-    let issuer = super::der_x509::extract_issuer_der(cert_der).unwrap_or_default();
-    let serial = super::der_x509::extract_serial_number(cert_der).unwrap_or_default();
-    let r = softhsmrustv3::native::register_certificate(
-        session, cert_der, &subject, &issuer, &serial, category, cka_id, "kmip-cert",
-    );
-    super::helpers::emit_pkcs11_result(
-        deps,
-        correlation_id,
-        &format!("native::register_certificate({op})"),
-        None,
-        &r,
-    );
-}
+/// Moved to `cert_projection.rs` (2026-07) — this module is native-only, but
+/// `register_import_export.rs` also needs to call this from a wasm32 build.
+pub(crate) use super::cert_projection::project_certificate_to_engine;
 
 // ── Audit helpers (mirror ops::sign) ─────────────────────────────────────────
 

--- a/kmip/src/ops/mod.rs
+++ b/kmip/src/ops/mod.rs
@@ -46,6 +46,7 @@ pub mod agility;
 pub mod allocation_and_config;
 pub mod async_ops;
 pub mod attribute_mutate;
+pub mod cert_projection;
 pub mod create;
 pub mod create_key_pair;
 pub mod decapsulate;

--- a/kmip/src/ops/register_import_export.rs
+++ b/kmip/src/ops/register_import_export.rs
@@ -632,7 +632,7 @@ pub fn register(
     // AUTHORITY is reserved for the CA bootstrap path.
     if req.object_type == ObjectType::Certificate {
         if let Some(der) = certificate_value.as_deref() {
-            super::certify::project_certificate_to_engine(
+            super::cert_projection::project_certificate_to_engine(
                 deps,
                 correlation_id,
                 "Register",
@@ -796,7 +796,7 @@ pub fn import_object(
     // this is best-effort and KMIP-authoritative).
     if req.object_type == ObjectType::Certificate {
         if let Some(der) = certificate_value.as_deref() {
-            super::certify::project_certificate_to_engine(
+            super::cert_projection::project_certificate_to_engine(
                 deps,
                 correlation_id,
                 "Import",
@@ -1233,7 +1233,7 @@ mod tests {
         let d = Deps::new(engine, Arc::new(MemoryStore::new()), sink, super::super::deps::DepsConfig::default())
             .with_engine_session(sess);
 
-        super::super::certify::project_certificate_to_engine(
+        super::super::cert_projection::project_certificate_to_engine(
             &d,
             "c-skip-audit",
             "TestOp",


### PR DESCRIPTION
## Summary
- Register/Import's certificate-projection call site (`register_import_export.rs`) called unconditionally into `certify::project_certificate_to_engine`, but the `certify` module is `#[cfg(feature = "native")]`-gated — its CSR/rcgen issuance logic doesn't cross-compile to wasm32. This silently broke any wasm32 build of the kmip crate since certificate support was added; nobody had attempted one until today's hub wasm-bundle refresh.
- Extracted the wasm-safe projection helper (depends only on `der_x509`/`helpers`/`softhsmrustv3::native`, no rcgen/aws_lc_rs) into a new always-compiled `kmip/src/ops/cert_projection.rs` module. `certify.rs` re-exports it via `pub(crate) use`, so its own native call sites (`bootstrap_ca_certificate`, `store_certificate`) are unaffected.
- Certify/Re-certify themselves remain native-only and correctly answer `OperationNotSupported` in wasm — this fix only unblocks the wasm32 *compile*, it does not add new wasm capability to those two ops.

## Test plan
- [x] Native `cargo build --tests` + `cargo test` — full kmip suite green, including the 3 existing certificate-projection tests (`register_certificate_projects_engine_object`, `register_certificate_rejects_unparseable_der`, `project_certificate_to_engine_skip_is_audited`).
- [x] `scripts/build-kmip-wasm.sh` wasm32 build succeeds (previously failed with `error[E0433]: cannot find 'certify' in 'super'`).
- [x] In-wasm smoke test passes: Query, Create, CreateKeyPair/Sign/Verify (ML-DSA-65), hybrid KEM (X25519MLKEM768) encapsulate/decapsulate.
- [x] Consumed downstream in pqctoday-hub's wasm bundle refresh (companion PR) — `tsc -b` clean, full hub unit suite + 8 named e2e specs green against the rebuilt bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)