### PR TITLE
docs(changelog): cut v0.14.0 release section, log #139-142, bump crate versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,56 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`Register(Certificate)` was unreachable on `wasm32`.**
+  `register_import_export.rs`'s Register/Import call into
+  `certify::project_certificate_to_engine` unconditionally, but the
+  `certify` module is `#[cfg(feature = "native")]`-gated (its CSR/rcgen
+  issuance logic doesn't cross-compile to wasm32) — no wasm32 build of
+  the `kmip` crate had been attempted since certificate support was
+  added, so this was silently broken. Extracted the wasm-safe projection
+  helper (no `rcgen`/`aws_lc_rs` dependency) into its own
+  always-compiled `cert_projection` module; `certify.rs`'s own native
+  call sites are unaffected.
+- **`Register(Certificate)` didn't share its linked key's `CKA_ID`.**
+  Unlike the native `Certify` path (`store_certificate`), which reuses
+  the linked key's own `CKA_ID` so a raw PKCS#11 client can match
+  cert-to-key by `CKA_ID` (the strongSwan pattern), `Register` with a
+  `PublicKeyLink` always minted a fresh one — and since `Certify` is
+  native-only, `Register` was the only wasm-reachable path that could
+  carry this pattern into the browser. Fixed: `Register(Certificate)`
+  now reuses a linked `PublicKey`'s `CKA_ID` when supplied, falling back
+  to a fresh one otherwise.
+- **`FrodoKEM`/`Classic McEliece` encapsulate/decapsulate overflowed the
+  wasm shadow stack.** `CKM_PQCTODAY_FRODOKEM_ENCAPSULATE` /
+  `CKM_PQCTODAY_CLASSIC_MCELIECE_ENCAPSULATE` (BSI TR-02102-1
+  §2.4.1/§2.4.2) trapped with "memory access out of bounds" in the wasm
+  build — a genuine wasm32 shadow-stack overflow (Classic McEliece's
+  `mceliece6688128` public key alone is over 1MB, handled via on-stack
+  buffers, exceeding wasm's default 1MB shadow stack even in
+  `--release`). Never caught because no existing test exercised these
+  two mechanisms through the wasm build (FrodoKEM-1344 was untested even
+  natively). Fixed by bumping `build-wasm-bundle.sh`'s linker
+  stack-size flag to 8MB across every build profile; adds a permanent
+  native `frodokem_1344_aes_round_trip` test.
+
+### Added
+
+- **`raw_pkcs11_encrypt_probe`** — a wasm-bindgen export on
+  `KmipPlayground` that bypasses the KMIP dispatcher and CACP policy
+  plane entirely, calling straight into the engine's native PKCS#11
+  Encrypt path against a KMIP object's own engine handle. Demonstrates
+  that PKCS#11 v3.2 §4.8 Table 13 (`CKA_ALLOWED_MECHANISMS`) is enforced
+  by the engine itself, not just by KMIP/CACP's policy layer.
+- **`register_certificate_demo`** and **`engine_certificate_attributes`**
+  wasm exports — register a caller-supplied certificate DER linked to an
+  existing public key, and read back a Certificate object's real
+  engine-side PKCS#11 attributes (`CKA_ID`, `CKA_VALUE`, `CKA_SUBJECT`,
+  `CKA_ISSUER`, `CKA_SERIAL_NUMBER`), not just the KMIP store record.
+
+## [0.14.0] — 2026-07-11
+
+### Fixed
+
 - **KMIP-created RSA/ECDSA keys could not Sign or Verify at all.** The
   `CKA_ALLOWED_MECHANISMS` whitelist auto-derived at key-creation time stored
   a coarse mechanism (bare `CKM_RSA_PKCS_PSS` / `CKM_ECDSA`), while

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ engine. It has its own checked-in PKCS#11 v3.2 conformance evidence
 The original Phase 0–6 roadmap (import + strip legacy, OpenSSL 3.x EVP
 migration, ML-DSA, ML-KEM, Emscripten WASM, npm package, app integration) is
 **complete**, as is the later hardening/conformance work. Current release is
-tracked in `CHANGELOG.md` (**0.13.1**, 2026-07-09). Recent programs: PKCS#11 v3.2
+tracked in `CHANGELOG.md` (**0.14.0**, 2026-07-11). Recent programs: PKCS#11 v3.2
 + KMIP 3.0 conformance evidence (real Split Key + asynchronous processing,
 honest `Query`), a follow-up gap-remediation audit (13 findings across both
 crates — silently-dropped errors, stub behavior — all fixed), the CACP

--- a/kmip/Cargo.lock
+++ b/kmip/Cargo.lock
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "pqctoday-kmip"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "softhsmrustv3"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",

--- a/kmip/Cargo.toml
+++ b/kmip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pqctoday-kmip"
-version     = "0.13.1"
+version     = "0.14.0"
 edition     = "2024"
 license     = "MIT"
 description = "KMIP 3.0 PQC + classical key management wrapper over pqctoday-hsm PKCS#11"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1660,7 +1660,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "softhsmrustv3"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softhsmrustv3"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2024"
 description = "A native Rust WebAssembly clone of SoftHSMv3"
 


### PR DESCRIPTION
## Summary
- CHANGELOG.md was released as v0.14.0 on GitHub but never got a release heading — its content stayed under `[Unreleased]`, and the 4 PRs merged after it (#139–142) had no entries at all
- Cuts `[Unreleased]` into `## [0.14.0] — 2026-07-11`, adds a fresh `[Unreleased]` covering #139 (wasm cert-projection gate fix), #140 (`raw_pkcs11_encrypt_probe`), #141 (Register(Certificate) CKA_ID sharing), #142 (FrodoKEM/McEliece wasm shadow-stack fix)
- Bumps `kmip/Cargo.toml` and `rust/Cargo.toml` (+ their `Cargo.lock` entries) 0.13.1 → 0.14.0, restoring the version-per-release convention every earlier tag followed but which was skipped at the v0.14.0 cut
- Updates the stale release pointer in CLAUDE.md's Status section
- `package.json` and `wasm/Cargo.toml` left untouched — confirmed via history they track an independent version cadence, not 1:1 with release tags

## Test plan
- [x] Docs/version-only change, no code touched
- [x] Verified changelog heading order and Cargo.lock entries match the new Cargo.toml versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)