### PR TITLE
fix: policy_op_layer stale deny-reason test helper (not a policy regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`policy_op_layer` test suite: stale `policy_denied()` helper gave 3
+  false failures, not a policy regression.** `DenyReason::to_result_reason()`
+  maps each rule family to its own KMIP `ResultReason` (`min_key_length` →
+  `BadCryptographicParameters`, `require_custom_attribute` /
+  `require_usage_mask` → `InvalidAttributeValue`, …) instead of collapsing
+  every denial onto `PermissionDenied` — the local-only op-layer suite's
+  helper still only recognized the old collapsed string, so it misread 3
+  correct denials (FIPS RSA-2048 below `min_key_length`, CNSA ML-DSA-87
+  without its classification tag, BSI FrodoKEM/Classic-McEliece without
+  the hybrid-partner tag) as allows. No production code changed; the
+  helper now recognizes all 5 deny-mapped reasons.
+
 ## [0.15.0] — 2026-07-18
 
 ### Added

--- a/kmip/tests/policy_op_layer.rs
+++ b/kmip/tests/policy_op_layer.rs
@@ -127,14 +127,30 @@ fn try_create_sym(
 
 const CNSA_TAG: (&str, &str) = ("x-pqctoday-cnsa-classification", "TopSecret");
 
-// The op handlers wrap every `Decision::Deny` as `ResultReason::PermissionDenied`
-// regardless of the internal deny reason, so a policy denial is unambiguous. A
-// policy *allow* proceeds to key generation which, engine-less (integration
-// tests compile the crate in non-test mode, so the placeholder path is off),
-// fails with `CryptographicFailure` — that still means the POLICY allowed it.
-// We therefore assert on the policy decision, not on crypto execution.
+// The op handlers surface a `Decision::Deny` via `DenyReason::to_result_reason()`
+// (kmip/src/policy/decision.rs) — a specific KMIP 3.0 §9.2 ResultReason per rule
+// family (`min_key_length` -> BadCryptographicParameters, `require_usage_mask` /
+// `require_custom_attribute` -> InvalidAttributeValue, `lifecycle_state_gate` ->
+// ObjectArchived, `max_key_age_days` -> WrongKeyLifecycleState, everything else
+// -> PermissionDenied) rather than collapsing every denial onto one generic
+// code, so a policy denial can surface as any of these five reasons. A policy
+// *allow* proceeds to key generation which, engine-less (integration tests
+// compile the crate in non-test mode, so the placeholder path is off), fails
+// with `CryptographicFailure` — that still means the POLICY allowed it. We
+// therefore assert on the policy decision, not on crypto execution.
 fn policy_denied(r: &Result<(), String>) -> bool {
-    matches!(r, Err(reason) if reason == "PermissionDenied")
+    matches!(
+        r,
+        Err(reason)
+            if matches!(
+                reason.as_str(),
+                "PermissionDenied"
+                    | "BadCryptographicParameters"
+                    | "ObjectArchived"
+                    | "InvalidAttributeValue"
+                    | "WrongKeyLifecycleState"
+            )
+    )
 }
 fn policy_allowed(r: &Result<(), String>) -> bool {
     !policy_denied(r)


### PR DESCRIPTION
## Summary

- Investigated 3 failing tests in the local-only `policy_op_layer` suite (`fips_allows_approved_classical_and_pqc_keypairs`, `cnsa_custom_attribute_gate_is_live`, `bsi_denies_frodokem_and_mceliece_without_hybrid_partner_tag`) that on the surface looked like fail-open policy regressions (RSA-2048 allowed under FIPS, ML-DSA-87 allowed without its CNSA classification tag, FrodoKEM allowed without BSI's hybrid-partner tag).
- Root cause: **not a policy engine bug.** `DenyReason::to_result_reason()` (`kmip/src/policy/decision.rs`) deliberately maps each rule family to its own specific KMIP `ResultReason` — `min_key_length` → `BadCryptographicParameters`, `require_custom_attribute`/`require_usage_mask` → `InvalidAttributeValue`, `lifecycle_state_gate` → `ObjectArchived`, `max_key_age_days` → `WrongKeyLifecycleState` — instead of collapsing every denial onto one generic `PermissionDenied` code. That refinement is itself documented in `decision.rs` as a fix for exactly the old collapsed behavior.
- The test file's `policy_denied()` helper was never updated to match — it only recognized the literal string `"PermissionDenied"`, so it misread these 3 legitimate denials as allows.
- Fix: widen `policy_denied()` to recognize all 5 deny-mapped `ResultReason` strings. No production code changed.

## Verification

- `cargo test --release --test policy_op_layer -- --include-ignored --test-threads=1`: 10/10 pass (was 7/10).
- Full kmip crate test suite (`cargo test --release -- --include-ignored`): 655 lib tests + every integration binary, 0 failures.
- `scripts/local-gate.sh`: all 5 steps passed (REPLAY GATE OK 97/0/5-deprecated-skip, wasm CACP smoke OK).

## Test plan

- [x] `policy_op_layer` suite green (10/10)
- [x] Full kmip test suite green
- [x] Local gate green