### PR TITLE
feat(kmip): Register(Certificate) shares its linked key's CKA_ID; wasm exports for a WP-3 showcase

### DIFF
--- a/kmip/src/ops/register_import_export.rs
+++ b/kmip/src/ops/register_import_export.rs
@@ -184,7 +184,34 @@ pub fn register(
     let now = OffsetDateTime::now_utc();
     // Stable CKA_ID for this object so the KMIP layer can locate the
     // engine handle later via `find_by_cka_id` (Sign/Decrypt path).
-    let cka_id_bytes = Uuid::new_v4().as_bytes().to_vec();
+    //
+    // PKCS#11 v3.2 §4.6 (the strongSwan cert-to-key matching pattern) —
+    // when Registering a Certificate linked to an existing PublicKey via
+    // `PublicKeyLink`, reuse THAT key's own CKA_ID instead of minting a
+    // fresh one, exactly like the native Certify path (`store_certificate`)
+    // already does. Without this, a Register'd certificate's engine
+    // projection never shares a CKA_ID with its linked key, and a raw
+    // PKCS#11 client has no way to match the two — silently defeating the
+    // whole point of projecting the certificate onto the engine at all.
+    // Only affects Certificate registrations that supply the link; every
+    // other Register (symmetric/asymmetric keys, link-less certificates)
+    // is unchanged.
+    let linked_public_key_cka_id = (req.object_type == ObjectType::Certificate)
+        .then(|| {
+            req.attributes.iter().find_map(|a| match a {
+                Attribute::PublicKeyLink(pk_uid) => deps
+                    .store
+                    .get(pk_uid)
+                    .ok()
+                    .flatten()
+                    .map(|r| r.pkcs11_cka_id)
+                    .filter(|id| !id.is_empty()),
+                _ => None,
+            })
+        })
+        .flatten();
+    let cka_id_bytes =
+        linked_public_key_cka_id.unwrap_or_else(|| Uuid::new_v4().as_bytes().to_vec());
     let key_format_type = key_block.map(|kb| kb.key_format_type as u32);
     let key_material = key_block.map(|kb| kb.key_value.clone());
 
@@ -1180,6 +1207,88 @@ mod tests {
             softhsmrustv3::native::get_attribute_u32(sess, handle, c::CKA_CERTIFICATE_CATEGORY),
             Some(c::CK_CERTIFICATE_CATEGORY_TOKEN_USER),
             "Register has no CA-designation signal — always TOKEN_USER"
+        );
+
+        let _ = session::finalize();
+    }
+
+    /// WP-3 remediation (2026-07-11) — Register(Certificate) with a
+    /// `PublicKeyLink` must reuse THAT key's own CKA_ID, exactly like the
+    /// native Certify path (`certify::store_certificate`) already does,
+    /// so a raw PKCS#11 client can match the projected certificate to its
+    /// key by CKA_ID (the strongSwan pattern). Before this fix, Register
+    /// always minted a fresh CKA_ID regardless of any link supplied,
+    /// silently defeating that matching even though the certificate WAS
+    /// projected onto the engine.
+    #[test]
+    fn register_certificate_with_public_key_link_shares_its_cka_id() {
+        use softhsmrustv3::constants as c;
+        use softhsmrustv3::native::{self, session, EccCurve};
+        let _lock = crate::engine_test_lock::acquire();
+        let _ = session::finalize();
+        session::init().expect("engine init");
+        let sess = session::bootstrap_default_token(0, "so-pin", "user-pin", "register-cert-link-test")
+            .expect("bootstrap session");
+
+        // A leaf key pair, stored as a KMIP PublicKey record with its own
+        // engine CKA_ID — mirrors certify.rs's
+        // `recertify_replaces_engine_object_sharing_linked_public_key_cka_id`
+        // fixture, since this is the Register-side counterpart of that fix.
+        let leaf_cka_id = b"register-leaf-key-id".to_vec();
+        let (leaf_pub_h, _leaf_prv_h) =
+            native::generate_ecdsa_keypair(sess, EccCurve::P256, &leaf_cka_id, "leaf-ec")
+                .expect("leaf keygen");
+        let leaf_spki = native::get_attribute(sess, leaf_pub_h, c::CKA_PUBLIC_KEY_INFO)
+            .expect("leaf public key SPKI");
+
+        let d = deps_with().with_engine_session(sess);
+        d.store
+            .put(ObjectRecord {
+                uid: "urn:leaf-pub".into(),
+                object_type: ObjectType::PublicKey,
+                algorithm: KmipAlgorithm::Ecdsa,
+                usage_mask: UsageMask::VERIFY,
+                state: State::Active,
+                pkcs11_cka_id: leaf_cka_id.clone(),
+                key_material: Some(leaf_spki),
+                ..ObjectRecord::default()
+            })
+            .unwrap();
+
+        let cert = rcgen::generate_simple_self_signed(vec!["wp-3.example.test".to_string()])
+            .expect("rcgen self-signed cert");
+        let der = cert.cert.der().to_vec();
+
+        let resp = register(
+            &d,
+            RegisterRequest {
+                object_type: ObjectType::Certificate,
+                attributes: vec![
+                    Attribute::Name("wp-3-register-cert-linked".into()),
+                    Attribute::PublicKeyLink("urn:leaf-pub".into()),
+                ],
+                managed_object: None,
+                protection_storage_masks: None,
+                certificate_payload: Some((0, der.clone())),
+                secret_data_type: None,
+            },
+            "c-wp3-register-linked",
+        )
+        .unwrap();
+
+        let rec = d.store.get(&resp.uid).unwrap().unwrap();
+        assert_eq!(
+            rec.pkcs11_cka_id, leaf_cka_id,
+            "the registered certificate must reuse the linked public key's CKA_ID, not a fresh one"
+        );
+
+        let handle = crate::ops::helpers::find_handle_for_object(sess, &leaf_cka_id, ObjectType::Certificate)
+            .unwrap()
+            .expect("the certificate must be projected onto the engine AT THE SHARED CKA_ID");
+        assert_eq!(
+            native::get_attribute(sess, handle, c::CKA_VALUE).unwrap(),
+            der,
+            "engine CKA_VALUE at the shared CKA_ID must byte-equal the registered Certificate Value"
         );
 
         let _ = session::finalize();

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -634,6 +634,107 @@ impl KmipPlayground {
         };
         serde_json::to_string(&value).unwrap_or_else(|_| "{}".into())
     }
+
+    /// WP-3 showcase — register a caller-supplied X.509 certificate (DER,
+    /// hex-encoded) linked to an existing KMIP public key, and project it
+    /// onto the engine as a real `CKO_CERTIFICATE` object sharing that
+    /// key's `CKA_ID` (the strongSwan cert-to-key matching pattern).
+    /// Native CA issuance (`Certify`) isn't reachable in wasm (its
+    /// rcgen/aws_lc_rs backend doesn't cross-compile to wasm32 — see this
+    /// crate's doc comment), so this exercises `Register`'s
+    /// wasm-reachable certificate projection instead, on a certificate
+    /// the caller already holds — exactly how a raw PKCS#11 client like
+    /// strongSwan would present one, not a full in-browser CA workflow.
+    #[wasm_bindgen]
+    pub fn register_certificate_demo(&self, linked_public_key_uid: &str, cert_der_hex: &str) -> String {
+        let outcome = (|| -> std::result::Result<Json, String> {
+            let der = hex_decode(cert_der_hex)?;
+            let req = pqctoday_kmip::kmip30::RegisterRequest {
+                object_type: ObjectType::Certificate,
+                attributes: vec![
+                    Attribute::Name("wp3-demo-certificate".into()),
+                    Attribute::PublicKeyLink(linked_public_key_uid.into()),
+                ],
+                managed_object: None,
+                protection_storage_masks: None,
+                certificate_payload: Some((0, der)),
+                secret_data_type: None,
+            };
+            pqctoday_kmip::ops::register_import_export::register(&self.deps, req, "wp3-register-cert-demo")
+                .map(|resp| json!({ "ok": true, "uid": resp.uid }))
+                .map_err(|e| format!("{e:?}"))
+        })();
+        let value = match outcome {
+            Ok(v) => v,
+            Err(e) => json!({ "ok": false, "error": e }),
+        };
+        serde_json::to_string(&value).unwrap_or_else(|_| "{}".into())
+    }
+
+    /// WP-3 showcase — read back a Certificate object's REAL engine-side
+    /// PKCS#11 attributes (not the KMIP store record) by its KMIP uid:
+    /// `CKA_ID`, `CKA_VALUE` length, `CKA_SUBJECT`/`CKA_ISSUER` DER
+    /// lengths, `CKA_SERIAL_NUMBER`, and a human-readable Subject CN
+    /// (re-derived from `CKA_VALUE` — the same DER the engine actually
+    /// holds, not the request that created it).
+    #[wasm_bindgen]
+    pub fn engine_certificate_attributes(&self, certificate_uid: &str) -> String {
+        let outcome = (|| -> std::result::Result<Json, String> {
+            let session = self
+                .deps
+                .engine_session
+                .ok_or_else(|| "no engine session".to_string())?;
+            let rec = self
+                .deps
+                .store
+                .get(certificate_uid)
+                .map_err(|e| format!("store error: {e:?}"))?
+                .ok_or_else(|| "object not found".to_string())?;
+            let handle = pqctoday_kmip::ops::helpers::find_handle_for_object(
+                session,
+                &rec.pkcs11_cka_id,
+                ObjectType::Certificate,
+            )
+            .map_err(|rv| format!("engine lookup failed, rv=0x{rv:08x}"))?
+            .ok_or_else(|| "no engine object at this certificate's CKA_ID".to_string())?;
+
+            let ck_value = softhsmrustv3::native::get_attribute(session, handle, softhsmrustv3::constants::CKA_VALUE);
+            let ck_subject = softhsmrustv3::native::get_attribute(session, handle, softhsmrustv3::constants::CKA_SUBJECT);
+            let ck_issuer = softhsmrustv3::native::get_attribute(session, handle, softhsmrustv3::constants::CKA_ISSUER);
+            let ck_serial = softhsmrustv3::native::get_attribute(session, handle, softhsmrustv3::constants::CKA_SERIAL_NUMBER);
+            let subject_cn = ck_value
+                .as_deref()
+                .and_then(pqctoday_kmip::ops::der_x509::extract_subject_cn);
+
+            Ok(json!({
+                "ckaId": hex_encode(&rec.pkcs11_cka_id),
+                "ckaValueLen": ck_value.as_ref().map(|v| v.len()),
+                "ckaSubjectDerLen": ck_subject.as_ref().map(|v| v.len()),
+                "ckaIssuerDerLen": ck_issuer.as_ref().map(|v| v.len()),
+                "ckaSerialNumberHex": ck_serial.as_ref().map(|v| hex_encode(v)),
+                "subjectCn": subject_cn,
+            }))
+        })();
+        let value = match outcome {
+            Ok(v) => v,
+            Err(e) => json!({ "error": e }),
+        };
+        serde_json::to_string(&value).unwrap_or_else(|_| "{}".into())
+    }
+}
+
+fn hex_decode(s: &str) -> std::result::Result<Vec<u8>, String> {
+    if s.len() % 2 != 0 {
+        return Err("odd-length hex string".to_string());
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).map_err(|e| e.to_string()))
+        .collect()
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 /// Decode any KMIP TTLV frame (request or response wire bytes) to a JSON tree


### PR DESCRIPTION
## Summary
- **Real fix**: `Register(Certificate)` with a `PublicKeyLink` always minted a fresh CKA_ID for the certificate's engine projection, ignoring the link. The native `Certify` path (`store_certificate`) already reuses the linked key's own CKA_ID so a raw PKCS#11 client can match cert-to-key by CKA_ID (the strongSwan pattern) — but `Certify` is native-only (unreachable in wasm), so `Register` was the only wasm-reachable path that could carry this pattern into the browser, and it silently didn't.
- Fixed: `Register(Certificate)` now reuses a linked `PublicKey`'s CKA_ID when a `PublicKeyLink` attribute is supplied, falling back to a fresh CKA_ID otherwise. All non-Certificate Registers, and link-less certificate Registers, are unaffected.
- Adds two wasm exports feeding the hub-side WP-3 showcase (companion PR): `register_certificate_demo` (register a caller-supplied cert DER linked to an existing public key) and `engine_certificate_attributes` (read back the real engine-side PKCS#11 attributes of a projected certificate object).

## Test plan
- [x] New native test `register_certificate_with_public_key_link_shares_its_cka_id`, mirroring `certify.rs`'s own CKA_ID-collision fixture.
- [x] Full `cargo test -p pqctoday-kmip`: 593 passed (was 592; +1 new test).
- [x] wasm32 build + existing smoke test green.
- [x] Standalone node verification: create an ECDSA key pair, register a real self-signed demo certificate linked to it, read back engine `CKA_VALUE`/`CKA_SUBJECT`/`CKA_ISSUER`/`CKA_SERIAL_NUMBER` — all genuinely populated, subject CN matches the fixture exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)