### PR TITLE
feat: hsm-perf-bench harness + KMIP tenant isolation hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ Makefile.in
 .vscode/
 .idea/
 rust/target/
+rust/bench-harness/target/
 openmls-provider/target/
 kmip/target/
 

--- a/kmip/bin/pqctoday-kmip.rs
+++ b/kmip/bin/pqctoday-kmip.rs
@@ -23,8 +23,9 @@ use clap::Parser;
 
 use pqctoday_kmip::auditlog::{AuditSink, CompositeSink, JsonlSink, OtlpSink, RingSink, SseSink, SyslogSink};
 use pqctoday_kmip::cert_init::init_certs_if_missing;
-use pqctoday_kmip::ops::{Deps, DepsConfig, RngSeedMode};
+use pqctoday_kmip::ops::{Deps, DepsConfig, RngSeedMode, TenancyMode};
 use pqctoday_kmip::policy::{load_from_str, Engine, PolicyStore};
+use pqctoday_kmip::server::auth::Identity;
 use pqctoday_kmip::server::{serve, tls_from_pem, tls_mtls, tls_self_signed, AuthUser};
 use pqctoday_kmip::store::{KeyStore, MemoryStore, SqliteStore};
 
@@ -168,6 +169,26 @@ struct Cli {
     /// be exercised, since a deployed server picks exactly one.
     #[arg(long = "rng-seed-mode", default_value = "full")]
     rng_seed_mode: String,
+
+    /// Part F §F7 / hsm-perf-bench plan §P0.5/§P3 — per-client tenancy
+    /// mode: `single` (default, today's behavior — every request shares
+    /// one engine session), `auto` (first request from each
+    /// mTLS-CN-derived identity auto-provisions a fresh token: next
+    /// free PKCS#11 slot, server-minted PIN pair recorded for operator
+    /// readback), or `strict` (only identities named via
+    /// `--strict-tenant` may operate; every other identity is rejected
+    /// before touching the engine). `strict` with no `--strict-tenant`
+    /// entries rejects every identity — a deliberate fail-closed
+    /// default, not a silent no-op.
+    #[arg(long = "tenancy", default_value = "single")]
+    tenancy: String,
+
+    /// One pre-configured tenant for `--tenancy strict`, repeatable:
+    /// `<identity-cn>:<slot>:<so-pin>:<user-pin>`. Ignored for
+    /// `single`/`auto`. Example:
+    /// `--strict-tenant alice:1:so-pin-1:user-pin-1`.
+    #[arg(long = "strict-tenant")]
+    strict_tenant: Vec<String>,
 }
 
 #[tokio::main]
@@ -340,6 +361,43 @@ async fn main() -> anyhow::Result<()> {
             );
         }
     };
+    let tenancy_mode = match cli.tenancy.as_str() {
+        "single" => TenancyMode::Single,
+        "auto" => TenancyMode::Auto,
+        "strict" => TenancyMode::Strict,
+        other => {
+            anyhow::bail!("--tenancy: unknown value {other:?} (expected single|auto|strict)");
+        }
+    };
+    if !matches!(tenancy_mode, TenancyMode::Strict) && !cli.strict_tenant.is_empty() {
+        anyhow::bail!("--strict-tenant requires --tenancy strict");
+    }
+    let strict_tenants = cli
+        .strict_tenant
+        .iter()
+        .map(|entry| {
+            let parts: Vec<&str> = entry.splitn(4, ':').collect();
+            let [cn, slot, so_pin, user_pin] = parts.as_slice() else {
+                anyhow::bail!(
+                    "--strict-tenant {entry:?}: expected <identity-cn>:<slot>:<so-pin>:<user-pin>"
+                );
+            };
+            let slot: u32 = slot
+                .parse()
+                .map_err(|_| anyhow::anyhow!("--strict-tenant {entry:?}: slot {slot:?} is not a valid u32"))?;
+            Ok(pqctoday_kmip::ops::StrictTenantConfig {
+                identity: Identity { username: cn.to_string() },
+                slot,
+                so_pin: so_pin.to_string(),
+                user_pin: user_pin.to_string(),
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    if matches!(tenancy_mode, TenancyMode::Strict) {
+        tracing::info!(tenants = strict_tenants.len(), "tenancy mode: strict");
+    } else if matches!(tenancy_mode, TenancyMode::Auto) {
+        tracing::info!("tenancy mode: auto (per-identity token auto-provisioning)");
+    }
     let config = DepsConfig {
         pkcs11_slot: cli.slot,
         pkcs11_pin: cli.pin,
@@ -348,12 +406,14 @@ async fn main() -> anyhow::Result<()> {
         auth_users,
         ca_key,
         rng_seed_mode,
-        // Part F §F7.2 — tenant-registry infrastructure exists but is not
-        // yet wired into the dispatcher (see ops/deps.rs); every
-        // production deployment stays Single-mode (today's behavior)
-        // until that wiring lands.
-        tenancy_mode: Default::default(),
-        strict_tenants: Vec::new(),
+        // Part F §F7 is fully wired into the dispatcher as of the
+        // 2026-07-18/19 tenancy work (commits ee62b0f..77381b8) — every
+        // by-UID handler and every shared Deps map is tenant-scoped.
+        // Single (this flag's default) preserves today's behavior
+        // byte-for-byte; --tenancy auto/strict is what the hsm-perf-bench
+        // plan's KMIP-axis multi-tenant benchmark cells need (§P2/§P3).
+        tenancy_mode,
+        strict_tenants,
     };
     let deps = Arc::new(
         Deps::new(engine, store, sink, config).with_engine_session(engine_session),

--- a/kmip/bin/pqctoday-kmip.rs
+++ b/kmip/bin/pqctoday-kmip.rs
@@ -348,6 +348,12 @@ async fn main() -> anyhow::Result<()> {
         auth_users,
         ca_key,
         rng_seed_mode,
+        // Part F §F7.2 — tenant-registry infrastructure exists but is not
+        // yet wired into the dispatcher (see ops/deps.rs); every
+        // production deployment stays Single-mode (today's behavior)
+        // until that wiring lands.
+        tenancy_mode: Default::default(),
+        strict_tenants: Vec::new(),
     };
     let deps = Arc::new(
         Deps::new(engine, store, sink, config).with_engine_session(engine_session),

--- a/kmip/src/dispatcher/mod.rs
+++ b/kmip/src/dispatcher/mod.rs
@@ -920,25 +920,25 @@ fn handle_payload(
 ) -> Result<ResponsePayload, KmipError> {
     Ok(match payload {
         RequestPayload::Query(r) => ResponsePayload::Query(query(deps, r, correlation_id)?),
-        RequestPayload::Create(r) => ResponsePayload::Create(create(deps, r, correlation_id)?),
+        RequestPayload::Create(r) => ResponsePayload::Create(create(deps, r, auth, correlation_id)?),
         RequestPayload::CreateKeyPair(r) => {
             let op_canonical = canonical_create_key_pair_op(&r);
             ResponsePayload::CreateKeyPair(create_key_pair(deps, r, &op_canonical, auth, correlation_id)?)
         }
-        RequestPayload::Get(r) => ResponsePayload::Get(get(deps, r, correlation_id)?),
-        RequestPayload::GetAttributes(r) => ResponsePayload::GetAttributes(get_attributes(deps, r, correlation_id)?),
+        RequestPayload::Get(r) => ResponsePayload::Get(get(deps, r, auth, correlation_id)?),
+        RequestPayload::GetAttributes(r) => ResponsePayload::GetAttributes(get_attributes(deps, r, auth, correlation_id)?),
         RequestPayload::GetAttributeList(r) => ResponsePayload::GetAttributeList(get_attribute_list(deps, r, correlation_id)?),
-        RequestPayload::Locate(r) => ResponsePayload::Locate(locate(deps, r, correlation_id)?),
+        RequestPayload::Locate(r) => ResponsePayload::Locate(locate(deps, r, auth, correlation_id)?),
         RequestPayload::Activate(r) => ResponsePayload::Activate(activate(deps, r, correlation_id)?),
         RequestPayload::Revoke(r) => ResponsePayload::Revoke(revoke(deps, r, correlation_id)?),
-        RequestPayload::Destroy(r) => ResponsePayload::Destroy(destroy(deps, r, correlation_id)?),
+        RequestPayload::Destroy(r) => ResponsePayload::Destroy(destroy(deps, r, auth, correlation_id)?),
         RequestPayload::Encrypt(r) => ResponsePayload::Encrypt(encrypt(deps, r, correlation_id)?),
         RequestPayload::Decrypt(r) => ResponsePayload::Decrypt(decrypt(deps, r, correlation_id)?),
         RequestPayload::Encapsulate(r) => {
             ResponsePayload::Encapsulate(encapsulate(deps, r, auth, correlation_id)?)
         }
         RequestPayload::Decapsulate(r) => {
-            ResponsePayload::Decapsulate(decapsulate(deps, r, correlation_id)?)
+            ResponsePayload::Decapsulate(decapsulate(deps, r, auth, correlation_id)?)
         }
         RequestPayload::Sign(r) => ResponsePayload::Sign(sign(deps, r, auth, correlation_id)?),
         RequestPayload::SignatureVerify(r) => {
@@ -1021,7 +1021,7 @@ fn handle_payload(
             ResponsePayload::DeriveKey(derive_key(deps, r, correlation_id)?)
         }
         // K21 — §6.1.51 Re-key / §6.1.52 Re-key Key Pair.
-        RequestPayload::ReKey(r) => ResponsePayload::ReKey(rekey(deps, r, correlation_id)?),
+        RequestPayload::ReKey(r) => ResponsePayload::ReKey(rekey(deps, r, auth, correlation_id)?),
         RequestPayload::ReKeyKeyPair(r) => {
             ResponsePayload::ReKeyKeyPair(rekey_key_pair(deps, r, auth, correlation_id)?)
         }

--- a/kmip/src/dispatcher/mod.rs
+++ b/kmip/src/dispatcher/mod.rs
@@ -952,8 +952,8 @@ fn handle_payload(
         RequestPayload::Activate(r) => ResponsePayload::Activate(activate(deps, r, correlation_id)?),
         RequestPayload::Revoke(r) => ResponsePayload::Revoke(revoke(deps, r, correlation_id)?),
         RequestPayload::Destroy(r) => ResponsePayload::Destroy(destroy(deps, r, auth, correlation_id)?),
-        RequestPayload::Encrypt(r) => ResponsePayload::Encrypt(encrypt(deps, r, correlation_id)?),
-        RequestPayload::Decrypt(r) => ResponsePayload::Decrypt(decrypt(deps, r, correlation_id)?),
+        RequestPayload::Encrypt(r) => ResponsePayload::Encrypt(encrypt(deps, r, auth, correlation_id)?),
+        RequestPayload::Decrypt(r) => ResponsePayload::Decrypt(decrypt(deps, r, auth, correlation_id)?),
         RequestPayload::Encapsulate(r) => {
             ResponsePayload::Encapsulate(encapsulate(deps, r, auth, correlation_id)?)
         }

--- a/kmip/src/dispatcher/mod.rs
+++ b/kmip/src/dispatcher/mod.rs
@@ -947,7 +947,7 @@ fn handle_payload(
         }
         RequestPayload::Get(r) => ResponsePayload::Get(get(deps, r, auth, correlation_id)?),
         RequestPayload::GetAttributes(r) => ResponsePayload::GetAttributes(get_attributes(deps, r, auth, correlation_id)?),
-        RequestPayload::GetAttributeList(r) => ResponsePayload::GetAttributeList(get_attribute_list(deps, r, correlation_id)?),
+        RequestPayload::GetAttributeList(r) => ResponsePayload::GetAttributeList(get_attribute_list(deps, r, auth, correlation_id)?),
         RequestPayload::Locate(r) => ResponsePayload::Locate(locate(deps, r, auth, correlation_id)?),
         RequestPayload::Activate(r) => ResponsePayload::Activate(activate(deps, r, correlation_id)?),
         RequestPayload::Revoke(r) => ResponsePayload::Revoke(revoke(deps, r, correlation_id)?),

--- a/kmip/src/dispatcher/mod.rs
+++ b/kmip/src/dispatcher/mod.rs
@@ -619,16 +619,28 @@ fn spawn_or_run_async_job(
         let spawned = std::thread::Builder::new()
             .name("kmip-async-job".into())
             .spawn(move || {
-                job_for_thread.mark_in_process();
+                // Cancel may have already won the Submitted→Completed
+                // race by the time the OS actually schedules this
+                // thread — if so, the real operation must never run
+                // (it would clobber the recorded cancellation outcome
+                // moments later) and the job's state must not be
+                // touched at all.
+                if !job_for_thread.try_start_if_submitted() {
+                    return;
+                }
                 let outcome = handle_payload(&deps_arc, payload, &correlation_id, &auth);
                 job_for_thread.mark_completed(outcome);
             });
         if spawned.is_ok() {
             return;
         }
-        job.mark_completed(Err(KmipError::internal(
-            "failed to spawn background async-job thread",
-        )));
+        // Same race, narrower window: Cancel could have completed the
+        // job between the `insert` above and this failed `spawn` call.
+        if job.try_start_if_submitted() {
+            job.mark_completed(Err(KmipError::internal(
+                "failed to spawn background async-job thread",
+            )));
+        }
         return;
     }
     run_async_job_eagerly(deps, job, payload, correlation_id, &auth);
@@ -647,7 +659,15 @@ fn run_async_job_eagerly(
     correlation_id: String,
     auth: &crate::server::auth::AuthContext,
 ) {
-    job.mark_in_process();
+    // This path runs synchronously inside `enqueue_async_job`, before
+    // its caller could ever have dispatched a `Cancel` for this job —
+    // `try_start_if_submitted` can't actually observe `false` here
+    // today. Using it anyway (not the unconditional `mark_in_process`)
+    // keeps this symmetric with the real-thread executor above and
+    // stays correct if that ordering assumption ever changes.
+    if !job.try_start_if_submitted() {
+        return;
+    }
     let outcome = handle_payload(deps, payload, &correlation_id, auth);
     job.mark_completed(outcome);
 }

--- a/kmip/src/dispatcher/mod.rs
+++ b/kmip/src/dispatcher/mod.rs
@@ -950,7 +950,7 @@ fn handle_payload(
         RequestPayload::GetAttributeList(r) => ResponsePayload::GetAttributeList(get_attribute_list(deps, r, auth, correlation_id)?),
         RequestPayload::Locate(r) => ResponsePayload::Locate(locate(deps, r, auth, correlation_id)?),
         RequestPayload::Activate(r) => ResponsePayload::Activate(activate(deps, r, correlation_id)?),
-        RequestPayload::Revoke(r) => ResponsePayload::Revoke(revoke(deps, r, correlation_id)?),
+        RequestPayload::Revoke(r) => ResponsePayload::Revoke(revoke(deps, r, auth, correlation_id)?),
         RequestPayload::Destroy(r) => ResponsePayload::Destroy(destroy(deps, r, auth, correlation_id)?),
         RequestPayload::Encrypt(r) => ResponsePayload::Encrypt(encrypt(deps, r, auth, correlation_id)?),
         RequestPayload::Decrypt(r) => ResponsePayload::Decrypt(decrypt(deps, r, auth, correlation_id)?),
@@ -962,7 +962,7 @@ fn handle_payload(
         }
         RequestPayload::Sign(r) => ResponsePayload::Sign(sign(deps, r, auth, correlation_id)?),
         RequestPayload::SignatureVerify(r) => {
-            ResponsePayload::SignatureVerify(signature_verify(deps, r, correlation_id)?)
+            ResponsePayload::SignatureVerify(signature_verify(deps, r, auth, correlation_id)?)
         }
         RequestPayload::Validate(r) => ResponsePayload::Validate(validate(deps, r, auth, correlation_id)?),
         // P2.3 — §6.1.6 Certify / §6.1.50 Re-certify (PQC-capable CA).
@@ -972,30 +972,30 @@ fn handle_payload(
         RequestPayload::Certify(r) => ResponsePayload::Certify(certify(deps, r, auth, correlation_id)?),
         RequestPayload::ReCertify(r) => ResponsePayload::ReCertify(recertify(deps, r, auth, correlation_id)?),
         RequestPayload::Interop(r) => ResponsePayload::Interop(interop(deps, r, correlation_id)?),
-        RequestPayload::AddAttribute(r) => ResponsePayload::AddAttribute(add_attribute(deps, r, correlation_id)?),
-        RequestPayload::ModifyAttribute(r) => ResponsePayload::ModifyAttribute(modify_attribute(deps, r, correlation_id)?),
-        RequestPayload::DeleteAttribute(r) => ResponsePayload::DeleteAttribute(delete_attribute(deps, r, correlation_id)?),
-        RequestPayload::SetAttribute(r) => ResponsePayload::SetAttribute(set_attribute(deps, r, correlation_id)?),
-        RequestPayload::AdjustAttribute(r) => ResponsePayload::AdjustAttribute(adjust_attribute(deps, r, correlation_id)?),
+        RequestPayload::AddAttribute(r) => ResponsePayload::AddAttribute(add_attribute(deps, r, auth, correlation_id)?),
+        RequestPayload::ModifyAttribute(r) => ResponsePayload::ModifyAttribute(modify_attribute(deps, r, auth, correlation_id)?),
+        RequestPayload::DeleteAttribute(r) => ResponsePayload::DeleteAttribute(delete_attribute(deps, r, auth, correlation_id)?),
+        RequestPayload::SetAttribute(r) => ResponsePayload::SetAttribute(set_attribute(deps, r, auth, correlation_id)?),
+        RequestPayload::AdjustAttribute(r) => ResponsePayload::AdjustAttribute(adjust_attribute(deps, r, auth, correlation_id)?),
         RequestPayload::Register(r) => ResponsePayload::Register(register(deps, r, auth, correlation_id)?),
         RequestPayload::Import(r) => ResponsePayload::Import(import_object(deps, r, auth, correlation_id)?),
         RequestPayload::Export(r) => ResponsePayload::Export(export(deps, r, auth, correlation_id)?),
         RequestPayload::Deactivate(r) => ResponsePayload::Deactivate(deactivate(deps, r, correlation_id)?),
         RequestPayload::Check(r) => ResponsePayload::Check(check(deps, r, correlation_id)?),
         RequestPayload::ObtainLease(r) => ResponsePayload::ObtainLease(obtain_lease(deps, r, correlation_id)?),
-        RequestPayload::CreateSplitKey(r) => ResponsePayload::CreateSplitKey(create_split_key(deps, r, correlation_id)?),
-        RequestPayload::JoinSplitKey(r) => ResponsePayload::JoinSplitKey(join_split_key(deps, r, correlation_id)?),
+        RequestPayload::CreateSplitKey(r) => ResponsePayload::CreateSplitKey(create_split_key(deps, r, auth, correlation_id)?),
+        RequestPayload::JoinSplitKey(r) => ResponsePayload::JoinSplitKey(join_split_key(deps, r, auth, correlation_id)?),
         RequestPayload::Archive(r) => ResponsePayload::Archive(archive(deps, r, correlation_id)?),
         RequestPayload::Recover(r) => ResponsePayload::Recover(recover(deps, r, correlation_id)?),
         RequestPayload::Obliterate(r) => ResponsePayload::Obliterate(obliterate(deps, r, correlation_id)?),
         RequestPayload::DiscoverVersions(r) => ResponsePayload::DiscoverVersions(discover_versions(deps, r, correlation_id)?),
         RequestPayload::Ping(r) => ResponsePayload::Ping(ping(deps, r, correlation_id)?),
-        RequestPayload::Mac(r) => ResponsePayload::Mac(mac(deps, r, correlation_id)?),
-        RequestPayload::MacVerify(r) => ResponsePayload::MacVerify(mac_verify(deps, r, correlation_id)?),
+        RequestPayload::Mac(r) => ResponsePayload::Mac(mac(deps, r, auth, correlation_id)?),
+        RequestPayload::MacVerify(r) => ResponsePayload::MacVerify(mac_verify(deps, r, auth, correlation_id)?),
         RequestPayload::Hash(r) => ResponsePayload::Hash(hash(deps, r, correlation_id)?),
-        RequestPayload::CreateCredential(r) => ResponsePayload::CreateCredential(create_credential(deps, r, correlation_id)?),
-        RequestPayload::CreateGroup(r) => ResponsePayload::CreateGroup(create_group(deps, r, correlation_id)?),
-        RequestPayload::CreateUser(r) => ResponsePayload::CreateUser(create_user(deps, r, correlation_id)?),
+        RequestPayload::CreateCredential(r) => ResponsePayload::CreateCredential(create_credential(deps, r, auth, correlation_id)?),
+        RequestPayload::CreateGroup(r) => ResponsePayload::CreateGroup(create_group(deps, r, auth, correlation_id)?),
+        RequestPayload::CreateUser(r) => ResponsePayload::CreateUser(create_user(deps, r, auth, correlation_id)?),
         RequestPayload::Log(r) => ResponsePayload::Log(log(deps, r, correlation_id)?),
         RequestPayload::Login(r) => ResponsePayload::Login(login(deps, r, auth, correlation_id)?),
         RequestPayload::Logout(r) => ResponsePayload::Logout(logout(deps, r, correlation_id)?),
@@ -1020,7 +1020,7 @@ fn handle_payload(
         }
         RequestPayload::RngRetrieve(r) => ResponsePayload::RngRetrieve(rng_retrieve(deps, r, correlation_id)?),
         RequestPayload::RngSeed(r) => ResponsePayload::RngSeed(rng_seed(deps, r, correlation_id)?),
-        RequestPayload::Pkcs11(r) => ResponsePayload::Pkcs11(pkcs11(deps, r, correlation_id)?),
+        RequestPayload::Pkcs11(r) => ResponsePayload::Pkcs11(pkcs11(deps, r, auth, correlation_id)?),
         // K19 — Baseline client-to-server ops (§6.1.26/27/58/59).
         RequestPayload::GetUsageAllocation(r) => {
             ResponsePayload::GetUsageAllocation(get_usage_allocation(deps, r, correlation_id)?)
@@ -1038,7 +1038,7 @@ fn handle_payload(
             ResponsePayload::SetEndpointRole(set_endpoint_role(deps, r, correlation_id)?)
         }
         RequestPayload::DeriveKey(r) => {
-            ResponsePayload::DeriveKey(derive_key(deps, r, correlation_id)?)
+            ResponsePayload::DeriveKey(derive_key(deps, r, auth, correlation_id)?)
         }
         // K21 — §6.1.51 Re-key / §6.1.52 Re-key Key Pair.
         RequestPayload::ReKey(r) => ResponsePayload::ReKey(rekey(deps, r, auth, correlation_id)?),

--- a/kmip/src/dispatcher/mod.rs
+++ b/kmip/src/dispatcher/mod.rs
@@ -452,7 +452,7 @@ fn dispatch_one(
     // synchronously"), which `handle_payload`'s uniform per-op wrapping
     // can't express. Handled first and returns early.
     if let RequestPayload::Poll(req) = &payload {
-        return handle_poll(deps, req);
+        return handle_poll(deps, req, auth);
     }
 
     // Async subsystem — KMIP 3.0 §8.1.2 `Asynchronous Indicator =
@@ -576,7 +576,10 @@ fn enqueue_async_job(
     auth: crate::server::auth::AuthContext,
 ) -> ResponseBatchItem {
     let cv = deps.new_correlation_value();
-    let job = crate::ops::AsyncJob::new(op);
+    // Part F §F7.5 — stamp the submitting tenant so Poll/Cancel/Process/
+    // QueryAsyncRequests can scope this job to its owner.
+    let owner = auth.identity.as_ref().map(|i| i.username.clone());
+    let job = crate::ops::AsyncJob::new(op, owner);
     deps.async_jobs
         .lock()
         .unwrap_or_else(|e| e.into_inner())
@@ -682,12 +685,23 @@ fn run_async_job_eagerly(
 ///   sent if the operation had completed synchronously" (§6.1.43):
 ///   echoes the ORIGINAL polled operation + its real outcome, exactly
 ///   as `dispatch_one`'s normal Success/Failed wrapping would have.
-fn handle_poll(deps: &Deps, req: &crate::kmip30::PollRequest) -> ResponseBatchItem {
+fn handle_poll(
+    deps: &Deps,
+    req: &crate::kmip30::PollRequest,
+    auth: &crate::server::auth::AuthContext,
+) -> ResponseBatchItem {
     use crate::kmip30::{Operation, ProcessingStage};
+    let requester = auth.identity.as_ref().map(|i| i.username.clone());
     let job = {
         let jobs = deps.async_jobs.lock().unwrap_or_else(|e| e.into_inner());
         jobs.get(&req.asynchronous_correlation_value).cloned()
     };
+    // Part F §F7.5 — a job owned by a different tenant is indistinguishable
+    // from a nonexistent one (anti-oracle): same `Invalid Asynchronous
+    // Correlation Value` a genuinely unknown CV produces. This is the
+    // load-bearing check — Poll below returns the deferred op's full
+    // payload, which for a deferred Get/Export/Decrypt is key material.
+    let job = job.filter(|j| j.state.lock().unwrap_or_else(|e| e.into_inner()).owner == requester);
     let Some(job) = job else {
         let err = KmipError::invalid_asynchronous_correlation_value();
         return ResponseBatchItem {
@@ -1032,7 +1046,7 @@ fn handle_payload(
             ResponsePayload::SetConstraints(set_constraints(deps, r, correlation_id)?)
         }
         RequestPayload::SetDefaults(r) => {
-            ResponsePayload::SetDefaults(set_defaults(deps, r, correlation_id)?)
+            ResponsePayload::SetDefaults(set_defaults(deps, r, auth, correlation_id)?)
         }
         RequestPayload::SetEndpointRole(r) => {
             ResponsePayload::SetEndpointRole(set_endpoint_role(deps, r, correlation_id)?)
@@ -1055,10 +1069,10 @@ fn handle_payload(
                 "Poll must be intercepted by dispatch_one before handle_payload",
             ));
         }
-        RequestPayload::Cancel(r) => ResponsePayload::Cancel(cancel(deps, r, correlation_id)?),
-        RequestPayload::Process(r) => ResponsePayload::Process(process(deps, r, correlation_id)?),
+        RequestPayload::Cancel(r) => ResponsePayload::Cancel(cancel(deps, r, auth, correlation_id)?),
+        RequestPayload::Process(r) => ResponsePayload::Process(process(deps, r, auth, correlation_id)?),
         RequestPayload::QueryAsynchronousRequests(r) => ResponsePayload::QueryAsynchronousRequests(
-            query_asynchronous_requests(deps, r, correlation_id)?,
+            query_asynchronous_requests(deps, r, auth, correlation_id)?,
         ),
     })
 }

--- a/kmip/src/dispatcher/mod.rs
+++ b/kmip/src/dispatcher/mod.rs
@@ -964,22 +964,22 @@ fn handle_payload(
         RequestPayload::SignatureVerify(r) => {
             ResponsePayload::SignatureVerify(signature_verify(deps, r, correlation_id)?)
         }
-        RequestPayload::Validate(r) => ResponsePayload::Validate(validate(deps, r, correlation_id)?),
+        RequestPayload::Validate(r) => ResponsePayload::Validate(validate(deps, r, auth, correlation_id)?),
         // P2.3 — §6.1.6 Certify / §6.1.50 Re-certify (PQC-capable CA).
         // Ungated since WP4 — pure Rust (`spki_verify` + the engine),
         // dispatched on wasm32 the same as native; no more `not(native)`
         // OperationNotSupported fallback for these three.
-        RequestPayload::Certify(r) => ResponsePayload::Certify(certify(deps, r, correlation_id)?),
-        RequestPayload::ReCertify(r) => ResponsePayload::ReCertify(recertify(deps, r, correlation_id)?),
+        RequestPayload::Certify(r) => ResponsePayload::Certify(certify(deps, r, auth, correlation_id)?),
+        RequestPayload::ReCertify(r) => ResponsePayload::ReCertify(recertify(deps, r, auth, correlation_id)?),
         RequestPayload::Interop(r) => ResponsePayload::Interop(interop(deps, r, correlation_id)?),
         RequestPayload::AddAttribute(r) => ResponsePayload::AddAttribute(add_attribute(deps, r, correlation_id)?),
         RequestPayload::ModifyAttribute(r) => ResponsePayload::ModifyAttribute(modify_attribute(deps, r, correlation_id)?),
         RequestPayload::DeleteAttribute(r) => ResponsePayload::DeleteAttribute(delete_attribute(deps, r, correlation_id)?),
         RequestPayload::SetAttribute(r) => ResponsePayload::SetAttribute(set_attribute(deps, r, correlation_id)?),
         RequestPayload::AdjustAttribute(r) => ResponsePayload::AdjustAttribute(adjust_attribute(deps, r, correlation_id)?),
-        RequestPayload::Register(r) => ResponsePayload::Register(register(deps, r, correlation_id)?),
-        RequestPayload::Import(r) => ResponsePayload::Import(import_object(deps, r, correlation_id)?),
-        RequestPayload::Export(r) => ResponsePayload::Export(export(deps, r, correlation_id)?),
+        RequestPayload::Register(r) => ResponsePayload::Register(register(deps, r, auth, correlation_id)?),
+        RequestPayload::Import(r) => ResponsePayload::Import(import_object(deps, r, auth, correlation_id)?),
+        RequestPayload::Export(r) => ResponsePayload::Export(export(deps, r, auth, correlation_id)?),
         RequestPayload::Deactivate(r) => ResponsePayload::Deactivate(deactivate(deps, r, correlation_id)?),
         RequestPayload::Check(r) => ResponsePayload::Check(check(deps, r, correlation_id)?),
         RequestPayload::ObtainLease(r) => ResponsePayload::ObtainLease(obtain_lease(deps, r, correlation_id)?),

--- a/kmip/src/dispatcher/mod.rs
+++ b/kmip/src/dispatcher/mod.rs
@@ -923,7 +923,7 @@ fn handle_payload(
         RequestPayload::Create(r) => ResponsePayload::Create(create(deps, r, correlation_id)?),
         RequestPayload::CreateKeyPair(r) => {
             let op_canonical = canonical_create_key_pair_op(&r);
-            ResponsePayload::CreateKeyPair(create_key_pair(deps, r, &op_canonical, correlation_id)?)
+            ResponsePayload::CreateKeyPair(create_key_pair(deps, r, &op_canonical, auth, correlation_id)?)
         }
         RequestPayload::Get(r) => ResponsePayload::Get(get(deps, r, correlation_id)?),
         RequestPayload::GetAttributes(r) => ResponsePayload::GetAttributes(get_attributes(deps, r, correlation_id)?),
@@ -935,12 +935,12 @@ fn handle_payload(
         RequestPayload::Encrypt(r) => ResponsePayload::Encrypt(encrypt(deps, r, correlation_id)?),
         RequestPayload::Decrypt(r) => ResponsePayload::Decrypt(decrypt(deps, r, correlation_id)?),
         RequestPayload::Encapsulate(r) => {
-            ResponsePayload::Encapsulate(encapsulate(deps, r, correlation_id)?)
+            ResponsePayload::Encapsulate(encapsulate(deps, r, auth, correlation_id)?)
         }
         RequestPayload::Decapsulate(r) => {
             ResponsePayload::Decapsulate(decapsulate(deps, r, correlation_id)?)
         }
-        RequestPayload::Sign(r) => ResponsePayload::Sign(sign(deps, r, correlation_id)?),
+        RequestPayload::Sign(r) => ResponsePayload::Sign(sign(deps, r, auth, correlation_id)?),
         RequestPayload::SignatureVerify(r) => {
             ResponsePayload::SignatureVerify(signature_verify(deps, r, correlation_id)?)
         }
@@ -1023,7 +1023,7 @@ fn handle_payload(
         // K21 — §6.1.51 Re-key / §6.1.52 Re-key Key Pair.
         RequestPayload::ReKey(r) => ResponsePayload::ReKey(rekey(deps, r, correlation_id)?),
         RequestPayload::ReKeyKeyPair(r) => {
-            ResponsePayload::ReKeyKeyPair(rekey_key_pair(deps, r, correlation_id)?)
+            ResponsePayload::ReKeyKeyPair(rekey_key_pair(deps, r, auth, correlation_id)?)
         }
         // Phase 4 — `Poll` never reaches here: `dispatch_one` intercepts
         // it before calling `handle_payload` (its response impersonates

--- a/kmip/src/ops/agility.rs
+++ b/kmip/src/ops/agility.rs
@@ -45,6 +45,7 @@ pub(crate) fn generate_replacement_pair(
     new_algorithm: &str,
     usage: UsageMask,
     op_canonical: &str,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<ReplacementPair> {
     let new_alg = super::create_key_pair::parse_algorithm(new_algorithm)?;
@@ -64,6 +65,7 @@ pub(crate) fn generate_replacement_pair(
             seed: None,
         },
         op_canonical,
+        auth,
         correlation_id,
     )?;
     super::activate::activate(

--- a/kmip/src/ops/agility.rs
+++ b/kmip/src/ops/agility.rs
@@ -103,12 +103,17 @@ pub(crate) fn generate_replacement_symmetric(
     if let Some(name) = &old.name {
         attrs.push(Attribute::Name(name.clone()));
     }
+    // Encrypt's own by-UID lookup isn't owner-gated yet (see the
+    // tenancy_e2e module doc's "still unwired" list), so there is no
+    // caller identity to stamp here — anonymous preserves today's
+    // behavior exactly (owner stays `None`, same as before F7.3/F7.4).
     let created = super::create::create(
         deps,
         crate::kmip30::CreateRequest {
             object_type: crate::kmip30::ObjectType::SymmetricKey,
             template_attribute: attrs,
         },
+        &crate::server::auth::AuthContext::open(),
         correlation_id,
     )?;
     super::activate::activate(

--- a/kmip/src/ops/agility.rs
+++ b/kmip/src/ops/agility.rs
@@ -90,6 +90,7 @@ pub(crate) fn generate_replacement_symmetric(
     deps: &Deps,
     old: &ObjectRecord,
     new_algorithm: &str,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<String> {
     let new_alg = super::create_key_pair::parse_algorithm(new_algorithm)?;
@@ -103,17 +104,17 @@ pub(crate) fn generate_replacement_symmetric(
     if let Some(name) = &old.name {
         attrs.push(Attribute::Name(name.clone()));
     }
-    // Encrypt's own by-UID lookup isn't owner-gated yet (see the
-    // tenancy_e2e module doc's "still unwired" list), so there is no
-    // caller identity to stamp here — anonymous preserves today's
-    // behavior exactly (owner stays `None`, same as before F7.3/F7.4).
+    // Encrypt is now owner-gated too (§J/this round), so the real
+    // caller identity is available and gets stamped on the
+    // replacement — the same tenant that owned `old` owns its
+    // auto-rekeyed successor.
     let created = super::create::create(
         deps,
         crate::kmip30::CreateRequest {
             object_type: crate::kmip30::ObjectType::SymmetricKey,
             template_attribute: attrs,
         },
-        &crate::server::auth::AuthContext::open(),
+        auth,
         correlation_id,
     )?;
     super::activate::activate(

--- a/kmip/src/ops/allocation_and_config.rs
+++ b/kmip/src/ops/allocation_and_config.rs
@@ -240,6 +240,7 @@ fn server_constraints() -> Vec<Constraint> {
 pub fn set_defaults(
     deps: &Deps,
     req: SetDefaultsRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<SetDefaultsResponse> {
     emit_request(
@@ -252,8 +253,12 @@ pub fn set_defaults(
         ),
     );
 
-    let mut map = deps.object_defaults.lock().unwrap();
-    map.clear();
+    // Part F §F7.5 — per-tenant: this Set Defaults replaces only the
+    // CALLING tenant's bucket, leaving every other tenant's untouched.
+    let requester = auth.identity.as_ref().map(|i| i.username.clone());
+    let mut outer = deps.object_defaults.lock().unwrap();
+    let mut map: std::collections::HashMap<ObjectType, Vec<Attribute>> =
+        std::collections::HashMap::new();
     if let Some(object_defaults) = req.defaults_information {
         for od in object_defaults {
             for ot in &od.object_types {
@@ -264,7 +269,15 @@ pub fn set_defaults(
             }
         }
     }
-    drop(map);
+    // Table 428 — a new set REPLACES the old one; an absent (or empty)
+    // Defaults Information removes this tenant's defaults entirely
+    // rather than leaving a dangling empty bucket in the shared map.
+    if map.is_empty() {
+        outer.remove(&requester);
+    } else {
+        outer.insert(requester, map);
+    }
+    drop(outer);
 
     emit_success(deps, correlation_id, "SetDefaults");
     Ok(SetDefaultsResponse)
@@ -284,8 +297,12 @@ pub fn apply_object_defaults(
     object_type: ObjectType,
     also_present: &[Attribute],
     template: &mut Vec<Attribute>,
+    auth: &crate::server::auth::AuthContext,
 ) {
-    let map = deps.object_defaults.lock().unwrap();
+    // Part F §F7.5 — read only the CALLING tenant's own defaults.
+    let requester = auth.identity.as_ref().map(|i| i.username.clone());
+    let outer = deps.object_defaults.lock().unwrap();
+    let Some(map) = outer.get(&requester) else { return };
     let Some(defaults) = map.get(&object_type) else { return };
     let missing: Vec<Attribute> = defaults
         .iter()
@@ -359,6 +376,7 @@ mod tests {
     use crate::auditlog::{AuditSink, RingSink};
     use crate::error::ResultReason;
     use crate::kmip30::{ObjectDefaults, UsageMask};
+    use crate::server::auth::AuthContext;
     use crate::policy::{load_from_str, Engine};
     use crate::store::{MemoryStore, ObjectRecord};
     use std::sync::Arc;
@@ -568,19 +586,23 @@ mod tests {
         set_defaults(&d, defaults_req(
             ObjectType::SymmetricKey,
             vec![Attribute::CryptographicUsageMask(UsageMask::ENCRYPT | UsageMask::DECRYPT)],
-        ), "c").unwrap();
+        ), &AuthContext::open(), "c").unwrap();
+        // One tenant bucket (the anonymous/open one), with one type in it.
         assert_eq!(d.object_defaults.lock().unwrap().len(), 1);
+        assert!(d.object_defaults.lock().unwrap().get(&None).unwrap().contains_key(&ObjectType::SymmetricKey));
         // Table 428 — a new set REPLACES the old one…
         set_defaults(&d, defaults_req(
             ObjectType::SecretData,
             vec![Attribute::Description("dflt".into())],
-        ), "c").unwrap();
-        let map = d.object_defaults.lock().unwrap();
+        ), &AuthContext::open(), "c").unwrap();
+        let outer = d.object_defaults.lock().unwrap();
+        let map = outer.get(&None).unwrap();
         assert!(!map.contains_key(&ObjectType::SymmetricKey), "old set replaced");
         assert!(map.contains_key(&ObjectType::SecretData));
-        drop(map);
-        // …and an absent Defaults Information removes all defaults.
-        set_defaults(&d, SetDefaultsRequest { defaults_information: None }, "c").unwrap();
+        drop(outer);
+        // …and an absent Defaults Information removes all defaults (the
+        // whole tenant bucket, so the shared outer map is empty again).
+        set_defaults(&d, SetDefaultsRequest { defaults_information: None }, &AuthContext::open(), "c").unwrap();
         assert!(d.object_defaults.lock().unwrap().is_empty());
     }
 
@@ -594,8 +616,9 @@ mod tests {
                 object_types: vec![ObjectType::PublicKey, ObjectType::PrivateKey],
                 attributes: vec![Attribute::Extractable(false)],
             }]),
-        }, "c").unwrap();
-        let map = d.object_defaults.lock().unwrap();
+        }, &AuthContext::open(), "c").unwrap();
+        let outer = d.object_defaults.lock().unwrap();
+        let map = outer.get(&None).unwrap();
         assert_eq!(map.get(&ObjectType::PublicKey), Some(&vec![Attribute::Extractable(false)]));
         assert_eq!(map.get(&ObjectType::PrivateKey), Some(&vec![Attribute::Extractable(false)]));
     }
@@ -612,17 +635,17 @@ mod tests {
                 Attribute::CryptographicUsageMask(UsageMask::ENCRYPT),
                 Attribute::Description("server default".into()),
             ],
-        ), "c").unwrap();
+        ), &AuthContext::open(), "c").unwrap();
 
         // Client omits both → both defaults applied.
         let mut t1 = vec![Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes)];
-        apply_object_defaults(&d, ObjectType::SymmetricKey, &[], &mut t1);
+        apply_object_defaults(&d, ObjectType::SymmetricKey, &[], &mut t1, &AuthContext::open());
         assert!(t1.contains(&Attribute::CryptographicUsageMask(UsageMask::ENCRYPT)));
         assert!(t1.contains(&Attribute::Description("server default".into())));
 
         // Client supplies a mask → the default mask yields.
         let mut t2 = vec![Attribute::CryptographicUsageMask(UsageMask::SIGN)];
-        apply_object_defaults(&d, ObjectType::SymmetricKey, &[], &mut t2);
+        apply_object_defaults(&d, ObjectType::SymmetricKey, &[], &mut t2, &AuthContext::open());
         assert!(t2.contains(&Attribute::CryptographicUsageMask(UsageMask::SIGN)));
         assert!(!t2.contains(&Attribute::CryptographicUsageMask(UsageMask::ENCRYPT)));
 
@@ -630,13 +653,13 @@ mod tests {
         // Common Attributes) also suppresses the default.
         let common = vec![Attribute::CryptographicUsageMask(UsageMask::VERIFY)];
         let mut t3 = Vec::new();
-        apply_object_defaults(&d, ObjectType::SymmetricKey, &common, &mut t3);
+        apply_object_defaults(&d, ObjectType::SymmetricKey, &common, &mut t3, &AuthContext::open());
         assert!(!t3.iter().any(|a| matches!(a, Attribute::CryptographicUsageMask(_))));
         assert!(t3.contains(&Attribute::Description("server default".into())));
 
         // No defaults stored for the type → template untouched.
         let mut t4 = vec![Attribute::Sensitive(true)];
-        apply_object_defaults(&d, ObjectType::Certificate, &[], &mut t4);
+        apply_object_defaults(&d, ObjectType::Certificate, &[], &mut t4, &AuthContext::open());
         assert_eq!(t4, vec![Attribute::Sensitive(true)]);
     }
 

--- a/kmip/src/ops/async_ops.rs
+++ b/kmip/src/ops/async_ops.rs
@@ -37,7 +37,12 @@ use super::helpers::{emit_request, emit_success, fail_err};
 /// it. A job already `Completed` reports `Completed` (succeeded) or
 /// `Failed` (the operation itself errored) — either way, too late to
 /// cancel. `Unavailable` is never produced by this implementation.
-pub fn cancel(deps: &Deps, req: CancelRequest, correlation_id: &str) -> Result<CancelResponse> {
+pub fn cancel(
+    deps: &Deps,
+    req: CancelRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<CancelResponse> {
     emit_request(
         deps,
         correlation_id,
@@ -45,13 +50,18 @@ pub fn cancel(deps: &Deps, req: CancelRequest, correlation_id: &str) -> Result<C
         format!("correlation_value={} bytes", req.asynchronous_correlation_value.len()),
     );
 
+    let requester = auth.identity.as_ref().map(|i| i.username.clone());
     let job = {
         let jobs = deps.async_jobs.lock().unwrap_or_else(|e| e.into_inner());
         jobs.get(&req.asynchronous_correlation_value).cloned()
     };
-    let job = job.ok_or_else(|| {
-        fail_err(deps, correlation_id, "Cancel", KmipError::invalid_asynchronous_correlation_value())
-    })?;
+    // Part F §F7.5 — a foreign tenant's job is indistinguishable from a
+    // nonexistent one (anti-oracle), same as Poll.
+    let job = job
+        .filter(|j| j.state.lock().unwrap_or_else(|e| e.into_inner()).owner == requester)
+        .ok_or_else(|| {
+            fail_err(deps, correlation_id, "Cancel", KmipError::invalid_asynchronous_correlation_value())
+        })?;
 
     let cancellation_result = if job.try_cancel_if_submitted() {
         CancellationResult::Canceled
@@ -83,7 +93,12 @@ pub fn cancel(deps: &Deps, req: CancelRequest, correlation_id: &str) -> Result<C
 /// named job reaches `Completed`. Never re-runs the operation itself
 /// (that would risk double-executing a side-effecting handler); it
 /// only waits on the same `Condvar` the executor signals.
-pub fn process(deps: &Deps, req: ProcessRequest, correlation_id: &str) -> Result<ProcessResponse> {
+pub fn process(
+    deps: &Deps,
+    req: ProcessRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<ProcessResponse> {
     emit_request(
         deps,
         correlation_id,
@@ -91,13 +106,19 @@ pub fn process(deps: &Deps, req: ProcessRequest, correlation_id: &str) -> Result
         format!("correlation_value={} bytes", req.asynchronous_correlation_value.len()),
     );
 
+    let requester = auth.identity.as_ref().map(|i| i.username.clone());
     let job = {
         let jobs = deps.async_jobs.lock().unwrap_or_else(|e| e.into_inner());
         jobs.get(&req.asynchronous_correlation_value).cloned()
     };
-    let job = job.ok_or_else(|| {
-        fail_err(deps, correlation_id, "Process", KmipError::invalid_asynchronous_correlation_value())
-    })?;
+    // Part F §F7.5 — foreign-tenant job indistinguishable from missing
+    // (anti-oracle); Process otherwise blocks until it can read the
+    // outcome, which is another tenant's result.
+    let job = job
+        .filter(|j| j.state.lock().unwrap_or_else(|e| e.into_inner()).owner == requester)
+        .ok_or_else(|| {
+            fail_err(deps, correlation_id, "Process", KmipError::invalid_asynchronous_correlation_value())
+        })?;
 
     job.wait_until_completed();
 
@@ -115,6 +136,7 @@ pub fn process(deps: &Deps, req: ProcessRequest, correlation_id: &str) -> Result
 pub fn query_asynchronous_requests(
     deps: &Deps,
     req: QueryAsynchronousRequestsRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<QueryAsynchronousRequestsResponse> {
     emit_request(
@@ -128,10 +150,18 @@ pub fn query_asynchronous_requests(
         ),
     );
 
+    let requester = auth.identity.as_ref().map(|i| i.username.clone());
     let jobs = deps.async_jobs.lock().unwrap_or_else(|e| e.into_inner());
     let mut requests = Vec::new();
     for (cv, job) in jobs.iter() {
         let st = job.state.lock().unwrap_or_else(|e| e.into_inner());
+        // Part F §F7.5 — a tenant sees only its OWN outstanding jobs,
+        // never another tenant's (which would leak that tenant's
+        // operation types + submission times, and expose correlation
+        // values to guess for a Poll).
+        if st.owner != requester {
+            continue;
+        }
         if st.stage == ProcessingStage::Completed {
             continue;
         }
@@ -183,7 +213,7 @@ mod tests {
 
     fn insert_job(deps: &Deps, op: Operation) -> (Vec<u8>, Arc<AsyncJob>) {
         let cv = deps.new_correlation_value();
-        let job = AsyncJob::new(op);
+        let job = AsyncJob::new(op, None);
         deps.async_jobs.lock().unwrap().insert(cv.clone(), job.clone());
         (cv, job)
     }
@@ -194,6 +224,7 @@ mod tests {
         let err = cancel(
             &deps,
             CancelRequest { asynchronous_correlation_value: vec![0xaa; 8] },
+            &crate::server::auth::AuthContext::open(),
             "t",
         )
         .unwrap_err();
@@ -204,7 +235,7 @@ mod tests {
     fn cancel_submitted_job_reports_canceled_and_poll_sees_the_cancellation() {
         let deps = deps();
         let (cv, job) = insert_job(&deps, Operation::Hash);
-        let resp = cancel(&deps, CancelRequest { asynchronous_correlation_value: cv }, "t").unwrap();
+        let resp = cancel(&deps, CancelRequest { asynchronous_correlation_value: cv }, &crate::server::auth::AuthContext::open(), "t").unwrap();
         assert_eq!(resp.cancellation_result, CancellationResult::Canceled);
         let st = job.state.lock().unwrap();
         assert_eq!(st.stage, ProcessingStage::Completed);
@@ -216,7 +247,7 @@ mod tests {
         let deps = deps();
         let (cv, job) = insert_job(&deps, Operation::Hash);
         job.mark_in_process();
-        let resp = cancel(&deps, CancelRequest { asynchronous_correlation_value: cv }, "t").unwrap();
+        let resp = cancel(&deps, CancelRequest { asynchronous_correlation_value: cv }, &crate::server::auth::AuthContext::open(), "t").unwrap();
         assert_eq!(resp.cancellation_result, CancellationResult::UnableToCancel);
     }
 
@@ -225,12 +256,12 @@ mod tests {
         let deps = deps();
         let (cv_ok, job_ok) = insert_job(&deps, Operation::Hash);
         job_ok.mark_completed(Ok(crate::kmip30::ResponsePayload::Process(ProcessResponse {})));
-        let resp = cancel(&deps, CancelRequest { asynchronous_correlation_value: cv_ok }, "t").unwrap();
+        let resp = cancel(&deps, CancelRequest { asynchronous_correlation_value: cv_ok }, &crate::server::auth::AuthContext::open(), "t").unwrap();
         assert_eq!(resp.cancellation_result, CancellationResult::Completed);
 
         let (cv_err, job_err) = insert_job(&deps, Operation::Hash);
         job_err.mark_completed(Err(KmipError::internal("boom")));
-        let resp = cancel(&deps, CancelRequest { asynchronous_correlation_value: cv_err }, "t").unwrap();
+        let resp = cancel(&deps, CancelRequest { asynchronous_correlation_value: cv_err }, &crate::server::auth::AuthContext::open(), "t").unwrap();
         assert_eq!(resp.cancellation_result, CancellationResult::Failed);
     }
 
@@ -239,7 +270,7 @@ mod tests {
         let deps = deps();
         let (cv, job) = insert_job(&deps, Operation::Hash);
         job.mark_completed(Ok(crate::kmip30::ResponsePayload::Process(ProcessResponse {})));
-        process(&deps, ProcessRequest { asynchronous_correlation_value: cv }, "t").unwrap();
+        process(&deps, ProcessRequest { asynchronous_correlation_value: cv }, &crate::server::auth::AuthContext::open(), "t").unwrap();
     }
 
     #[test]
@@ -248,6 +279,7 @@ mod tests {
         let err = process(
             &deps,
             ProcessRequest { asynchronous_correlation_value: vec![0xbb; 8] },
+            &crate::server::auth::AuthContext::open(),
             "t",
         )
         .unwrap_err();
@@ -262,7 +294,7 @@ mod tests {
         // Completed jobs are no longer "outstanding".
         job_sign.mark_completed(Ok(crate::kmip30::ResponsePayload::Process(ProcessResponse {})));
 
-        let all = query_asynchronous_requests(&deps, QueryAsynchronousRequestsRequest::default(), "t")
+        let all = query_asynchronous_requests(&deps, QueryAsynchronousRequestsRequest::default(), &crate::server::auth::AuthContext::open(), "t")
             .unwrap();
         assert_eq!(all.requests.len(), 1);
         assert_eq!(all.requests[0].asynchronous_correlation_value, cv_hash);
@@ -275,6 +307,7 @@ mod tests {
                 asynchronous_correlation_values: vec![],
                 operations: vec![Operation::Sign],
             },
+            &crate::server::auth::AuthContext::open(),
             "t",
         )
         .unwrap();

--- a/kmip/src/ops/attribute_mutate.rs
+++ b/kmip/src/ops/attribute_mutate.rs
@@ -44,14 +44,17 @@ use super::helpers::{canonical_name, emit_request, emit_success, fail_err, state
 pub fn add_attribute(
     deps: &Deps,
     req: AddAttributeRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<AddAttributeResponse> {
     emit_request(deps, correlation_id, "AddAttribute",
                  format!("uid={} attr={:?}", req.uid, attribute_name(&req.new_attribute)));
 
-    let mut obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "AddAttribute", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    let mut obj = super::helpers::authorize_object(deps, auth, &req.uid, || {
+        KmipError::object_not_found(&req.uid)
+    })
+    .map_err(|e| fail_err(deps, correlation_id, "AddAttribute", e))?;
     policy_gate(deps, &obj, "AddAttribute", correlation_id)?;
 
     // KMIP 3.0 §6.1.48 + §11 — `Name` MUST be unique across the
@@ -97,7 +100,7 @@ pub fn add_attribute(
 
     check_circular_link(deps, "AddAttribute", &req.uid, &req.new_attribute, correlation_id)?;
     apply_attribute(&mut obj, &req.new_attribute);
-    commit_mutation(deps, correlation_id, obj)?;
+    commit_mutation(deps, auth, correlation_id, obj)?;
     emit_success(deps, correlation_id, "AddAttribute");
     Ok(AddAttributeResponse { uid: req.uid })
 }
@@ -107,14 +110,17 @@ pub fn add_attribute(
 pub fn modify_attribute(
     deps: &Deps,
     req: ModifyAttributeRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<ModifyAttributeResponse> {
     emit_request(deps, correlation_id, "ModifyAttribute",
                  format!("uid={} attr={:?}", req.uid, attribute_name(&req.new_attribute)));
 
-    let mut obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "ModifyAttribute", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    let mut obj = super::helpers::authorize_object(deps, auth, &req.uid, || {
+        KmipError::object_not_found(&req.uid)
+    })
+    .map_err(|e| fail_err(deps, correlation_id, "ModifyAttribute", e))?;
     policy_gate(deps, &obj, "ModifyAttribute", correlation_id)?;
 
     // Per KMIP 3.0 §6.1.38 + §11 attribute table — Read-Only attributes
@@ -176,7 +182,7 @@ pub fn modify_attribute(
 
     check_circular_link(deps, "ModifyAttribute", &req.uid, &req.new_attribute, correlation_id)?;
     apply_attribute(&mut obj, &req.new_attribute);
-    commit_mutation(deps, correlation_id, obj)?;
+    commit_mutation(deps, auth, correlation_id, obj)?;
     emit_success(deps, correlation_id, "ModifyAttribute");
     Ok(ModifyAttributeResponse { uid: req.uid })
 }
@@ -186,14 +192,17 @@ pub fn modify_attribute(
 pub fn delete_attribute(
     deps: &Deps,
     req: DeleteAttributeRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<DeleteAttributeResponse> {
     emit_request(deps, correlation_id, "DeleteAttribute",
                  format!("uid={} ref={:?}", req.uid, req.attribute_reference));
 
-    let mut obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "DeleteAttribute", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    let mut obj = super::helpers::authorize_object(deps, auth, &req.uid, || {
+        KmipError::object_not_found(&req.uid)
+    })
+    .map_err(|e| fail_err(deps, correlation_id, "DeleteAttribute", e))?;
     policy_gate(deps, &obj, "DeleteAttribute", correlation_id)?;
 
     // Per §6.1.17:
@@ -268,7 +277,7 @@ pub fn delete_attribute(
             )));
     }
 
-    commit_mutation(deps, correlation_id, obj)?;
+    commit_mutation(deps, auth, correlation_id, obj)?;
     emit_success(deps, correlation_id, "DeleteAttribute");
     Ok(DeleteAttributeResponse { uid: req.uid })
 }
@@ -278,14 +287,17 @@ pub fn delete_attribute(
 pub fn set_attribute(
     deps: &Deps,
     req: SetAttributeRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<SetAttributeResponse> {
     emit_request(deps, correlation_id, "SetAttribute",
                  format!("uid={} attr={:?}", req.uid, attribute_name(&req.new_attribute)));
 
-    let mut obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "SetAttribute", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    let mut obj = super::helpers::authorize_object(deps, auth, &req.uid, || {
+        KmipError::object_not_found(&req.uid)
+    })
+    .map_err(|e| fail_err(deps, correlation_id, "SetAttribute", e))?;
     policy_gate(deps, &obj, "SetAttribute", correlation_id)?;
 
     // Per §6.1.56: "Read-Only attributes SHALL NOT be added or modified
@@ -314,7 +326,7 @@ pub fn set_attribute(
 
     check_circular_link(deps, "SetAttribute", &req.uid, &req.new_attribute, correlation_id)?;
     apply_attribute(&mut obj, &req.new_attribute);
-    commit_mutation(deps, correlation_id, obj)?;
+    commit_mutation(deps, auth, correlation_id, obj)?;
     emit_success(deps, correlation_id, "SetAttribute");
     Ok(SetAttributeResponse { uid: req.uid })
 }
@@ -324,14 +336,17 @@ pub fn set_attribute(
 pub fn adjust_attribute(
     deps: &Deps,
     req: AdjustAttributeRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<AdjustAttributeResponse> {
     emit_request(deps, correlation_id, "AdjustAttribute",
                  format!("uid={} ref={:?} type={:?}", req.uid, req.attribute_reference, req.adjustment_type));
 
-    let mut obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "AdjustAttribute", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    let mut obj = super::helpers::authorize_object(deps, auth, &req.uid, || {
+        KmipError::object_not_found(&req.uid)
+    })
+    .map_err(|e| fail_err(deps, correlation_id, "AdjustAttribute", e))?;
 
     // K22 — §6.1.3.1 Error Handling – Adjust Attribute is the only
     // attribute-mutation error table that lists `Object Archived`
@@ -377,7 +392,7 @@ pub fn adjust_attribute(
         }
     }
 
-    commit_mutation(deps, correlation_id, obj)?;
+    commit_mutation(deps, auth, correlation_id, obj)?;
     emit_success(deps, correlation_id, "AdjustAttribute");
     Ok(AdjustAttributeResponse { uid: req.uid })
 }
@@ -389,9 +404,14 @@ pub fn adjust_attribute(
 /// attribute of the managed object changes (K-13); stamping it here,
 /// immediately before `store.update`, guarantees no mutation op can
 /// forget it.
-fn commit_mutation(deps: &Deps, correlation_id: &str, mut obj: ObjectRecord) -> Result<()> {
+fn commit_mutation(
+    deps: &Deps,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+    mut obj: ObjectRecord,
+) -> Result<()> {
     obj.last_change_date = Some(OffsetDateTime::now_utc());
-    refresh_engine_mechanism_whitelist(deps, correlation_id, &obj);
+    refresh_engine_mechanism_whitelist(deps, auth, correlation_id, &obj);
     deps.store.update(obj)
 }
 
@@ -411,7 +431,12 @@ fn commit_mutation(deps: &Deps, correlation_id: &str, mut obj: ObjectRecord) -> 
 /// family) and have no PKCS#11 concept of a mechanism whitelist. Best-effort,
 /// same posture as key creation: a set_attribute failure here doesn't unwind
 /// the already-decided KMIP-side mutation.
-fn refresh_engine_mechanism_whitelist(deps: &Deps, correlation_id: &str, obj: &ObjectRecord) {
+fn refresh_engine_mechanism_whitelist(
+    deps: &Deps,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+    obj: &ObjectRecord,
+) {
     use crate::kmip30::ObjectType;
     if !matches!(
         obj.object_type,
@@ -419,7 +444,11 @@ fn refresh_engine_mechanism_whitelist(deps: &Deps, correlation_id: &str, obj: &O
     ) {
         return;
     }
-    let Some(session) = deps.engine_session else { return };
+    // Part F §F7 — the mutated object's engine mirror lives in the
+    // CALLING tenant's own token (ownership verified upstream by
+    // authorize_object), so the whitelist refresh uses the caller's
+    // resolved session.
+    let Some(session) = deps.resolve_tenant_session(auth.identity.as_ref()).ok() else { return };
     let Ok(Some(handle)) =
         super::helpers::find_handle_for_object(session, &obj.pkcs11_cka_id, obj.object_type)
     else {
@@ -993,7 +1022,7 @@ mod tests {
         add_attribute(&d, AddAttributeRequest {
             uid: "u".into(),
             new_attribute: Attribute::Name("my-key".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(d.store.get("u").unwrap().unwrap().name.as_deref(), Some("my-key"));
     }
 
@@ -1004,13 +1033,13 @@ mod tests {
         // First add succeeds.
         add_attribute(&d, AddAttributeRequest {
             uid: "u".into(), new_attribute: Attribute::Name("x".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         // Second add on same attribute must fail per §6.1.2 with
         // `AttributeSingleValued` (v0.1 carries only one Name per
         // record; multi-valued Name support would relax this).
         let err = add_attribute(&d, AddAttributeRequest {
             uid: "u".into(), new_attribute: Attribute::Name("y".into()),
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::AttributeSingleValued);
     }
 
@@ -1021,7 +1050,7 @@ mod tests {
         let err = add_attribute(&d, AddAttributeRequest {
             uid: "u".into(),
             new_attribute: Attribute::ObjectType(ObjectType::SymmetricKey),
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         // §6.1.2 — Add against an always-present (single-valued)
         // attribute fails the presence check first → `AttributeSingleValued`.
         assert_eq!(err.result_reason(), ResultReason::AttributeSingleValued);
@@ -1033,11 +1062,11 @@ mod tests {
         put(&d, "u");
         add_attribute(&d, AddAttributeRequest {
             uid: "u".into(), new_attribute: Attribute::Name("v1".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         modify_attribute(&d, ModifyAttributeRequest {
             uid: "u".into(), current_attribute: None,
             new_attribute: Attribute::Name("v2".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(d.store.get("u").unwrap().unwrap().name.as_deref(), Some("v2"));
     }
 
@@ -1052,7 +1081,7 @@ mod tests {
             uid: "u".into(),
             current_attribute: None,
             new_attribute: Attribute::State(crate::kmip30::State::Compromised),
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::AttributeReadOnly);
     }
 
@@ -1069,7 +1098,7 @@ mod tests {
             uid: "u".into(),
             current_attribute: None,
             new_attribute: Attribute::ActivationDate(123_456_789),
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::WrongKeyLifecycleState);
     }
 
@@ -1104,7 +1133,7 @@ mod tests {
             uid: "p".into(),
             current_attribute: None,
             new_attribute: Attribute::ActivationDate(42),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         let rec = d.store.get("p").unwrap().unwrap();
         assert_eq!(rec.activation_date.unwrap().unix_timestamp(), 42);
     }
@@ -1117,7 +1146,7 @@ mod tests {
         let err = modify_attribute(&d, ModifyAttributeRequest {
             uid: "u".into(), current_attribute: None,
             new_attribute: Attribute::Name("v".into()),
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::ItemNotFound);
     }
 
@@ -1127,11 +1156,11 @@ mod tests {
         put(&d, "u");
         add_attribute(&d, AddAttributeRequest {
             uid: "u".into(), new_attribute: Attribute::Name("x".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         delete_attribute(&d, DeleteAttributeRequest {
             uid: "u".into(), current_attribute: None,
             attribute_reference: Some("Name".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert!(d.store.get("u").unwrap().unwrap().name.is_none());
     }
 
@@ -1142,7 +1171,7 @@ mod tests {
         let err = delete_attribute(&d, DeleteAttributeRequest {
             uid: "u".into(), current_attribute: None,
             attribute_reference: Some("CryptographicAlgorithm".into()),
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
     }
 
@@ -1152,7 +1181,7 @@ mod tests {
         put(&d, "u");
         set_attribute(&d, SetAttributeRequest {
             uid: "u".into(), new_attribute: Attribute::Name("first".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(d.store.get("u").unwrap().unwrap().name.as_deref(), Some("first"));
     }
 
@@ -1162,10 +1191,10 @@ mod tests {
         put(&d, "u");
         set_attribute(&d, SetAttributeRequest {
             uid: "u".into(), new_attribute: Attribute::Name("first".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         set_attribute(&d, SetAttributeRequest {
             uid: "u".into(), new_attribute: Attribute::Name("second".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(d.store.get("u").unwrap().unwrap().name.as_deref(), Some("second"));
     }
 
@@ -1180,7 +1209,7 @@ mod tests {
         assert!(d.store.get("u").unwrap().unwrap().last_change_date.is_none());
         add_attribute(&d, AddAttributeRequest {
             uid: "u".into(), new_attribute: Attribute::Name("n".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert!(d.store.get("u").unwrap().unwrap().last_change_date.is_some());
     }
 
@@ -1190,7 +1219,7 @@ mod tests {
         put(&d, "u");
         set_attribute(&d, SetAttributeRequest {
             uid: "u".into(), new_attribute: Attribute::Comment("c".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert!(d.store.get("u").unwrap().unwrap().last_change_date.is_some());
     }
 
@@ -1200,12 +1229,12 @@ mod tests {
         put(&d, "u");
         add_attribute(&d, AddAttributeRequest {
             uid: "u".into(), new_attribute: Attribute::Name("v1".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         let after_add = d.store.get("u").unwrap().unwrap().last_change_date.unwrap();
         modify_attribute(&d, ModifyAttributeRequest {
             uid: "u".into(), current_attribute: None,
             new_attribute: Attribute::Name("v2".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         let after_modify = d.store.get("u").unwrap().unwrap().last_change_date.unwrap();
         assert!(after_modify >= after_add);
     }
@@ -1216,11 +1245,11 @@ mod tests {
         put(&d, "u");
         add_attribute(&d, AddAttributeRequest {
             uid: "u".into(), new_attribute: Attribute::Name("x".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         delete_attribute(&d, DeleteAttributeRequest {
             uid: "u".into(), current_attribute: None,
             attribute_reference: Some("Name".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert!(d.store.get("u").unwrap().unwrap().last_change_date.is_some());
     }
 
@@ -1233,7 +1262,7 @@ mod tests {
             attribute_reference: "Cryptographic Usage Mask".into(),
             adjustment_type: AdjustmentType::Increment,
             adjustment_value: Some(UsageMask::SIGN.bits() as i64),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert!(d.store.get("u").unwrap().unwrap().last_change_date.is_some());
     }
 
@@ -1246,7 +1275,7 @@ mod tests {
             attribute_reference: "Cryptographic Usage Mask".into(),
             adjustment_type: AdjustmentType::Increment,
             adjustment_value: Some(UsageMask::SIGN.bits() as i64),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         let rec = d.store.get("u").unwrap().unwrap();
         assert!(rec.usage_mask.contains(UsageMask::ENCRYPT));
         assert!(rec.usage_mask.contains(UsageMask::SIGN));
@@ -1263,7 +1292,7 @@ mod tests {
         let err = add_attribute(&d, AddAttributeRequest {
             uid: "u".into(),
             new_attribute: Attribute::NextLink("u".into()),
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::CircularLinkError);
         // The link must not have been committed.
         assert!(d.store.get("u").unwrap().unwrap().links.is_empty());
@@ -1281,12 +1310,12 @@ mod tests {
         add_attribute(&d, AddAttributeRequest {
             uid: "b".into(),
             new_attribute: Attribute::NextLink("a".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         // a → b via NextLink now closes a same-type 2-cycle.
         let err = add_attribute(&d, AddAttributeRequest {
             uid: "a".into(),
             new_attribute: Attribute::NextLink("b".into()),
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::CircularLinkError);
     }
 
@@ -1304,12 +1333,12 @@ mod tests {
         add_attribute(&d, AddAttributeRequest {
             uid: "a".into(),
             new_attribute: Attribute::NextLink("b".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         // b → a via PreviousLink (the spec inverse — the back edge).
         add_attribute(&d, AddAttributeRequest {
             uid: "b".into(),
             new_attribute: Attribute::PreviousLink("a".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(
             d.store.get("b").unwrap().unwrap().links.get("PreviousLink").map(String::as_str),
             Some("a")
@@ -1320,11 +1349,11 @@ mod tests {
         add_attribute(&d, AddAttributeRequest {
             uid: "priv".into(),
             new_attribute: Attribute::PublicKeyLink("pub".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         add_attribute(&d, AddAttributeRequest {
             uid: "pub".into(),
             new_attribute: Attribute::PrivateKeyLink("priv".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
     }
 
     /// A non-cyclic link (A → B with no back-link) is accepted.
@@ -1336,7 +1365,7 @@ mod tests {
         add_attribute(&d, AddAttributeRequest {
             uid: "a".into(),
             new_attribute: Attribute::NextLink("b".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(
             d.store.get("a").unwrap().unwrap().links.get("NextLink").map(String::as_str),
             Some("b")
@@ -1359,7 +1388,7 @@ mod tests {
         set_attribute(&d, SetAttributeRequest {
             uid: "u".into(),
             new_attribute: Attribute::CryptographicParameters(cp.clone()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(
             d.store.get("u").unwrap().unwrap().cryptographic_parameters,
             Some(cp),
@@ -1374,7 +1403,7 @@ mod tests {
         set_attribute(&d, SetAttributeRequest {
             uid: "u".into(),
             new_attribute: Attribute::ProtectionLevel(1),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(d.store.get("u").unwrap().unwrap().protection_level, Some(1));
     }
 
@@ -1387,7 +1416,7 @@ mod tests {
         set_attribute(&d, SetAttributeRequest {
             uid: "u".into(),
             new_attribute: Attribute::UsageLimits { total: 500, count: None, unit: Some(1) },
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         let rec = d.store.get("u").unwrap().unwrap();
         assert_eq!(rec.usage_limits_total, Some(500));
         assert_eq!(rec.usage_limits_unit, Some(1));
@@ -1408,14 +1437,14 @@ mod tests {
         let err = set_attribute(&d, SetAttributeRequest {
             uid: "u".into(),
             new_attribute: Attribute::UsageLimits { total: 2000, count: None, unit: None },
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
 
         let err = modify_attribute(&d, ModifyAttributeRequest {
             uid: "u".into(),
             current_attribute: None,
             new_attribute: Attribute::UsageLimits { total: 2000, count: None, unit: None },
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
 
         // The stored value must be untouched by the rejected attempts.
@@ -1432,7 +1461,7 @@ mod tests {
         let err = set_attribute(&d, SetAttributeRequest {
             uid: "u".into(),
             new_attribute: Attribute::CryptographicDomainParameters { qlength: None, recommended_curve: None },
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
     }
 
@@ -1444,7 +1473,7 @@ mod tests {
         let err = set_attribute(&d, SetAttributeRequest {
             uid: "u".into(),
             new_attribute: Attribute::ProtectionStorageMask(1),
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
     }
 
@@ -1456,7 +1485,7 @@ mod tests {
         let err = set_attribute(&d, SetAttributeRequest {
             uid: "u".into(),
             new_attribute: Attribute::KeyFormatType(0x01), // Raw
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
     }
 
@@ -1472,7 +1501,7 @@ mod tests {
         set_attribute(&d, SetAttributeRequest {
             uid: "a".into(),
             new_attribute: Attribute::DerivationBaseObjectLink("b".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(
             d.store.get("a").unwrap().unwrap().links.get("DerivationBaseObjectLink").map(String::as_str),
             Some("b")
@@ -1482,7 +1511,7 @@ mod tests {
         let err = set_attribute(&d, SetAttributeRequest {
             uid: "b".into(),
             new_attribute: Attribute::DerivationBaseObjectLink("a".into()),
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::CircularLinkError);
 
         // b → a via the spec INVERSE (DerivedObjectLink) is the
@@ -1490,7 +1519,7 @@ mod tests {
         set_attribute(&d, SetAttributeRequest {
             uid: "b".into(),
             new_attribute: Attribute::DerivedObjectLink("a".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(
             d.store.get("b").unwrap().unwrap().links.get("DerivedObjectLink").map(String::as_str),
             Some("a")
@@ -1511,7 +1540,7 @@ mod tests {
         add_attribute(&d, AddAttributeRequest {
             uid: "u".into(),
             new_attribute: Attribute::ProtectionLevel(1),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(d.store.get("u").unwrap().unwrap().protection_level, Some(1));
     }
 
@@ -1524,7 +1553,7 @@ mod tests {
         add_attribute(&d, AddAttributeRequest {
             uid: "a".into(),
             new_attribute: Attribute::DerivationBaseObjectLink("b".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(
             d.store.get("a").unwrap().unwrap().links.get("DerivationBaseObjectLink").map(String::as_str),
             Some("b")
@@ -1541,24 +1570,24 @@ mod tests {
         put(&d, "u");
         set_attribute(&d, SetAttributeRequest {
             uid: "u".into(), new_attribute: Attribute::ProtectionLevel(2),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         delete_attribute(&d, DeleteAttributeRequest {
             uid: "u".into(),
             current_attribute: Some(Attribute::ProtectionLevel(2)),
             attribute_reference: None,
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(d.store.get("u").unwrap().unwrap().protection_level, None);
 
         put(&d, "a");
         put(&d, "b");
         set_attribute(&d, SetAttributeRequest {
             uid: "a".into(), new_attribute: Attribute::NextLink("b".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         delete_attribute(&d, DeleteAttributeRequest {
             uid: "a".into(),
             current_attribute: Some(Attribute::NextLink("b".into())),
             attribute_reference: None,
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert!(d.store.get("a").unwrap().unwrap().links.get("NextLink").is_none());
     }
 
@@ -1574,13 +1603,13 @@ mod tests {
         put(&d, "b");
         set_attribute(&d, SetAttributeRequest {
             uid: "a".into(), new_attribute: Attribute::NextLink("b".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         // Simulates the space-cased name `tag_name_from_code` decodes.
         delete_attribute(&d, DeleteAttributeRequest {
             uid: "a".into(),
             current_attribute: None,
             attribute_reference: Some("Next Link".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert!(d.store.get("a").unwrap().unwrap().links.get("NextLink").is_none());
     }
 
@@ -1594,12 +1623,12 @@ mod tests {
         set_attribute(&d, SetAttributeRequest {
             uid: "u".into(),
             new_attribute: Attribute::UsageLimits { total: 100, count: None, unit: Some(1) },
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         delete_attribute(&d, DeleteAttributeRequest {
             uid: "u".into(),
             current_attribute: None,
             attribute_reference: Some("Usage Limits".into()),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(d.store.get("u").unwrap().unwrap().usage_limits_total, None);
     }
 
@@ -1619,14 +1648,14 @@ mod tests {
             uid: "u".into(),
             current_attribute: Some(Attribute::UsageLimits { total: 1000, count: None, unit: None }),
             attribute_reference: None,
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
 
         let err = delete_attribute(&d, DeleteAttributeRequest {
             uid: "u".into(),
             current_attribute: None,
             attribute_reference: Some("Usage Limits".into()),
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
 
         assert_eq!(d.store.get("u").unwrap().unwrap().usage_limits_total, Some(1000));

--- a/kmip/src/ops/catalyst.rs
+++ b/kmip/src/ops/catalyst.rs
@@ -44,6 +44,7 @@ use x509_cert::TbsCertificate;
 
 use crate::error::{KmipError, Result, ResultReason};
 
+#[cfg(test)]
 use super::deps::Deps;
 use super::spki_verify::{verify_with_spki, SpkiVerdict};
 
@@ -123,8 +124,8 @@ pub fn tbs_minus_alt_sig_value(tbs: &TbsCertificate) -> Result<Vec<u8>> {
 /// AND-combining both verdicts — this function only speaks to the alt
 /// half, mirroring the split `verify_composite_signature` uses for
 /// composite-signature's two halves (WP-C4).
-pub fn verify_alt_signature(deps: &Deps, fields: &AltSigFields, tbs_minus_alt: &[u8]) -> Result<SpkiVerdict> {
-    verify_with_spki(deps, &fields.alt_spki, &fields.alt_sig_alg, tbs_minus_alt, &fields.alt_sig_value)
+pub fn verify_alt_signature(session: Option<u32>, fields: &AltSigFields, tbs_minus_alt: &[u8]) -> Result<SpkiVerdict> {
+    verify_with_spki(session, &fields.alt_spki, &fields.alt_sig_alg, tbs_minus_alt, &fields.alt_sig_value)
 }
 
 #[cfg(test)]
@@ -299,7 +300,7 @@ pub(crate) mod tests {
         let reparsed = TbsCertificate::from_der(&tbs_minus_alt).unwrap();
         assert_eq!(reparsed.extensions.as_ref().map(|e| e.len()), Some(2));
 
-        let verdict = verify_alt_signature(&deps, &fields, &tbs_minus_alt).unwrap();
+        let verdict = verify_alt_signature(deps.engine_session, &fields, &tbs_minus_alt).unwrap();
         assert_eq!(verdict, SpkiVerdict::Valid, "a real ML-DSA alt signature over the correct bytes must verify");
     }
 
@@ -311,7 +312,7 @@ pub(crate) mod tests {
 
         let fields = extract_alt_sig_fields(&tbs).unwrap().expect("Catalyst extensions present");
         let tbs_minus_alt = tbs_minus_alt_sig_value(&tbs).unwrap();
-        let verdict = verify_alt_signature(&deps, &fields, &tbs_minus_alt).unwrap();
+        let verdict = verify_alt_signature(deps.engine_session, &fields, &tbs_minus_alt).unwrap();
         assert_eq!(verdict, SpkiVerdict::Invalid, "a tampered alt signature must never verify");
     }
 

--- a/kmip/src/ops/cert_projection.rs
+++ b/kmip/src/ops/cert_projection.rs
@@ -34,8 +34,13 @@ use super::deps::Deps;
 /// all; it remains a safety net for the server-generated paths
 /// (`bootstrap_ca_certificate`, `Certify`, `Re-certify`), where hitting it
 /// would indicate a real bug upstream.
+/// Part F §F7 — `session` is the CALLER's already-resolved tenant
+/// session (`deps.resolve_tenant_session(...)`), so the projected
+/// `CKO_CERTIFICATE` lands in the requesting tenant's own token, not a
+/// shared one. `deps` stays for audit emission only.
 pub(crate) fn project_certificate_to_engine(
     deps: &Deps,
+    session: Option<u32>,
     correlation_id: &str,
     op: &str,
     uid: &str,
@@ -43,7 +48,7 @@ pub(crate) fn project_certificate_to_engine(
     cka_id: &[u8],
     category: u32,
 ) {
-    let Some(session) = deps.engine_session else {
+    let Some(session) = session else {
         return;
     };
     let subject = super::der_x509::extract_subject_der(cert_der).unwrap_or_default();

--- a/kmip/src/ops/certify.rs
+++ b/kmip/src/ops/certify.rs
@@ -2101,6 +2101,7 @@ pub(crate) mod tests {
         super::super::destroy::destroy(
             &f.deps,
             crate::kmip30::DestroyRequest { uid: resp.uid.clone() },
+            &AuthContext::open(),
             "c-wpc-destroy",
         )
         .unwrap();
@@ -2279,6 +2280,7 @@ pub(crate) mod tests {
         super::super::destroy::destroy(
             &f.deps,
             crate::kmip30::DestroyRequest { uid: issued.uid.clone() },
+            &AuthContext::open(),
             "c-destroy-old",
         )
         .unwrap();

--- a/kmip/src/ops/certify.rs
+++ b/kmip/src/ops/certify.rs
@@ -383,6 +383,7 @@ struct SubjectInputs {
 fn resolve_subject(
     deps: &Deps,
     op: &str,
+    auth: &crate::server::auth::AuthContext,
     uid: Option<&str>,
     csr_type: Option<CertificateRequestType>,
     csr: Option<&[u8]>,
@@ -401,7 +402,7 @@ fn resolve_subject(
                     ));
                 }
             }
-            parse_pkcs10_csr(deps, op, csr_bytes)
+            parse_pkcs10_csr(deps.resolve_tenant_session(auth.identity.as_ref()).ok(), op, csr_bytes)
         }
         (None, _) => {
             // No CSR — certify a stored PublicKey by UID. Its DER public
@@ -413,10 +414,12 @@ fn resolve_subject(
                     format!("{op}: neither a Certificate Request nor a Unique Identifier supplied"),
                 )
             })?;
-            let rec = deps
-                .store
-                .get(uid)?
-                .ok_or_else(|| KmipError::object_not_found(uid))?;
+            // Part F §F7.4 — owner-checked: certifying a foreign
+            // tenant's PublicKey fails as the same ObjectNotFound a
+            // missing UID produces (anti-oracle).
+            let rec = super::helpers::authorize_object(deps, auth, uid, || {
+                KmipError::object_not_found(uid)
+            })?;
             if rec.object_type != ObjectType::PublicKey {
                 return Err(KmipError::invalid_object_type(format!(
                     "{op}: {uid:?} is a {:?}, not a PublicKey to certify",
@@ -453,7 +456,12 @@ fn resolve_subject(
                 match rec.key_material.as_deref() {
                     Some(bytes) => bytes,
                     None => {
-                        let session = deps.engine_session.ok_or_else(|| {
+                        // Part F §F7 — the subject's PublicKey lives in
+                        // the CALLING tenant's own token (ownership just
+                        // verified above), so the live SPKI lookup uses
+                        // the caller's resolved session, not the bare
+                        // engine_session field.
+                        let session = deps.resolve_tenant_session(auth.identity.as_ref()).ok().ok_or_else(|| {
                             KmipError::failed(
                                 ResultReason::KeyValueNotPresent,
                                 format!(
@@ -562,13 +570,13 @@ pub(crate) fn live_composite_public_key_spki(
 /// every other signature check removes that gap: any algorithm
 /// `verify_with_spki` supports (RSA/ECDSA/ML-DSA/Ed25519) is now
 /// checkable, PQC included.
-fn parse_pkcs10_csr(deps: &Deps, op: &str, csr: &[u8]) -> Result<SubjectInputs> {
+fn parse_pkcs10_csr(session: Option<u32>, op: &str, csr: &[u8]) -> Result<SubjectInputs> {
     let req = x509_cert::request::CertReq::from_der(csr).map_err(|e| {
         KmipError::invalid_csr(format!("{op}: PKCS#10 CSR DER unparseable: {e}"))
     })?;
     let signed_bytes = req.info.to_der().map_err(der_err)?;
     let verdict = super::spki_verify::verify_with_spki(
-        deps,
+        session,
         &req.info.public_key,
         &req.algorithm,
         &signed_bytes,
@@ -687,6 +695,19 @@ fn sign_tbs_in_engine(
     ca: &CaContext,
     tbs_der: &[u8],
 ) -> Result<Vec<u8>> {
+    // Part F §F7 — DELIBERATELY the bare `deps.engine_session`, not a
+    // per-tenant resolved session (user decision, plan §L): the CA
+    // signing key is server-wide shared infrastructure (one
+    // `DepsConfig::ca_key` designation for the whole server), living in
+    // the server's own base token where the operator configured it —
+    // NOT in any calling tenant's token. The tenant-owned halves of a
+    // Certify (the subject key lookup, the issued certificate's engine
+    // projection) each use the caller's resolved session; only this CA
+    // signature is issued from the base token, matching how a real CA
+    // is shared signing infrastructure with per-tenant subjects. In
+    // Strict/Auto mode with no base token bootstrapped, this correctly
+    // fails closed ("CA key unavailable") — an operator running a
+    // multi-tenant CA must provision the base token the CA key lives in.
     match deps.engine_session {
         Some(session) => sign_tbs_with_plan(deps, session, op, correlation_id, &ca.plan, &ca.private_record, &ca.private_uid, tbs_der),
         None => {
@@ -1036,8 +1057,13 @@ pub fn bootstrap_ca_certificate(
         pkcs11_cka_id: priv_rec.pkcs11_cka_id.clone(),
         ..ObjectRecord::default()
     })?;
+    // Base session, not a tenant session — the CA root cert is server
+    // infrastructure bootstrapped into the server's own token (see
+    // `sign_tbs_in_engine`'s Part F comment); this function has no
+    // caller identity and is not dispatcher-reachable.
     project_certificate_to_engine(
         deps,
+        Some(session),
         "bootstrap",
         "BootstrapCa",
         certificate_uid,
@@ -1050,7 +1076,12 @@ pub fn bootstrap_ca_certificate(
 
 // ── Certify (§6.1.6) ────────────────────────────────────────────────────────
 
-pub fn certify(deps: &Deps, req: CertifyRequest, correlation_id: &str) -> Result<CertifyResponse> {
+pub fn certify(
+    deps: &Deps,
+    req: CertifyRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<CertifyResponse> {
     let started = OffsetDateTime::now_utc();
     emit_request(deps, correlation_id, "Certify", format!(
         "csr={} uid={:?}",
@@ -1058,10 +1089,15 @@ pub fn certify(deps: &Deps, req: CertifyRequest, correlation_id: &str) -> Result
         req.uid
     ));
 
+    // `resolve_ca` deliberately takes no `auth`: the CA designation is
+    // operator config, its key/cert records are server infrastructure
+    // (ownerless), and the lookup is not caller-scoped — see
+    // `sign_tbs_in_engine`'s Part F comment for the full rationale.
     let ca = resolve_ca(deps, "Certify").map_err(|e| fail(deps, correlation_id, "Certify", e))?;
     let subject_inputs = resolve_subject(
         deps,
         "Certify",
+        auth,
         req.uid.as_deref(),
         req.certificate_request_type,
         req.certificate_request.as_deref(),
@@ -1079,6 +1115,7 @@ pub fn certify(deps: &Deps, req: CertifyRequest, correlation_id: &str) -> Result
 
     let uid = store_certificate(
         deps,
+        auth,
         correlation_id,
         &cert_der,
         not_before,
@@ -1098,6 +1135,7 @@ pub fn certify(deps: &Deps, req: CertifyRequest, correlation_id: &str) -> Result
 pub fn recertify(
     deps: &Deps,
     req: ReCertifyRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<ReCertifyResponse> {
     emit_request(deps, correlation_id, "Re-certify", format!("uid={}", req.uid));
@@ -1105,11 +1143,13 @@ pub fn recertify(
     let ca =
         resolve_ca(deps, "Re-certify").map_err(|e| fail(deps, correlation_id, "Re-certify", e))?;
 
-    // The existing certificate being renewed.
-    let existing = deps
-        .store
-        .get(&req.uid)?
-        .ok_or_else(|| fail(deps, correlation_id, "Re-certify", KmipError::object_not_found(&req.uid)))?;
+    // The existing certificate being renewed. Part F §F7.4 —
+    // owner-checked: renewing a foreign tenant's certificate fails as
+    // the same ObjectNotFound a missing UID produces (anti-oracle).
+    let existing = super::helpers::authorize_object(deps, auth, &req.uid, || {
+        KmipError::object_not_found(&req.uid)
+    })
+    .map_err(|e| fail(deps, correlation_id, "Re-certify", e))?;
     if existing.object_type != ObjectType::Certificate {
         return Err(fail(
             deps,
@@ -1153,7 +1193,7 @@ pub fn recertify(
     // in place). The PublicKey link is carried over from the existing
     // certificate record if present.
     let subject_inputs = if let Some(csr) = req.certificate_request.as_deref() {
-        parse_pkcs10_csr(deps, "Re-certify", csr)
+        parse_pkcs10_csr(deps.resolve_tenant_session(auth.identity.as_ref()).ok(), "Re-certify", csr)
             .map_err(|e| fail(deps, correlation_id, "Re-certify", e))?
     } else {
         SubjectInputs {
@@ -1206,7 +1246,11 @@ pub fn recertify(
     // still-active certificate. Best-effort: if the handle is already
     // gone, proceed anyway — the KMIP-side lifecycle transition below is
     // authoritative regardless.
-    if let Some(session) = deps.engine_session {
+    // Part F §F7 — the old cert's engine mirror lives in the CALLING
+    // tenant's own token (its ownership was just verified above), so
+    // its teardown uses the caller's resolved session — the same one
+    // `store_certificate` below projects the replacement into.
+    if let Some(session) = deps.resolve_tenant_session(auth.identity.as_ref()).ok() {
         if let Ok(Some(handle)) = super::helpers::find_handle_for_object(
             session, &existing.pkcs11_cka_id, existing.object_type,
         ) {
@@ -1225,6 +1269,7 @@ pub fn recertify(
     // existing cert's Name (§6.1.50: the new cert takes over the Name).
     let new_uid = store_certificate(
         deps,
+        auth,
         correlation_id,
         &cert_der,
         not_before,
@@ -1274,6 +1319,7 @@ pub fn recertify(
 /// Certificate/PublicKey cross-links. Returns the new UID.
 fn store_certificate(
     deps: &Deps,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
     cert_der: &[u8],
     not_before: OffsetDateTime,
@@ -1307,7 +1353,7 @@ fn store_certificate(
     // projection is still independently addressable and destroyable.
     let cka_id = linked_cka_id.unwrap_or_else(|| uuid::Uuid::new_v4().as_bytes().to_vec());
 
-    deps.store.put(ObjectRecord {
+    deps.store.put(super::helpers::stamp_owner(ObjectRecord {
         uid: uid.clone(),
         object_type: ObjectType::Certificate,
         // X.509 certificate object — the §11 surface treats the DER as
@@ -1341,7 +1387,7 @@ fn store_certificate(
         // below by the same CKA_ID later — see ops::destroy (#141).
         pkcs11_cka_id: cka_id.clone(),
         ..ObjectRecord::default()
-    })?;
+    }, auth))?;
 
     // §6.1.6: "For the public key, the server SHALL create a Certificate
     // Link attribute pointing to the generated certificate."
@@ -1355,6 +1401,7 @@ fn store_certificate(
 
     project_certificate_to_engine(
         deps,
+        deps.resolve_tenant_session(auth.identity.as_ref()).ok(),
         correlation_id,
         "Certify",
         &uid,
@@ -1459,14 +1506,14 @@ pub(crate) mod tests {
     #[test]
     fn certify_without_ca_configured_is_permission_denied() {
         let deps = deps_no_engine();
-        let err = certify(&deps, CertifyRequest::default(), "c").unwrap_err();
+        let err = certify(&deps, CertifyRequest::default(), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::PermissionDenied);
     }
 
     #[test]
     fn certify_ca_key_not_found_is_object_not_found() {
         let deps = deps_no_engine().with_ca_key("urn:nope-priv", "urn:nope-cert");
-        let err = certify(&deps, CertifyRequest::default(), "c").unwrap_err();
+        let err = certify(&deps, CertifyRequest::default(), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::ObjectNotFound);
     }
 
@@ -1482,7 +1529,7 @@ pub(crate) mod tests {
                 ..ObjectRecord::default()
             })
             .unwrap();
-        let err = certify(&deps, CertifyRequest::default(), "c").unwrap_err();
+        let err = certify(&deps, CertifyRequest::default(), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidObjectType);
     }
 
@@ -1508,6 +1555,7 @@ pub(crate) mod tests {
                 certificate_request: Some(csr_der),
                 ..CertifyRequest::default()
             },
+            &AuthContext::open(),
             "c",
         )
         .unwrap_err();
@@ -1647,6 +1695,7 @@ pub(crate) mod tests {
                 certificate_request: Some(csr.der().to_vec()),
                 ..CertifyRequest::default()
             },
+            &AuthContext::open(),
             "c-issue",
         )
         .unwrap();
@@ -1826,6 +1875,7 @@ pub(crate) mod tests {
                 certificate_request: Some(csr_der),
                 ..CertifyRequest::default()
             },
+            &AuthContext::open(),
             "c-pqc-csr",
         )
         .expect("a genuinely self-signature-valid ML-DSA CSR must be accepted");
@@ -1850,6 +1900,7 @@ pub(crate) mod tests {
                 certificate_request: Some(csr_der),
                 ..CertifyRequest::default()
             },
+            &AuthContext::open(),
             "c-pqc-csr-bad",
         )
         .unwrap_err();
@@ -1926,6 +1977,7 @@ pub(crate) mod tests {
         let resp = certify(
             &f.deps,
             CertifyRequest { uid: Some("urn:subj-pub".into()), ..CertifyRequest::default() },
+            &AuthContext::open(),
             "c-supplied",
         )
         .unwrap();
@@ -1986,6 +2038,7 @@ pub(crate) mod tests {
         let resp = certify(
             &f.deps,
             CertifyRequest { uid: Some(subj.public_key_uid.clone()), ..CertifyRequest::default() },
+            &AuthContext::open(),
             "c-fresh",
         )
         .unwrap_or_else(|e| panic!("{algo:?}: Certify a freshly-created PublicKey UID must \
@@ -2067,6 +2120,7 @@ pub(crate) mod tests {
                 certificate_request: Some(csr.der().to_vec()),
                 ..CertifyRequest::default()
             },
+            &AuthContext::open(),
             "c-wpc-leaf",
         )
         .unwrap();
@@ -2155,6 +2209,7 @@ pub(crate) mod tests {
                 ],
                 ..CertifyRequest::default()
             },
+            &AuthContext::open(),
             "c-first",
         )
         .unwrap();
@@ -2167,6 +2222,7 @@ pub(crate) mod tests {
                 offset: Some(3600),
                 ..ReCertifyRequest::default()
             },
+            &AuthContext::open(),
             "c-renew",
         )
         .unwrap();
@@ -2240,6 +2296,7 @@ pub(crate) mod tests {
         let issued = certify(
             &f.deps,
             CertifyRequest { uid: Some("urn:leaf-pub".into()), ..CertifyRequest::default() },
+            &AuthContext::open(),
             "c-initial",
         )
         .unwrap();
@@ -2252,6 +2309,7 @@ pub(crate) mod tests {
         let renewed = recertify(
             &f.deps,
             ReCertifyRequest { uid: issued.uid.clone(), ..ReCertifyRequest::default() },
+            &AuthContext::open(),
             "c-renew",
         )
         .unwrap();
@@ -2475,6 +2533,7 @@ pub(crate) mod tests {
                 certificate_request: None,
                 attributes: vec![],
             },
+            &AuthContext::open(),
             "corr-certify-kem-leaf",
         )
         .expect("Certify the hybrid-KEM leaf under the ML-DSA CA");
@@ -2499,7 +2558,7 @@ pub(crate) mod tests {
         // an otherwise-normal, already-proven certificate.
         let ca_cert_der = deps.store.get("urn:ca-cert").unwrap().unwrap().key_material.unwrap();
         assert_eq!(
-            super::super::validate::validate_chain(&deps, &[leaf_cert_der, ca_cert_der], OffsetDateTime::now_utc()),
+            super::super::validate::validate_chain(deps.engine_session, &[leaf_cert_der, ca_cert_der], OffsetDateTime::now_utc()),
             SignatureValidity::Valid,
             "a hybrid-KEM leaf certified by a plain ML-DSA CA must validate"
         );
@@ -2535,6 +2594,7 @@ pub(crate) mod tests {
                 certificate_request: None,
                 attributes: vec![],
             },
+            &AuthContext::open(),
             "corr-certify-kem-p256-leaf",
         )
         .unwrap_err();

--- a/kmip/src/ops/certify.rs
+++ b/kmip/src/ops/certify.rs
@@ -1422,6 +1422,7 @@ fn fail(deps: &Deps, correlation_id: &str, op: &str, err: KmipError) -> KmipErro
 pub(crate) mod tests {
     use super::*;
     use crate::auditlog::RingSink;
+    use crate::server::auth::AuthContext;
     use crate::store::MemoryStore;
     use std::sync::Arc;
 
@@ -1965,6 +1966,7 @@ pub(crate) mod tests {
                 seed: None,
             },
             "CreateKeyPair",
+            &AuthContext::open(),
             "c-subj-fresh",
         )
         .unwrap();
@@ -2456,7 +2458,7 @@ pub(crate) mod tests {
             seed: None,
         };
         let resp = super::super::create_key_pair::create_key_pair(
-            &deps, req, "CreateKeyPair:KeyAgreement", "corr-hybrid-leaf",
+            &deps, req, "CreateKeyPair:KeyAgreement", &AuthContext::open(), "corr-hybrid-leaf",
         )
         .expect("hybrid-KEM CreateKeyPair");
         let pub_record = deps.store.get(&resp.public_key_uid).unwrap().unwrap();
@@ -2519,7 +2521,7 @@ pub(crate) mod tests {
             seed: None,
         };
         let resp = super::super::create_key_pair::create_key_pair(
-            &deps, req, "CreateKeyPair:KeyAgreement", "corr-hybrid-p256-leaf",
+            &deps, req, "CreateKeyPair:KeyAgreement", &AuthContext::open(), "corr-hybrid-p256-leaf",
         )
         .expect("hybrid-KEM CreateKeyPair");
 

--- a/kmip/src/ops/chameleon.rs
+++ b/kmip/src/ops/chameleon.rs
@@ -54,6 +54,7 @@ use x509_cert::TbsCertificate;
 
 use crate::error::{KmipError, Result, ResultReason};
 
+#[cfg(test)]
 use super::deps::Deps;
 use super::spki_verify::{verify_with_spki, SpkiVerdict};
 
@@ -134,9 +135,10 @@ pub fn reconstruct_delta(primary_tbs: &TbsCertificate) -> Result<Option<DeltaCer
 /// Verify the reconstructed delta certificate's own signature against
 /// its own SPKI — an entirely independent check from the primary
 /// certificate's signature (which `validate.rs`'s ordinary path already
-/// verifies).
-pub fn verify_delta_signature(deps: &Deps, delta: &DeltaCert) -> Result<SpkiVerdict> {
-    verify_with_spki(deps, &delta.spki, &delta.sig_alg, &delta.tbs_der, &delta.signature)
+/// verifies). `session` is the caller's resolved tenant session (Part F
+/// §F7) — see `verify_with_spki`'s doc comment.
+pub fn verify_delta_signature(session: Option<u32>, delta: &DeltaCert) -> Result<SpkiVerdict> {
+    verify_with_spki(session, &delta.spki, &delta.sig_alg, &delta.tbs_der, &delta.signature)
 }
 
 #[cfg(test)]
@@ -341,7 +343,7 @@ pub(crate) mod tests {
             reparsed.extensions.unwrap_or_default().iter().map(|e| e.extn_id.to_string()).collect();
         assert_eq!(remaining_oids, vec![KeyUsage::OID.to_string()]);
 
-        let verdict = verify_delta_signature(&deps, &delta).unwrap();
+        let verdict = verify_delta_signature(deps.engine_session, &delta).unwrap();
         assert_eq!(verdict, SpkiVerdict::Valid, "a real ECDSA delta signature over the reconstructed TBS must verify");
     }
 
@@ -352,7 +354,7 @@ pub(crate) mod tests {
         let (_cert_der, tbs) = build_chameleon_primary_tbs(session, true);
 
         let delta = reconstruct_delta(&tbs).unwrap().expect("DeltaCertificateDescriptor present");
-        let verdict = verify_delta_signature(&deps, &delta).unwrap();
+        let verdict = verify_delta_signature(deps.engine_session, &delta).unwrap();
         assert_eq!(verdict, SpkiVerdict::Invalid, "a tampered delta signature must never verify");
     }
 

--- a/kmip/src/ops/composite_sig.rs
+++ b/kmip/src/ops/composite_sig.rs
@@ -41,7 +41,6 @@ use spki::SubjectPublicKeyInfoOwned;
 use crate::error::{KmipError, Result, ResultReason};
 use crate::kmip30::KmipAlgorithm;
 
-use super::deps::Deps;
 
 /// Fixed Prefix per draft-19 §2.2 — ASCII "CompositeAlgorithmSignatures2025",
 /// byte-identical to `certBuilder.ts::COMPOSITE_DRAFT19_PREFIX` (verified
@@ -286,7 +285,7 @@ impl Drop for DestroyOnDrop {
 /// exactly like it already does for `verify_with_spki`, never surfacing
 /// it as a false `Invalid`.
 pub fn verify_composite_signature(
-    deps: &Deps,
+    session: Option<u32>,
     profile: &CompositeSigProfile,
     composite_spki: &SubjectPublicKeyInfoOwned,
     tbs_der: &[u8],
@@ -295,7 +294,10 @@ pub fn verify_composite_signature(
     use super::spki_verify::SpkiVerdict;
     use softhsmrustv3::constants::CKR_SIGNATURE_INVALID;
 
-    let session = deps.engine_session.ok_or_else(|| {
+    // Part F §F7 — caller-resolved tenant session; see
+    // `spki_verify::verify_with_spki`'s doc comment for why this is an
+    // explicit parameter rather than a `deps.engine_session` read.
+    let session = session.ok_or_else(|| {
         KmipError::failed(
             ResultReason::CryptographicFailure,
             "verify_composite_signature: no engine session — cannot verify without key material",

--- a/kmip/src/ops/create.rs
+++ b/kmip/src/ops/create.rs
@@ -28,9 +28,14 @@ use crate::policy::{Decision, PolicyRequest};
 use crate::store::ObjectRecord;
 
 use super::deps::Deps;
-use super::helpers::{emit_request, emit_success, fail_err};
+use super::helpers::{emit_request, emit_success, fail_err, stamp_owner};
 
-pub fn create(deps: &Deps, mut req: CreateRequest, correlation_id: &str) -> Result<CreateResponse> {
+pub fn create(
+    deps: &Deps,
+    mut req: CreateRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<CreateResponse> {
     let started = OffsetDateTime::now_utc();
     emit_request(
         deps,
@@ -194,7 +199,7 @@ pub fn create(deps: &Deps, mut req: CreateRequest, correlation_id: &str) -> Resu
     let x = super::register_import_export::extract_attrs(&req.template_attribute);
     let initial_state = super::register_import_export::compute_initial_state(now, &x);
     let cp = x.cryptographic_parameters.clone();
-    deps.store.put(ObjectRecord {
+    deps.store.put(stamp_owner(ObjectRecord {
         uid: uid.clone(),
         object_type: req.object_type,
         algorithm: algo,
@@ -234,7 +239,7 @@ pub fn create(deps: &Deps, mut req: CreateRequest, correlation_id: &str) -> Resu
         // with nothing behind it).
         lease_time: Some(3600),
     ..ObjectRecord::default()
-})?;
+}, auth))?;
 
     emit_success(deps, correlation_id, "Create");
 
@@ -424,7 +429,7 @@ rules:
         let resp = create(&d, CreateRequest {
             object_type: ObjectType::SymmetricKey,
             template_attribute: vec![],
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(rec.algorithm, KmipAlgorithm::Aes);
         assert_eq!(rec.object_type, ObjectType::SymmetricKey);
@@ -437,7 +442,7 @@ rules:
         let err = create(&d, CreateRequest {
             object_type: ObjectType::PrivateKey,
             template_attribute: vec![],
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidAttributeValue);
     }
 
@@ -447,7 +452,7 @@ rules:
         let err = create(&d, CreateRequest {
             object_type: ObjectType::SymmetricKey,
             template_attribute: vec![Attribute::CryptographicAlgorithm(KmipAlgorithm::MlDsa87)],
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidAttributeValue);
     }
 
@@ -459,7 +464,7 @@ rules:
             template_attribute: vec![
                 Attribute::CryptographicAlgorithm(KmipAlgorithm::HmacSha256),
             ],
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(rec.algorithm, KmipAlgorithm::HmacSha256);
     }
@@ -495,7 +500,7 @@ rules:
                 Attribute::CryptographicLength(256),
                 Attribute::CryptographicUsageMask(UsageMask::ENCRYPT | UsageMask::DECRYPT),
             ],
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
 
         let handle =

--- a/kmip/src/ops/create.rs
+++ b/kmip/src/ops/create.rs
@@ -71,6 +71,7 @@ pub fn create(
         req.object_type,
         &[],
         &mut req.template_attribute,
+        auth,
     );
 
     let (algorithm_in, algo_enum, key_length, usage_mask) = extract_template(&req.template_attribute);

--- a/kmip/src/ops/create.rs
+++ b/kmip/src/ops/create.rs
@@ -178,6 +178,7 @@ pub fn create(
     // Plane-3: real bridge call when a session is wired. K15 — the
     // audit record is emitted after the generate call with its real rv.
     let cka_id_bytes = Uuid::new_v4().as_bytes().to_vec();
+    let session = deps.resolve_tenant_session(auth.identity.as_ref()).ok();
     let digest_value = engine_generate_symmetric(
         deps,
         correlation_id,
@@ -187,6 +188,7 @@ pub fn create(
         mech,
         &cka_id_bytes,
         usage_mask.unwrap_or_else(UsageMask::empty),
+        session,
     )
     .map_err(|e| fail_err(deps, correlation_id, "Create", e))?;
 
@@ -257,7 +259,15 @@ pub fn create(
 /// session it audits the soft placeholder path and returns `None`
 /// (unit-test store record only). K15 — the `Pkcs11Call` audit record
 /// is emitted after the native call with its real rv; `op` names the
-/// calling KMIP operation in the error mapping.
+/// calling KMIP operation in the error mapping. `session` is the
+/// CALLER's already-resolved `deps.resolve_tenant_session(...)` result,
+/// not re-derived here — this helper has no `auth` context of its own,
+/// and reading the bare `deps.engine_session` field internally (as it
+/// did before this round) silently ignored tenancy: in Strict/Auto
+/// mode that field is never populated, so both Create and symmetric
+/// ReKey would fall through to the test-only placeholder path in
+/// production, leaving multi-tenant symmetric keys without real engine
+/// material on their own tenant's slot.
 pub(crate) fn engine_generate_symmetric(
     deps: &Deps,
     correlation_id: &str,
@@ -267,9 +277,10 @@ pub(crate) fn engine_generate_symmetric(
     mech: u32,
     cka_id_bytes: &[u8],
     usage_mask: UsageMask,
+    session: Option<u32>,
 ) -> Result<Option<Vec<u8>>> {
     let mut digest_value: Option<Vec<u8>> = None;
-    if let Some(session) = deps.engine_session {
+    if let Some(session) = session {
         let (native_fn, result) = match algo {
             KmipAlgorithm::Aes => {
                 let bits = key_length.unwrap_or(256);

--- a/kmip/src/ops/create_key_pair.rs
+++ b/kmip/src/ops/create_key_pair.rs
@@ -1554,6 +1554,7 @@ rules: []
                 certificate_request: None,
                 attributes: vec![],
             },
+            &AuthContext::open(),
             "corr-certify-leaf",
         )
         .expect("Certify the composite leaf under the composite CA");
@@ -1568,7 +1569,7 @@ rules: []
 
         // ── Validate the resulting 2-cert chain end to end.
         assert_eq!(
-            super::super::validate::validate_chain(&d, &[leaf_cert_der.clone(), ca_cert_der], time::OffsetDateTime::now_utc()),
+            super::super::validate::validate_chain(d.engine_session, &[leaf_cert_der.clone(), ca_cert_der], time::OffsetDateTime::now_utc()),
             SignatureValidity::Valid,
             "a CreateKeyPair-generated composite leaf, certified by a composite CA, must validate"
         );
@@ -1578,7 +1579,7 @@ rules: []
         tampered[last] ^= 0xff;
         let ca_cert_der_2 = d.store.get(&ca_cert_uid).unwrap().unwrap().key_material.unwrap();
         assert_eq!(
-            super::super::validate::validate_chain(&d, &[tampered, ca_cert_der_2], time::OffsetDateTime::now_utc()),
+            super::super::validate::validate_chain(d.engine_session, &[tampered, ca_cert_der_2], time::OffsetDateTime::now_utc()),
             SignatureValidity::Invalid,
             "a tampered leaf signature must never come back Valid"
         );

--- a/kmip/src/ops/create_key_pair.rs
+++ b/kmip/src/ops/create_key_pair.rs
@@ -82,12 +82,14 @@ pub fn create_key_pair(
         ObjectType::PrivateKey,
         &req.common_attributes,
         &mut req.private_key_attributes,
+        auth,
     );
     super::allocation_and_config::apply_object_defaults(
         deps,
         ObjectType::PublicKey,
         &req.common_attributes,
         &mut req.public_key_attributes,
+        auth,
     );
 
     // KMIP 3.0 Spec §6.1.10 CreateKeyPair — three distinct attribute

--- a/kmip/src/ops/create_key_pair.rs
+++ b/kmip/src/ops/create_key_pair.rs
@@ -542,7 +542,7 @@ pub fn create_key_pair(
     let priv_state = super::register_import_export::compute_initial_state(now, &priv_x);
     let pub_state = super::register_import_export::compute_initial_state(now, &pub_x);
     let _ = (usage_mask, key_length); // silence unused warnings
-    deps.store.put(ObjectRecord {
+    deps.store.put(super::helpers::stamp_owner(ObjectRecord {
         uid: priv_uid.clone(),
         object_type: ObjectType::PrivateKey,
         algorithm: kmip_algo,
@@ -621,8 +621,8 @@ pub fn create_key_pair(
             protection_storage_mask: Some(0x01),
             lease_time: Some(3600),
     ..ObjectRecord::default()
-})?;
-    deps.store.put(ObjectRecord {
+}, auth))?;
+    deps.store.put(super::helpers::stamp_owner(ObjectRecord {
         uid: pub_uid.clone(),
         object_type: ObjectType::PublicKey,
         algorithm: kmip_algo,
@@ -681,7 +681,7 @@ pub fn create_key_pair(
             protection_storage_mask: Some(0x01),
             lease_time: Some(3600),
     ..ObjectRecord::default()
-})?;
+}, auth))?;
 
     deps.sink.emit(AuditEvent::at(
         OffsetDateTime::now_utc(),

--- a/kmip/src/ops/create_key_pair.rs
+++ b/kmip/src/ops/create_key_pair.rs
@@ -47,8 +47,15 @@ pub fn create_key_pair(
     deps: &Deps,
     mut req: CreateKeyPairRequest,
     op_canonical: &str,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<CreateKeyPairResponse> {
+    // Part F §F7 — this tenant's own engine session (Single mode: the
+    // one shared `engine_session`, unchanged; Auto/Strict: this
+    // identity's own token). `.ok()` folds a resolution failure into
+    // `None`, matching every existing "no engine session" fallback path
+    // below exactly (including the engine-less unit-test placeholder).
+    let session = deps.resolve_tenant_session(auth.identity.as_ref()).ok();
     let started = OffsetDateTime::now_utc();
     deps.sink.emit(AuditEvent::at(
         started,
@@ -257,7 +264,7 @@ pub fn create_key_pair(
     // both handles.
     let (generated, hybrid_pub_material, hybrid_priv_material, hybrid_secondary_cka_id) =
         if let Some(hybrid) = kmip_algo.hybrid_kem() {
-            match deps.engine_session {
+            match session {
                 Some(session) => {
                     let mlkem_cka_id = Uuid::new_v4().as_bytes().to_vec();
                     let classical_cka_id = Uuid::new_v4().as_bytes().to_vec();
@@ -345,7 +352,7 @@ pub fn create_key_pair(
             // `live_composite_public_key_spki`, ported from
             // `certBuilder.ts::buildCompositeCertDraft19`'s own SPKI
             // builder).
-            match deps.engine_session {
+            match session {
                 Some(session) => {
                     let mldsa_cka_id = Uuid::new_v4().as_bytes().to_vec();
                     let classical_cka_id = Uuid::new_v4().as_bytes().to_vec();
@@ -505,6 +512,7 @@ pub fn create_key_pair(
             match engine_generate_keypair(
                 deps,
                 correlation_id,
+                session,
                 kmip_algo,
                 key_length,
                 mech,
@@ -713,6 +721,7 @@ pub(crate) struct GeneratedKeyPair {
 pub(crate) fn engine_generate_keypair(
     deps: &Deps,
     correlation_id: &str,
+    session: Option<u32>,
     kmip_algo: KmipAlgorithm,
     key_length: Option<u32>,
     mech: u32,
@@ -721,7 +730,10 @@ pub(crate) fn engine_generate_keypair(
     usage_pub: UsageMask,
     usage_priv: UsageMask,
 ) -> std::result::Result<GeneratedKeyPair, KmipError> {
-    if let Some(session) = deps.engine_session {
+    // Part F §F7 — `session` is the CALLER's resolved per-tenant engine
+    // session (`Deps::resolve_tenant_session`), not the raw shared
+    // `deps.engine_session` — see the plan's dispatcher-wiring note.
+    if let Some(session) = session {
         // K15 — `native_generate_keypair` emits the Pkcs11Call audit
         // record itself, after the native call, with the real rv and
         // the actual entry-point name.
@@ -1216,6 +1228,7 @@ mod tests {
     use super::*;
     use crate::auditlog::RingSink;
     use crate::policy::{load_from_str, Engine};
+    use crate::server::auth::AuthContext;
     use crate::store::MemoryStore;
     use std::sync::Arc;
 
@@ -1267,7 +1280,7 @@ rules:
     #[test]
     fn defaults_pqc_signing_under_pqc_policy() {
         let (ring, d) = deps_with(PQC_DEFAULTS);
-        let resp = create_key_pair(&d, empty_req(), "CreateKeyPair:Sign", "corr-1").unwrap();
+        let resp = create_key_pair(&d, empty_req(), "CreateKeyPair:Sign", &AuthContext::open(), "corr-1").unwrap();
         let priv_record = d.store.get(&resp.private_key_uid).unwrap().unwrap();
         assert_eq!(priv_record.algorithm, KmipAlgorithm::MlDsa87);
         // Audit: 1 RequestReceived (p2) + 1 PolicyDecided (p1) + 1 Pkcs11Call (p3)
@@ -1280,7 +1293,7 @@ rules:
     fn defaults_pqc_kem_under_pqc_policy() {
         let (_ring, d) = deps_with(PQC_DEFAULTS);
         let resp =
-            create_key_pair(&d, empty_req(), "CreateKeyPair:KeyAgreement", "corr-2").unwrap();
+            create_key_pair(&d, empty_req(), "CreateKeyPair:KeyAgreement", &AuthContext::open(), "corr-2").unwrap();
         let priv_record = d.store.get(&resp.private_key_uid).unwrap().unwrap();
         assert_eq!(priv_record.algorithm, KmipAlgorithm::MlKem1024);
     }
@@ -1294,7 +1307,7 @@ metadata: { name: empty, description: empty, authority: t, effective: "always" }
 rules: []
 "#,
         );
-        let err = create_key_pair(&d, empty_req(), "CreateKeyPair:Sign", "corr-3").unwrap_err();
+        let err = create_key_pair(&d, empty_req(), "CreateKeyPair:Sign", &AuthContext::open(), "corr-3").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::MissingData);
     }
 
@@ -1371,7 +1384,7 @@ rules: []
             public_key_attributes: vec![Attribute::CryptographicParameters(pub_cp.clone())],
             seed: None,
         };
-        let resp = create_key_pair(&d, req, "CreateKeyPair:Sign", "corr-cp").unwrap();
+        let resp = create_key_pair(&d, req, "CreateKeyPair:Sign", &AuthContext::open(), "corr-cp").unwrap();
         let priv_record = d.store.get(&resp.private_key_uid).unwrap().unwrap();
         let pub_record = d.store.get(&resp.public_key_uid).unwrap().unwrap();
         assert_eq!(priv_record.cryptographic_parameters, Some(priv_cp));
@@ -1393,7 +1406,7 @@ rules: []
             public_key_attributes: vec![],
             seed: None,
         };
-        let err = create_key_pair(&d, req, "CreateKeyPair:Sign", "corr-qs").unwrap_err();
+        let err = create_key_pair(&d, req, "CreateKeyPair:Sign", &AuthContext::open(), "corr-qs").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::GeneralFailure);
     }
 
@@ -1412,7 +1425,7 @@ rules: []
             public_key_attributes: vec![],
             seed: None,
         };
-        create_key_pair(&d, req, "CreateKeyPair:Sign", "corr-qs-ok").unwrap();
+        create_key_pair(&d, req, "CreateKeyPair:Sign", &AuthContext::open(), "corr-qs-ok").unwrap();
     }
 
     /// `deps_with` plus a real engine session — same pattern as
@@ -1494,7 +1507,7 @@ rules: []
             public_key_attributes: vec![],
             seed: None,
         };
-        let resp = create_key_pair(&d, req, "CreateKeyPair:Sign", "corr-leaf").unwrap();
+        let resp = create_key_pair(&d, req, "CreateKeyPair:Sign", &AuthContext::open(), "corr-leaf").unwrap();
         let priv_record = d.store.get(&resp.private_key_uid).unwrap().unwrap();
         let pub_record = d.store.get(&resp.public_key_uid).unwrap().unwrap();
 

--- a/kmip/src/ops/decapsulate.rs
+++ b/kmip/src/ops/decapsulate.rs
@@ -21,11 +21,12 @@ use crate::kmip30::{DecapsulateRequest, DecapsulateResponse, PkcsOp, State};
 
 use super::deps::Deps;
 use super::encapsulate::{is_classic_mceliece, is_classical_kem, is_frodokem, is_ml_kem, store_shared_secret};
-use super::helpers::{emit_pkcs11, emit_pkcs11_result, emit_request, emit_success, fail_err, state_name};
+use super::helpers::{authorize_object, emit_pkcs11, emit_pkcs11_result, emit_request, emit_success, fail_err, state_name};
 
 pub fn decapsulate(
     deps: &Deps,
     req: DecapsulateRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<DecapsulateResponse> {
     emit_request(
@@ -35,9 +36,8 @@ pub fn decapsulate(
         format!("uid={} ct_len={}", req.uid, req.data.len()),
     );
 
-    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "Decapsulate", KmipError::object_not_found(&req.uid))
-    })?;
+    let obj = authorize_object(deps, auth, &req.uid, || KmipError::object_not_found(&req.uid))
+        .map_err(|e| fail_err(deps, correlation_id, "Decapsulate", e))?;
 
     // K6 — Decapsulate accepts ML-KEM, the hybrid KEMs, classical
     // ECDH/X25519/X448 in DHKEM mode, and (2026-07-06) BSI TR-02102-1's
@@ -145,7 +145,7 @@ pub fn decapsulate(
     // material never enters this layer (that is the non-extractability fix);
     // ML-KEM implicit rejection is preserved inside the engine.
     if let Some(hybrid) = obj.algorithm.hybrid_kem() {
-        let session = deps.engine_session.ok_or_else(|| {
+        let session = deps.resolve_tenant_session(auth.identity.as_ref()).ok().ok_or_else(|| {
             KmipError::failed(
                 ResultReason::CryptographicFailure,
                 "hybrid KEM decapsulate requires an engine session".to_string(),
@@ -187,12 +187,12 @@ pub fn decapsulate(
             )
         })?;
         emit_pkcs11(deps, correlation_id, "soft::hybrid_kem_decapsulate", None, 0, "CKR_OK");
-        let ss_uid = store_shared_secret(deps, obj.algorithm, shared_secret)?;
+        let ss_uid = store_shared_secret(deps, obj.algorithm, shared_secret, auth)?;
         emit_success(deps, correlation_id, "Decapsulate");
         return Ok(DecapsulateResponse { uid: ss_uid });
     }
 
-    let shared_secret = match deps.engine_session {
+    let shared_secret = match deps.resolve_tenant_session(auth.identity.as_ref()).ok() {
         Some(session) => {
             // Resolve by PKCS#11 class: Decapsulate needs the PRIVATE key, but
             // a CreateKeyPair pair shares one CKA_ID across both halves, so a
@@ -254,7 +254,7 @@ pub fn decapsulate(
         }
     };
 
-    let ss_uid = store_shared_secret(deps, obj.algorithm, shared_secret)?;
+    let ss_uid = store_shared_secret(deps, obj.algorithm, shared_secret, auth)?;
 
     emit_success(deps, correlation_id, "Decapsulate");
 
@@ -279,6 +279,7 @@ mod tests {
     use crate::auditlog::{AuditSink, RingSink};
     use crate::kmip30::{KmipAlgorithm, ObjectType, UsageMask};
     use crate::policy::Engine;
+    use crate::server::auth::AuthContext;
     use crate::store::{MemoryStore, ObjectRecord};
     use std::sync::Arc;
 
@@ -313,6 +314,7 @@ mod tests {
                 data: vec![0u8; 1088],
                 cryptographic_parameters: None,
             },
+            &AuthContext::open(),
             "t",
         )
         .unwrap();
@@ -347,6 +349,7 @@ mod tests {
                 data: vec![0u8; 65], // SEC1 uncompressed P-256 point length
                 cryptographic_parameters: None,
             },
+            &AuthContext::open(),
             "t",
         )
         .unwrap();

--- a/kmip/src/ops/decrypt.rs
+++ b/kmip/src/ops/decrypt.rs
@@ -33,11 +33,16 @@ use crate::policy::{Decision, PolicyRequest};
 
 use super::deps::Deps;
 use super::helpers::{
-    emit_pkcs11, emit_pkcs11_result, emit_request, emit_success, fail_err,
+    authorize_object, emit_pkcs11, emit_pkcs11_result, emit_request, emit_success, fail_err,
     state_name,
 };
 
-pub fn decrypt(deps: &Deps, req: DecryptRequest, correlation_id: &str) -> Result<DecryptResponse> {
+pub fn decrypt(
+    deps: &Deps,
+    req: DecryptRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<DecryptResponse> {
     let started = OffsetDateTime::now_utc();
     emit_request(
         deps,
@@ -46,9 +51,9 @@ pub fn decrypt(deps: &Deps, req: DecryptRequest, correlation_id: &str) -> Result
         format!("uid={} data_len={}", req.uid, req.data.len()),
     );
 
-    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "Decrypt", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    let obj = authorize_object(deps, auth, &req.uid, || KmipError::object_not_found(&req.uid))
+        .map_err(|e| fail_err(deps, correlation_id, "Decrypt", e))?;
 
     // Lifecycle gate per §3.4 — Decrypt allowed in Active / Deactivated /
     // Compromised; PreActive and Destroyed rejected.
@@ -157,9 +162,9 @@ pub fn decrypt(deps: &Deps, req: DecryptRequest, correlation_id: &str) -> Result
 
     // Plane-3: branch on algorithm.
     let resp = if is_ml_kem(obj.algorithm) {
-        decrypt_ml_kem(deps, &req, &obj, correlation_id)
+        decrypt_ml_kem(deps, &req, &obj, auth, correlation_id)
     } else {
-        decrypt_classical(deps, &req, &obj, correlation_id)
+        decrypt_classical(deps, &req, &obj, auth, correlation_id)
     }?;
 
     emit_success(deps, correlation_id, "Decrypt");
@@ -176,6 +181,7 @@ fn decrypt_ml_kem(
     deps: &Deps,
     req: &DecryptRequest,
     obj: &crate::store::ObjectRecord,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<DecryptResponse> {
     let mech = obj.algorithm.to_pkcs11_mech(PkcsOp::Decrypt).ok_or_else(|| {
@@ -186,7 +192,7 @@ fn decrypt_ml_kem(
     })?;
 
     // K15 — the Plane-3 record is emitted after the call with its real rv.
-    let shared_secret = match deps.engine_session {
+    let shared_secret = match deps.resolve_tenant_session(auth.identity.as_ref()).ok() {
         Some(session) => {
             // WP-4 remediation — class-aware, not the ambiguous class-blind
             // find_by_cka_id: a certified private key now shares its
@@ -231,6 +237,7 @@ fn decrypt_classical(
     deps: &Deps,
     req: &DecryptRequest,
     obj: &crate::store::ObjectRecord,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<DecryptResponse> {
     // KMIP 3.0 §6.1.21 — request-time `CryptographicParameters`
@@ -298,7 +305,7 @@ fn decrypt_classical(
         );
         emit_pkcs11_result(deps, correlation_id, "native::decrypt_with_key_bytes", Some(mech), &r);
         r.map_err(|rv| super::helpers::ck_rv_to_kmip_error(rv, "Decrypt"))?
-    } else if let Some(session) = deps.engine_session {
+    } else if let Some(session) = deps.resolve_tenant_session(auth.identity.as_ref()).ok() {
         // WP-4 remediation — class-aware, not the ambiguous class-blind
         // find_by_cka_id: a certified RSA private key now shares its
         // CKA_ID with its public key AND a linked certificate.
@@ -407,7 +414,7 @@ mod tests {
     fn ml_kem_branch_calls_decapsulate() {
         let (ring, d) = deps_and_ring();
         put(&d, "k", KmipAlgorithm::MlKem1024, ObjectType::PrivateKey, State::Active, UsageMask::KEY_AGREEMENT);
-        let r = decrypt(&d, DecryptRequest { uid: "k".into(), data: vec![0u8; 1568], iv: None , cryptographic_parameters: None, aad: None}, "c").unwrap();
+        let r = decrypt(&d, DecryptRequest { uid: "k".into(), data: vec![0u8; 1568], iv: None , cryptographic_parameters: None, aad: None}, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(r.data.len(), 32, "shared secret length");
         // K15 — no engine session: the audit names the soft decap
         // fallback that actually ran, not the classical decrypt path.
@@ -431,7 +438,7 @@ mod tests {
             iv: Some(vec![0; 12]),
             cryptographic_parameters: None,
             aad: None,
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(
             err.result_reason(),
             crate::error::ResultReason::IncompatibleCryptographicUsageMask
@@ -442,7 +449,7 @@ mod tests {
     fn classical_branch_audits_soft_decrypt_path() {
         let (ring, d) = deps_and_ring();
         put(&d, "a", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Active, UsageMask::DECRYPT);
-        let _r = decrypt(&d, DecryptRequest { uid: "a".into(), data: vec![0; 32], iv: Some(vec![0; 12]) , cryptographic_parameters: None, aad: None}, "c").unwrap();
+        let _r = decrypt(&d, DecryptRequest { uid: "a".into(), data: vec![0; 32], iv: Some(vec![0; 12]) , cryptographic_parameters: None, aad: None}, &crate::server::auth::AuthContext::open(), "c").unwrap();
         // K15 — no key material + no session: soft fallback is named.
         let p3: Vec<_> = ring.filter_plane(Plane::Pkcs11);
         assert!(p3.iter().any(|e| matches!(&e.event, EventPayload::Pkcs11Call { function, .. } if function == "soft::placeholder_decrypt")));
@@ -455,14 +462,14 @@ mod tests {
         // AES-GCM (the default for KmipAlgorithm::Aes) requires a
         // 12-byte IV per KMIP 3.0 §6.1.21 + NIST SP 800-38D. Supply
         // one so the lifecycle gate is what's actually under test.
-        let _ = decrypt(&d, DecryptRequest { uid: "a".into(), data: vec![0; 32], iv: Some(vec![0; 12]) , cryptographic_parameters: None, aad: None}, "c").unwrap();
+        let _ = decrypt(&d, DecryptRequest { uid: "a".into(), data: vec![0; 32], iv: Some(vec![0; 12]) , cryptographic_parameters: None, aad: None}, &crate::server::auth::AuthContext::open(), "c").unwrap();
     }
 
     #[test]
     fn decrypt_pre_active_rejected() {
         let (_ring, d) = deps_and_ring();
         put(&d, "a", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::PreActive, UsageMask::DECRYPT);
-        let err = decrypt(&d, DecryptRequest { uid: "a".into(), data: vec![0; 32], iv: None , cryptographic_parameters: None, aad: None}, "c").unwrap_err();
+        let err = decrypt(&d, DecryptRequest { uid: "a".into(), data: vec![0; 32], iv: None , cryptographic_parameters: None, aad: None}, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         // KMIP 3.0 §11: PreActive is a lifecycle-state failure, not
         // "object archived". ObjectArchived (0x0d) is reserved for
         // Destroyed* per §6.1.19.

--- a/kmip/src/ops/deps.rs
+++ b/kmip/src/ops/deps.rs
@@ -90,6 +90,29 @@ impl AsyncJob {
         st.stage = crate::kmip30::ProcessingStage::InProcess;
     }
 
+    /// Atomically transition `Submitted` → `InProcess`, but ONLY if
+    /// still `Submitted`. Returns `false` (state left untouched) if the
+    /// job already left `Submitted` — e.g. `try_cancel_if_submitted`
+    /// won the race against the executor and already marked it
+    /// `Completed`. The executor (real background thread or the eager
+    /// inline fallback) MUST check this before running the real
+    /// operation: calling the unconditional `mark_in_process` here
+    /// instead would clobber an already-recorded cancellation outcome
+    /// with the real result moments later, and briefly resurrect an
+    /// already-`Completed` job's stage back to `InProcess` in between —
+    /// a genuine window where a concurrent `Poll` (sees `Completed`)
+    /// and a `QueryAsynchronousRequests` running immediately after (sees
+    /// the resurrected `InProcess`) visibly disagree about whether the
+    /// same job is done.
+    pub fn try_start_if_submitted(&self) -> bool {
+        let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if st.stage != crate::kmip30::ProcessingStage::Submitted {
+            return false;
+        }
+        st.stage = crate::kmip30::ProcessingStage::InProcess;
+        true
+    }
+
     pub fn mark_completed(&self, outcome: crate::error::Result<crate::kmip30::ResponsePayload>) {
         {
             let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());

--- a/kmip/src/ops/deps.rs
+++ b/kmip/src/ops/deps.rs
@@ -697,28 +697,23 @@ mod tests {
         );
     }
 
-    // Several pre-existing tests elsewhere in this crate (e.g. ops::certify)
-    // call softhsmrustv3::native::session::finalize() directly against the
-    // process-global engine, with no cross-file synchronization — a
-    // pre-existing test-suite hygiene gap, not a production concern
-    // (production KMIP's C_Finalize handling deliberately does NOT call the
-    // real engine finalize(), so this class of interference cannot occur
-    // outside `cargo test`; see the pkcs11_virtual_initialized doc comment
-    // above). Verified: both tests below pass reliably every time run
-    // together in isolation (`cargo test -- <these two test names>`) and
-    // fail only when raced against the full suite's parallel finalize()
-    // callers. Ignored rather than serialized against files this change
-    // doesn't otherwise touch; run manually with `--include-ignored` (or
-    // filtered, as above) to exercise them.
+    // These two tests exercise the real engine (via `resolve_tenant_session`'s
+    // Strict/Auto provisioning path). The engine's session/token state is
+    // process-global and `cargo test` runs lib tests in parallel, so any
+    // other test's `native::session::finalize()` would wipe the slot this
+    // one just provisioned. The fix (2026-07-19, closing §G2's finalize()
+    // gap) is the same one every other engine-touching lib test in this
+    // crate already uses: hold the crate-wide `engine_lock()` for the whole
+    // test. Every finalize()-calling test acquires that same lock (verified:
+    // certify via `ca_engine_deps`, register_import_export, create, and the
+    // helper-based spki_verify/catalyst/chameleon/… fixtures all do), so
+    // while this test holds it no concurrent finalize() can run. Slots 61/72
+    // remain unique to these two tests, and neither finalizes at the end —
+    // the next engine test's own start-of-test finalize() clears them, since
+    // it can only run once this one releases the lock.
     #[test]
-    #[ignore = "races other tests' direct native::session::finalize() calls under full-suite parallelism — run in isolation, see comment above"]
     fn strict_mode_provisions_configured_tenant_and_caches_it() {
-        // NOTE: deliberately no native::session::finalize() here — this
-        // engine state is process-global, and cargo test runs this crate's
-        // lib tests in parallel by default; wiping it would race every
-        // other concurrently-running test that also touches the engine
-        // (several already do). Using a slot (61) no other test in this
-        // crate touches is what makes this test safe without it.
+        let _guard = crate::ops::helpers::engine_lock();
         let alice = crate::server::auth::Identity { username: "alice-strict-provision".into() };
         let config = DepsConfig {
             tenancy_mode: TenancyMode::Strict,
@@ -759,21 +754,15 @@ mod tests {
 
     /// The engine-touching half: one auto-provisioned tenant actually
     /// lands on the requested slot, with a real USER-logged-in session
-    /// and a recorded PIN pair. Deliberately ONE tenant, not two — a
-    /// second provisioning call in the same test opens a window where a
-    /// concurrently-running test's own `finalize()` (several pre-existing
-    /// tests elsewhere in this crate call it, sharing the same
-    /// process-global engine) can land between the two calls and wipe
-    /// the slot this test just created (observed: deterministic
-    /// CKR_SLOT_ID_INVALID under cargo test's default parallelism with a
-    /// two-tenant version of this test). `resolve_tenant_session`'s Auto
-    /// branch runs the identical provisioning path regardless of which
-    /// identity or slot number is involved, so this single-tenant,
-    /// single-engine-call test — combined with the slot-numbering test
-    /// above — covers the same property without the vulnerable window.
+    /// and a recorded PIN pair. Holds `engine_lock()` for the whole test
+    /// (see `strict_mode_provisions_configured_tenant_and_caches_it`),
+    /// which serialises it against every other engine-touching test — so
+    /// a second provisioning call is now safe (no concurrent finalize()
+    /// can land between the two), and this test exercises the cache-hit
+    /// path directly rather than deferring it to the slot-numbering test.
     #[test]
-    #[ignore = "races other tests' direct native::session::finalize() calls under full-suite parallelism — run in isolation, see the comment on strict_mode_provisions_configured_tenant_and_caches_it above"]
     fn auto_mode_provisions_tenant_with_recorded_pins() {
+        let _guard = crate::ops::helpers::engine_lock();
         let config = DepsConfig { tenancy_mode: TenancyMode::Auto, ..DepsConfig::default() };
         let deps = test_deps(config);
         deps.next_auto_slot.store(72, std::sync::atomic::Ordering::Relaxed);

--- a/kmip/src/ops/deps.rs
+++ b/kmip/src/ops/deps.rs
@@ -28,6 +28,13 @@ pub struct StreamCtx {
     /// UID the stream was initialised against — §6.1.21 requires every
     /// part to target the same key.
     pub uid: String,
+    /// Part F §F7.5 — the tenant that opened this stream. A continuation
+    /// part from a different identity is rejected as an unknown
+    /// correlation value (anti-oracle), even though the entry-level
+    /// owner check on the stream's `uid` already blocks the direct
+    /// cross-tenant path — this makes the stream map self-defending
+    /// rather than relying on that distant check.
+    pub owner: Option<String>,
 }
 
 /// Phase 4 — mutable state of one server-tracked asynchronous job
@@ -42,6 +49,16 @@ pub struct AsyncJobState {
     /// the async subsystem changes *when* the client learns the
     /// result, never *what* the result is.
     pub outcome: Option<crate::error::Result<crate::kmip30::ResponsePayload>>,
+    /// Part F §F7.5 — the tenant that submitted this job. `Poll` returns
+    /// the deferred operation's FULL response payload (which for a
+    /// deferred `Get`/`Export`/`Decrypt` is key material), so
+    /// Poll/Cancel/Process must reject a foreign tenant's correlation
+    /// value as the same `Invalid Asynchronous Correlation Value` a
+    /// genuinely unknown one produces, and `QueryAsynchronousRequests`
+    /// must list only the caller's own jobs. Without this, a tenant
+    /// could Poll another tenant's deferred material by guessing its
+    /// (monotonic, predictable) correlation value.
+    pub owner: Option<String>,
 }
 
 /// One server-tracked async job (§6.1.43 Poll / §6.1.5 Cancel / §6.1.44
@@ -59,13 +76,14 @@ pub struct AsyncJob {
 }
 
 impl AsyncJob {
-    pub fn new(operation: crate::kmip30::Operation) -> Arc<Self> {
+    pub fn new(operation: crate::kmip30::Operation, owner: Option<String>) -> Arc<Self> {
         Arc::new(Self {
             state: Mutex::new(AsyncJobState {
                 operation,
                 stage: crate::kmip30::ProcessingStage::Submitted,
                 submitted_at: time::OffsetDateTime::now_utc(),
                 outcome: None,
+                owner,
             }),
             done: Condvar::new(),
         })
@@ -371,8 +389,15 @@ pub struct Deps {
     /// template > Set Defaults > server hardcoded). In-memory only —
     /// server-config state, not a managed object, so it is not
     /// persisted in the object store and is reset on restart.
-    pub object_defaults:
-        Mutex<HashMap<crate::kmip30::ObjectType, Vec<crate::kmip30::Attribute>>>,
+    ///
+    /// Part F §F7.5 — PER-TENANT: the outer key is the setting tenant's
+    /// identity (`None` = the `Single`-mode / anonymous bucket). One
+    /// tenant's `Set Defaults` only affects its own factory operations,
+    /// matching the isolation model of every managed object — a tenant
+    /// can't silently change another tenant's key-generation defaults.
+    pub object_defaults: Mutex<
+        HashMap<Option<String>, HashMap<crate::kmip30::ObjectType, Vec<crate::kmip30::Attribute>>>,
+    >,
     /// Phase 3.2 — client-set §6.1.57 Constraints, replacing the
     /// engine-bounds default `Get Constraints` (§6.1.26) otherwise
     /// reports. `None` ⇒ no client override yet; `get_constraints`

--- a/kmip/src/ops/deps.rs
+++ b/kmip/src/ops/deps.rs
@@ -160,6 +160,13 @@ pub struct DepsConfig {
     /// §6.1.55 RNG Seed behavior — see [`RngSeedMode`]. Defaults to
     /// full-consume (the pre-existing behavior; CS-RNG-O-1 pins it).
     pub rng_seed_mode: RngSeedMode,
+
+    /// Part F §F7.2 — see [`TenancyMode`]. Defaults to `Single` (today's
+    /// behavior, unchanged).
+    pub tenancy_mode: TenancyMode,
+    /// Pre-configured tenants for `TenancyMode::Strict`. Ignored in
+    /// `Single`/`Auto` modes.
+    pub strict_tenants: Vec<StrictTenantConfig>,
 }
 
 /// P2.3 — designates the single key/cert pair the server may use as a
@@ -222,6 +229,59 @@ pub enum RngSeedMode {
 /// exactly 16 regardless of the client-supplied seed length.
 pub const RNG_SEED_PARTIAL_CONSUME_CAP: usize = 16;
 
+/// Part F (rust-hsm-perf-bench-scenario-plan-07182026.md §F7.2) — how a
+/// KMIP client identity gets its own PKCS#11 token. `Single` (the
+/// default) is EXACTLY today's behavior: every request shares
+/// `Deps::engine_session`, one tenant, zero config needed, zero change
+/// to any of the ~60 existing `deps.engine_session` call sites.
+///
+/// STATUS: the resolution primitive (`Deps::resolve_tenant_session`)
+/// exists and is tested for all three modes, but is NOT YET called by
+/// the dispatcher or any op handler — those still read
+/// `deps.engine_session` directly, so today every deployment runs
+/// (and behaves) as `Single` regardless of this field's value. Wiring
+/// the dispatcher to authenticate-then-resolve-then-thread the tenant
+/// session into op handlers is the remaining piece of §F7 (a
+/// signature-level change across every op handler, tracked separately —
+/// see the plan's F7/rev-5 status note).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum TenancyMode {
+    #[default]
+    Single,
+    /// First connection from a CA-validated identity auto-provisions a
+    /// fresh token: next free slot, a server-generated PIN recorded in
+    /// `Deps::tenant_pins` (readable by the operator) so the token
+    /// stays openable by out-of-band PKCS#11 tooling — the user's
+    /// "per-tenant configured PINs" decision, reconciled with
+    /// auto-onboarding by having the server mint (rather than
+    /// pre-collect) the PIN.
+    Auto,
+    /// Only identities in `DepsConfig::strict_tenants` may operate;
+    /// every other identity is rejected before touching the engine.
+    Strict,
+}
+
+/// One pre-configured tenant for `TenancyMode::Strict` — identity, the
+/// PKCS#11 slot it owns, and its token's PINs (per-tenant CONFIGURED
+/// PINs, per the user's decision — the same PIN an operator could use
+/// to open this tenant's token directly through raw PKCS#11 tooling).
+#[derive(Clone, Debug)]
+pub struct StrictTenantConfig {
+    pub identity: crate::server::auth::Identity,
+    pub slot: u32,
+    pub so_pin: String,
+    pub user_pin: String,
+}
+
+/// A provisioned tenant's live engine binding — the slot its token
+/// occupies and the open, USER-logged-in session requests for that
+/// tenant should use.
+#[derive(Clone, Copy, Debug)]
+pub struct TenantCtx {
+    pub slot: u32,
+    pub engine_session: u32,
+}
+
 impl DepsConfig {
     /// `true` when a credential store is configured (auth enforced).
     pub fn auth_enabled(&self) -> bool {
@@ -239,6 +299,8 @@ impl Default for DepsConfig {
             auth_users: Vec::new(), // open-auth — replay harness depends on this
             ca_key: None,           // not a CA unless explicitly configured
             rng_seed_mode: RngSeedMode::FullConsume,
+            tenancy_mode: TenancyMode::Single, // today's behavior, unchanged
+            strict_tenants: Vec::new(),
         }
     }
 }
@@ -260,6 +322,20 @@ pub struct Deps {
     /// engine and passes `Some(session)`. Closes the §12.7.7 lock from
     /// `IMPLEMENTATION_PLAN.md` once every op handler honours this branch.
     pub engine_session: Option<u32>,
+    /// Part F §F7.2 — live per-identity tenant bindings (populated by
+    /// `resolve_tenant_session` in `Auto`/`Strict` modes; empty and
+    /// unused in `Single` mode). Slot 0 is reserved for `engine_session`
+    /// (the `Single`-mode / `cli.slot` default); tenant provisioning
+    /// starts at `next_auto_slot`.
+    pub tenants: Mutex<HashMap<crate::server::auth::Identity, TenantCtx>>,
+    /// `Auto`-mode server-generated PINs, recorded so an operator can
+    /// read them back and open a tenant's token directly through raw
+    /// PKCS#11 tooling (the user's "per-tenant configured PINs"
+    /// decision, reconciled with auto-onboarding — see [`TenancyMode::Auto`]).
+    pub tenant_pins: Mutex<HashMap<crate::server::auth::Identity, (String, String)>>,
+    /// Next PKCS#11 slot `Auto` mode will provision. Starts at 1 (slot 0
+    /// is the `Single`-mode default token).
+    pub next_auto_slot: std::sync::atomic::AtomicU32,
     /// Active multi-part Encrypt/Decrypt streams, keyed by the
     /// server-issued `Correlation Value` (KMIP 3.0 §6.1.21). Lives on
     /// `Deps` so streams survive across requests on the same server.
@@ -332,6 +408,9 @@ impl Deps {
             sink,
             config,
             engine_session: None,
+            tenants: Mutex::new(HashMap::new()),
+            tenant_pins: Mutex::new(HashMap::new()),
+            next_auto_slot: std::sync::atomic::AtomicU32::new(1),
             streams: Mutex::new(HashMap::new()),
             next_correlation: std::sync::atomic::AtomicU64::new(1),
             object_defaults: Mutex::new(HashMap::new()),
@@ -369,6 +448,112 @@ impl Deps {
         self
     }
 
+    /// Part F §F7.2 — resolve the PKCS#11 engine session an authenticated
+    /// request should use.
+    ///
+    /// `Single` mode (default) returns `self.engine_session` unchanged —
+    /// `identity` is ignored, so this is a drop-in, zero-behavior-change
+    /// replacement for reading `deps.engine_session` directly wherever a
+    /// call site is migrated to it.
+    ///
+    /// `Auto`/`Strict` require `identity`; each looks up (or, in `Auto`,
+    /// provisions) that identity's own token, so different tenants get
+    /// different sessions on different slots — which is what makes the
+    /// Part F engine-side isolation gate (already merged) actually
+    /// separate KMIP clients from each other, instead of every client
+    /// sharing the one `Single`-mode token.
+    pub fn resolve_tenant_session(
+        &self,
+        identity: Option<&crate::server::auth::Identity>,
+    ) -> crate::error::Result<u32> {
+        match self.config.tenancy_mode {
+            TenancyMode::Single => self.engine_session.ok_or_else(|| {
+                crate::error::KmipError::failed(
+                    crate::error::ResultReason::GeneralFailure,
+                    "engine not initialised (no engine_session)",
+                )
+            }),
+            TenancyMode::Strict => {
+                let identity = identity.ok_or_else(Self::no_identity_err)?;
+                if let Some(ctx) = self.tenants_lock().get(identity) {
+                    return Ok(ctx.engine_session);
+                }
+                let cfg = self
+                    .config
+                    .strict_tenants
+                    .iter()
+                    .find(|t| &t.identity == identity)
+                    .cloned()
+                    .ok_or_else(|| {
+                        crate::error::KmipError::failed(
+                            crate::error::ResultReason::AuthenticationNotSuccessful,
+                            "identity is not a configured strict tenant",
+                        )
+                    })?;
+                self.provision_tenant(identity.clone(), cfg.slot, &cfg.so_pin, &cfg.user_pin)
+            }
+            TenancyMode::Auto => {
+                let identity = identity.ok_or_else(Self::no_identity_err)?;
+                if let Some(ctx) = self.tenants_lock().get(identity) {
+                    return Ok(ctx.engine_session);
+                }
+                let slot = self
+                    .next_auto_slot
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let so_pin = generate_tenant_pin();
+                let user_pin = generate_tenant_pin();
+                let session = self.provision_tenant(identity.clone(), slot, &so_pin, &user_pin)?;
+                self.tenant_pins
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .insert(identity.clone(), (so_pin, user_pin));
+                Ok(session)
+            }
+        }
+    }
+
+    fn no_identity_err() -> crate::error::KmipError {
+        crate::error::KmipError::failed(
+            crate::error::ResultReason::AuthenticationNotSuccessful,
+            "this tenancy mode requires an authenticated identity",
+        )
+    }
+
+    fn tenants_lock(&self) -> std::sync::MutexGuard<'_, HashMap<crate::server::auth::Identity, TenantCtx>> {
+        self.tenants.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Bring a brand-new tenant's token online (§F7.2: `ensure_slot` +
+    /// `C_InitToken` + `C_InitPIN` + USER login, via the engine's own
+    /// `bootstrap_default_token` helper — the same sequence the
+    /// `Single`-mode production binary already runs for slot 0) and
+    /// record its live session in `self.tenants`.
+    fn provision_tenant(
+        &self,
+        identity: crate::server::auth::Identity,
+        slot: u32,
+        so_pin: &str,
+        user_pin: &str,
+    ) -> crate::error::Result<u32> {
+        // Multi-slot activation hook — the engine boots single-slot (slot
+        // 0), and `C_InitToken` on any other slot fails CKR_SLOT_ID_INVALID
+        // until this runs first (found the hard way during the
+        // hsm-perf-bench P0 spikes; see the plan's §E2/§F1).
+        softhsmrustv3::state::ensure_slot(slot);
+        let label = format!("kmip-tenant-{}", identity.username);
+        let session = softhsmrustv3::native::session::bootstrap_default_token(
+            slot, so_pin, user_pin, &label,
+        )
+        .map_err(|rv| {
+            crate::error::KmipError::failed(
+                crate::error::ResultReason::GeneralFailure,
+                format!("tenant token provisioning failed for slot {slot}: engine rv=0x{rv:x}"),
+            )
+        })?;
+        self.tenants_lock().insert(identity, TenantCtx { slot, engine_session: session });
+        Ok(session)
+    }
+
     /// P2.3 — designate the CA key/cert pair this server signs issuances
     /// with (see [`CaKeyDesignation`]). Used by tests and the production
     /// binary's `--ca-key` / `--ca-cert` flags.
@@ -379,6 +564,19 @@ impl Deps {
         });
         self
     }
+}
+
+/// Part F §F7.2 (`TenancyMode::Auto`) — mint a fresh PIN for a
+/// newly-provisioned tenant token. 16 random bytes, hex-encoded (32
+/// chars) — well over PKCS#11's typical minimum PIN length, and, being
+/// server-generated and per-tenant, never reused across tenants. `hex`
+/// is dev-dependency-only in this crate (see Cargo.toml), so this is a
+/// small inline encoder rather than a new production dependency.
+fn generate_tenant_pin() -> String {
+    use rand::RngCore;
+    let mut bytes = [0u8; 16];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 #[cfg(test)]
@@ -403,5 +601,152 @@ mod tests {
         let c = DepsConfig::default();
         assert!(!c.vendor_identification.is_empty());
         assert!(!c.server_version.is_empty());
+    }
+
+    // ── Part F §F7.2 — resolve_tenant_session ────────────────────────────
+    // Distinct, high slot numbers per test (the engine's slot/token store
+    // is process-global) to avoid colliding with other tests' slot 0 use
+    // or with each other under cargo test's default parallelism.
+
+    fn test_deps(config: DepsConfig) -> Deps {
+        let sink: Arc<dyn AuditSink> = Arc::new(RingSink::new(64));
+        Deps::new(Engine::permissive(), Arc::new(MemoryStore::new()), sink, config)
+    }
+
+    #[test]
+    fn single_mode_returns_engine_session_ignoring_identity() {
+        let deps = test_deps(DepsConfig::default()).with_engine_session(4242);
+        assert_eq!(deps.resolve_tenant_session(None).unwrap(), 4242);
+        let someone = crate::server::auth::Identity { username: "anyone".into() };
+        assert_eq!(deps.resolve_tenant_session(Some(&someone)).unwrap(), 4242);
+    }
+
+    #[test]
+    fn single_mode_without_engine_session_errors() {
+        let deps = test_deps(DepsConfig::default());
+        assert!(deps.resolve_tenant_session(None).is_err());
+    }
+
+    #[test]
+    fn strict_mode_rejects_no_identity_and_unconfigured_identity() {
+        let alice = crate::server::auth::Identity { username: "alice-strict".into() };
+        let config = DepsConfig {
+            tenancy_mode: TenancyMode::Strict,
+            strict_tenants: vec![StrictTenantConfig {
+                identity: alice.clone(),
+                slot: 60,
+                so_pin: "so-pin-60".into(),
+                user_pin: "user-pin-60".into(),
+            }],
+            ..DepsConfig::default()
+        };
+        let deps = test_deps(config);
+        assert!(deps.resolve_tenant_session(None).is_err(), "no identity must be rejected");
+        let mallory = crate::server::auth::Identity { username: "mallory-not-configured".into() };
+        assert!(
+            deps.resolve_tenant_session(Some(&mallory)).is_err(),
+            "an identity absent from strict_tenants must be rejected"
+        );
+    }
+
+    // Several pre-existing tests elsewhere in this crate (e.g. ops::certify)
+    // call softhsmrustv3::native::session::finalize() directly against the
+    // process-global engine, with no cross-file synchronization — a
+    // pre-existing test-suite hygiene gap, not a production concern
+    // (production KMIP's C_Finalize handling deliberately does NOT call the
+    // real engine finalize(), so this class of interference cannot occur
+    // outside `cargo test`; see the pkcs11_virtual_initialized doc comment
+    // above). Verified: both tests below pass reliably every time run
+    // together in isolation (`cargo test -- <these two test names>`) and
+    // fail only when raced against the full suite's parallel finalize()
+    // callers. Ignored rather than serialized against files this change
+    // doesn't otherwise touch; run manually with `--include-ignored` (or
+    // filtered, as above) to exercise them.
+    #[test]
+    #[ignore = "races other tests' direct native::session::finalize() calls under full-suite parallelism — run in isolation, see comment above"]
+    fn strict_mode_provisions_configured_tenant_and_caches_it() {
+        // NOTE: deliberately no native::session::finalize() here — this
+        // engine state is process-global, and cargo test runs this crate's
+        // lib tests in parallel by default; wiping it would race every
+        // other concurrently-running test that also touches the engine
+        // (several already do). Using a slot (61) no other test in this
+        // crate touches is what makes this test safe without it.
+        let alice = crate::server::auth::Identity { username: "alice-strict-provision".into() };
+        let config = DepsConfig {
+            tenancy_mode: TenancyMode::Strict,
+            strict_tenants: vec![StrictTenantConfig {
+                identity: alice.clone(),
+                slot: 61,
+                so_pin: "so-pin-61".into(),
+                user_pin: "user-pin-61".into(),
+            }],
+            ..DepsConfig::default()
+        };
+        let deps = test_deps(config);
+        let session1 = deps.resolve_tenant_session(Some(&alice)).expect("provision must succeed");
+        assert_eq!(softhsmrustv3::state::session_slot(session1), Some(61));
+        // Second call for the same identity returns the SAME session — no
+        // re-provisioning (which would fail: C_InitToken on a token with
+        // an open session errors CKR_SESSION_EXISTS).
+        let session2 = deps.resolve_tenant_session(Some(&alice)).expect("cached lookup must succeed");
+        assert_eq!(session1, session2, "second resolve must reuse the cached session");
+    }
+
+    /// Slot allocation is pure Rust logic (`AtomicU32::fetch_add`, no
+    /// engine call) — verified without touching the process-global
+    /// engine at all, so this half of "distinct tenants get distinct
+    /// slots" is fully race-free regardless of what other tests do
+    /// concurrently.
+    #[test]
+    fn auto_mode_allocates_a_fresh_slot_number_per_new_identity() {
+        let config = DepsConfig { tenancy_mode: TenancyMode::Auto, ..DepsConfig::default() };
+        let deps = test_deps(config);
+        let start = deps.next_auto_slot.load(std::sync::atomic::Ordering::Relaxed);
+        let first = deps.next_auto_slot.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let second = deps.next_auto_slot.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(first, start);
+        assert_eq!(second, start + 1);
+        assert_ne!(first, second, "each new identity gets a distinct slot number");
+    }
+
+    /// The engine-touching half: one auto-provisioned tenant actually
+    /// lands on the requested slot, with a real USER-logged-in session
+    /// and a recorded PIN pair. Deliberately ONE tenant, not two — a
+    /// second provisioning call in the same test opens a window where a
+    /// concurrently-running test's own `finalize()` (several pre-existing
+    /// tests elsewhere in this crate call it, sharing the same
+    /// process-global engine) can land between the two calls and wipe
+    /// the slot this test just created (observed: deterministic
+    /// CKR_SLOT_ID_INVALID under cargo test's default parallelism with a
+    /// two-tenant version of this test). `resolve_tenant_session`'s Auto
+    /// branch runs the identical provisioning path regardless of which
+    /// identity or slot number is involved, so this single-tenant,
+    /// single-engine-call test — combined with the slot-numbering test
+    /// above — covers the same property without the vulnerable window.
+    #[test]
+    #[ignore = "races other tests' direct native::session::finalize() calls under full-suite parallelism — run in isolation, see the comment on strict_mode_provisions_configured_tenant_and_caches_it above"]
+    fn auto_mode_provisions_tenant_with_recorded_pins() {
+        let config = DepsConfig { tenancy_mode: TenancyMode::Auto, ..DepsConfig::default() };
+        let deps = test_deps(config);
+        deps.next_auto_slot.store(72, std::sync::atomic::Ordering::Relaxed);
+
+        let alice = crate::server::auth::Identity { username: "alice-auto-single".into() };
+        let session = deps.resolve_tenant_session(Some(&alice)).expect("auto-provision alice");
+        assert_eq!(softhsmrustv3::state::session_slot(session), Some(72));
+
+        // Cached on the second call (no re-provisioning).
+        let session2 = deps.resolve_tenant_session(Some(&alice)).expect("cached lookup");
+        assert_eq!(session, session2);
+
+        // PINs were generated and recorded (readable by an operator, per
+        // the user's "per-tenant configured PINs" decision).
+        let pins = deps.tenant_pins.lock().unwrap();
+        let (so_pin, user_pin) = pins.get(&alice).expect("PIN pair recorded");
+        assert_eq!(so_pin.len(), 32, "16 random bytes hex-encoded");
+        assert_ne!(so_pin, user_pin, "SO and USER PINs must differ");
+        drop(pins);
+
+        // Auto mode still requires an identity.
+        assert!(deps.resolve_tenant_session(None).is_err());
     }
 }

--- a/kmip/src/ops/derive_key.rs
+++ b/kmip/src/ops/derive_key.rs
@@ -71,6 +71,7 @@ const LINK_DERIVED_OBJECT: &str = "DerivedObjectLink";
 pub fn derive_key(
     deps: &Deps,
     mut req: DeriveKeyRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<DeriveKeyResponse> {
     let started = OffsetDateTime::now_utc();
@@ -111,10 +112,13 @@ pub fn derive_key(
     // (Incompatible Cryptographic Usage Mask, K12/audit K-9).
     let mut bases: Vec<ObjectRecord> = Vec::with_capacity(req.uids.len());
     for uid in &req.uids {
-        let obj = deps
-            .store
-            .get(uid)?
-            .ok_or_else(|| fail(KmipError::object_not_found(uid)))?;
+        // Part F §F7.4 — owner-checked: deriving from a foreign tenant's
+        // base object fails as the same ObjectNotFound a missing UID
+        // produces (anti-oracle).
+        let obj = super::helpers::authorize_object(deps, auth, uid, || {
+            KmipError::object_not_found(uid)
+        })
+        .map_err(&fail)?;
         if obj.state != State::Active {
             return Err(fail(super::helpers::non_active_state_error(&obj.uid, obj.state)));
         }
@@ -272,7 +276,7 @@ pub fn derive_key(
                      (algorithm {:?}; §7.13 — Cryptographic Parameters are ignored)",
                     base.uid, base.algorithm
                 ))))?;
-            let out = hmac_prf(deps, correlation_id, base, hash)?(data)?;
+            let out = hmac_prf(deps, deps.resolve_tenant_session(auth.identity.as_ref()).ok(), correlation_id, base, hash)?(data)?;
             // §6.1.18 — "If the specified length exceeds the output of
             // the derivation method, then the server SHALL return an
             // error." Single HMAC ⇒ output = one hash block.
@@ -378,7 +382,7 @@ pub fn derive_key(
             let hash = request_hash
                 .or_else(|| base_key_prf_hash(base))
                 .unwrap_or(HashingAlgorithm::Sha256);
-            let prf = hmac_prf(deps, correlation_id, base, hash)?;
+            let prf = hmac_prf(deps, deps.resolve_tenant_session(auth.identity.as_ref()).ok(), correlation_id, base, hash)?;
             let mut out: Vec<u8> = Vec::with_capacity(len_bytes);
             let mut counter: u32 = 1;
             while out.len() < len_bytes {
@@ -405,7 +409,9 @@ pub fn derive_key(
                      Derivation Data (§7.13 Table 465)",
                 ))
             })?;
-            let session = deps.engine_session.ok_or_else(|| {
+            // Part F §F7 — the base private key lives in the caller's
+            // own token (ownership verified above).
+            let session = deps.resolve_tenant_session(auth.identity.as_ref()).ok().ok_or_else(|| {
                 fail(KmipError::failed(
                     ResultReason::CryptographicFailure,
                     "Asymmetric Key derivation requires an engine session".to_string(),
@@ -448,7 +454,7 @@ pub fn derive_key(
     // machinery) so MAC / future derives can use the engine handle;
     // other derived material stays KMIP-store-held (same as Register'd
     // raw AES, which Encrypt serves from `key_material`).
-    if let (Some(session), ObjectType::SymmetricKey) = (deps.engine_session, req.object_type) {
+    if let (Some(session), ObjectType::SymmetricKey) = (deps.resolve_tenant_session(auth.identity.as_ref()).ok(), req.object_type) {
         if matches!(
             derived_algorithm,
             KmipAlgorithm::HmacSha256 | KmipAlgorithm::HmacSha384 | KmipAlgorithm::HmacSha512
@@ -473,7 +479,7 @@ pub fn derive_key(
     // mirror DerivedObjectLink on EVERY base below).
     links.insert(LINK_DERIVATION_BASE.to_string(), base.uid.clone());
 
-    deps.store.put(ObjectRecord {
+    deps.store.put(super::helpers::stamp_owner(ObjectRecord {
         uid: uid.clone(),
         object_type: req.object_type,
         algorithm: derived_algorithm,
@@ -508,7 +514,7 @@ pub fn derive_key(
         // KMIP §11 Fresh = True for server-generated objects.
         fresh: Some(true),
         ..ObjectRecord::default()
-    })?;
+    }, auth))?;
 
     // §6.1.18 — "the server SHALL create a Derived Object Link
     // attribute pointing to the … object derived as a result of this
@@ -542,12 +548,13 @@ fn base_key_prf_hash(base: &ObjectRecord) -> Option<HashingAlgorithm> {
 #[allow(clippy::type_complexity)]
 fn hmac_prf<'a>(
     deps: &'a Deps,
+    session: Option<u32>,
     correlation_id: &'a str,
     base: &'a ObjectRecord,
     hash: HashingAlgorithm,
 ) -> Result<Box<dyn Fn(&[u8]) -> Result<Vec<u8>> + 'a>> {
     let fail = move |e: KmipError| fail_err(deps, correlation_id, "DeriveKey", e);
-    match (&base.key_material, deps.engine_session) {
+    match (&base.key_material, session) {
         (Some(key), _) => {
             let key = key.clone();
             Ok(Box::new(move |data: &[u8]| {
@@ -735,7 +742,7 @@ mod tests {
                 ..Default::default()
             },
             aes_template(256),
-        ), "c").unwrap();
+        ), &AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(
             hex::encode(rec.key_material.as_deref().unwrap()),
@@ -763,7 +770,7 @@ mod tests {
         };
         let resp = derive_key(&d, request(
             DerivationMethod::Hmac, vec!["b1"], dp(), aes_template(128),
-        ), "c").unwrap();
+        ), &AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(
             hex::encode(rec.key_material.as_deref().unwrap()),
@@ -771,7 +778,7 @@ mod tests {
         );
         let err = derive_key(&d, request(
             DerivationMethod::Hmac, vec!["b1"], dp(), aes_template(512),
-        ), "c").unwrap_err();
+        ), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidAttribute);
     }
 
@@ -795,7 +802,7 @@ mod tests {
                 ..Default::default()
             },
             template_attribute: vec![Attribute::CryptographicLength(256)],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(
             hex::encode(rec.key_material.as_deref().unwrap()),
@@ -814,7 +821,7 @@ mod tests {
         let err = derive_key(&d, request(
             DerivationMethod::Hash, vec!["b1"],
             DerivationParameters::default(), aes_template(128),
-        ), "c").unwrap_err();
+        ), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::BadCryptographicParameters);
     }
 
@@ -838,7 +845,7 @@ mod tests {
                 ..Default::default()
             },
             aes_template(512),
-        ), "c").unwrap();
+        ), &AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(
             hex::encode(rec.key_material.as_deref().unwrap()),
@@ -861,7 +868,7 @@ mod tests {
                 ..Default::default()
             },
             aes_template(128),
-        ), "c").unwrap_err();
+        ), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
         let err = derive_key(&d, request(
             DerivationMethod::Pbkdf2, vec!["pw"],
@@ -870,7 +877,7 @@ mod tests {
                 ..Default::default()
             },
             aes_template(128),
-        ), "c").unwrap_err();
+        ), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
     }
 
@@ -893,7 +900,7 @@ mod tests {
                 ..Default::default()
             },
             aes_template(256),
-        ), "c").unwrap();
+        ), &AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
 
         let mut input = 1u32.to_be_bytes().to_vec();
@@ -920,7 +927,7 @@ mod tests {
                 ..Default::default()
             },
             template_attribute: vec![Attribute::CryptographicLength(72 * 8)],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
 
         let mut expected = Vec::new();
@@ -950,13 +957,13 @@ mod tests {
         let err = derive_key(&d, request(
             DerivationMethod::Hmac, vec!["b1"], dp(),
             vec![Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes)],
-        ), "c").unwrap_err();
+        ), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
         // SymmetricKey without CryptographicAlgorithm.
         let err = derive_key(&d, request(
             DerivationMethod::Hmac, vec!["b1"], dp(),
             vec![Attribute::CryptographicLength(128)],
-        ), "c").unwrap_err();
+        ), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
     }
 
@@ -967,7 +974,7 @@ mod tests {
         let err = derive_key(&d, request(
             DerivationMethod::Hmac, vec!["ghost"],
             DerivationParameters::default(), aes_template(128),
-        ), "c").unwrap_err();
+        ), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::ObjectNotFound);
         // PreActive base → Wrong Key Lifecycle State (0x43).
         put_base(&d, "pre", ObjectType::SymmetricKey, KmipAlgorithm::HmacSha256,
@@ -975,7 +982,7 @@ mod tests {
         let err = derive_key(&d, request(
             DerivationMethod::Hmac, vec!["pre"],
             DerivationParameters::default(), aes_template(128),
-        ), "c").unwrap_err();
+        ), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::WrongKeyLifecycleState);
         // Mask without the Derive Key bit (§6.1.18: "SHALL only apply
         // to Managed Objects that have the Derive Key bit set") → 0x29.
@@ -984,7 +991,7 @@ mod tests {
         let err = derive_key(&d, request(
             DerivationMethod::Hmac, vec!["nomask"],
             DerivationParameters::default(), aes_template(128),
-        ), "c").unwrap_err();
+        ), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(
             err.result_reason(),
             ResultReason::IncompatibleCryptographicUsageMask
@@ -1012,7 +1019,7 @@ mod tests {
                     ..Default::default()
                 },
                 aes_template(128),
-            ), "c").unwrap_err();
+            ), &AuthContext::open(), "c").unwrap_err();
             assert_eq!(
                 err.result_reason(),
                 ResultReason::OperationNotSupported,
@@ -1031,7 +1038,7 @@ mod tests {
             DerivationParameters::default(), aes_template(128),
         );
         req.object_type = ObjectType::PrivateKey;
-        let err = derive_key(&d, req, "c").unwrap_err();
+        let err = derive_key(&d, req, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidObjectType);
     }
 
@@ -1051,7 +1058,7 @@ mod tests {
                 ..Default::default()
             },
             aes_template(128),
-        ), "c").unwrap_err();
+        ), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
     }
 
@@ -1068,7 +1075,7 @@ mod tests {
         let resp = derive_key(&d, request(
             DerivationMethod::Hmac, vec!["key", "sd"],
             DerivationParameters::default(), aes_template(256),
-        ), "c").unwrap();
+        ), &AuthContext::open(), "c").unwrap();
 
         // Same KAT as the explicit-data path (RFC 4231 case 2).
         let derived = d.store.get(&resp.uid).unwrap().unwrap();
@@ -1106,7 +1113,7 @@ mod tests {
                 ..Default::default()
             },
             aes_template(128),
-        ), "c").unwrap();
+        ), &AuthContext::open(), "c").unwrap();
 
         let ga = super::super::get_attributes::get_attributes(
             &d,
@@ -1142,7 +1149,7 @@ mod tests {
                 ..Default::default()
             },
             aes_template(128),
-        ), "c").unwrap();
+        ), &AuthContext::open(), "c").unwrap();
         let events = ring.snapshot();
         assert!(events.iter().any(|e| matches!(
             &e.event,
@@ -1172,7 +1179,7 @@ mod tests {
                     OffsetDateTime::now_utc().unix_timestamp() - 3600,
                 ),
             ],
-        ), "c").unwrap();
+        ), &AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(rec.state, State::Active);
         assert_eq!(rec.key_material.as_ref().map(|m| m.len()), Some(32));

--- a/kmip/src/ops/derive_key.rs
+++ b/kmip/src/ops/derive_key.rs
@@ -208,6 +208,7 @@ pub fn derive_key(
         req.object_type,
         &[],
         &mut req.template_attribute,
+        auth,
     );
     let x = super::register_import_export::extract_attrs(&req.template_attribute);
 

--- a/kmip/src/ops/derive_key.rs
+++ b/kmip/src/ops/derive_key.rs
@@ -1185,6 +1185,7 @@ mod tests {
                 iv: Some(vec![0u8; 12]), // AES-GCM nonce
                 ..Default::default()
             },
+            &crate::server::auth::AuthContext::open(),
             "c-enc",
         ).unwrap();
         assert!(!enc.ciphertext.is_empty());

--- a/kmip/src/ops/derive_key.rs
+++ b/kmip/src/ops/derive_key.rs
@@ -644,6 +644,7 @@ mod tests {
     use crate::auditlog::{AuditSink, EventPayload, RingSink};
     use crate::kmip30::{Attribute, CryptographicParameters, DerivationParameters};
     use crate::policy::{load_from_str, Engine};
+    use crate::server::auth::AuthContext;
     use crate::store::MemoryStore;
     use std::sync::Arc;
 
@@ -1110,6 +1111,7 @@ mod tests {
         let ga = super::super::get_attributes::get_attributes(
             &d,
             crate::kmip30::GetAttributesRequest { uid: resp.uid.clone(), attribute_references: vec![] },
+            &AuthContext::open(),
             "c2",
         ).unwrap();
         assert!(ga.attributes.iter().any(|a| matches!(
@@ -1119,6 +1121,7 @@ mod tests {
         let ga = super::super::get_attributes::get_attributes(
             &d,
             crate::kmip30::GetAttributesRequest { uid: "key".into(), attribute_references: vec![] },
+            &AuthContext::open(),
             "c3",
         ).unwrap();
         assert!(ga.attributes.iter().any(|a| matches!(

--- a/kmip/src/ops/destroy.rs
+++ b/kmip/src/ops/destroy.rs
@@ -27,17 +27,22 @@ use crate::policy::{Decision, PolicyRequest};
 
 use super::deps::Deps;
 use super::helpers::{
-    canonical_name, emit_request, emit_state_change, emit_success, fail_err,
+    authorize_object, canonical_name, emit_request, emit_state_change, emit_success, fail_err,
     state_name,
 };
 
-pub fn destroy(deps: &Deps, req: DestroyRequest, correlation_id: &str) -> Result<DestroyResponse> {
+pub fn destroy(
+    deps: &Deps,
+    req: DestroyRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<DestroyResponse> {
     let started = OffsetDateTime::now_utc();
     emit_request(deps, correlation_id, "Destroy", format!("uid={}", req.uid));
 
-    let mut obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "Destroy", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    let mut obj = authorize_object(deps, auth, &req.uid, || KmipError::object_not_found(&req.uid))
+        .map_err(|e| fail_err(deps, correlation_id, "Destroy", e))?;
 
     // KMIP 3.0 §3.x lifecycle — Active cannot transition directly to Destroyed;
     // already-Destroyed is terminal.
@@ -87,7 +92,7 @@ pub fn destroy(deps: &Deps, req: DestroyRequest, correlation_id: &str) -> Result
     // audit record is emitted after the call with its real rv; when no
     // engine call happens (no session / handle already gone) no
     // `Pkcs11Call` record is fabricated.
-    if let Some(session) = deps.engine_session {
+    if let Some(session) = deps.resolve_tenant_session(auth.identity.as_ref()).ok() {
         // Best-effort: if the handle is already gone (e.g. engine restart
         // between record creation and Destroy), ignore the error — the
         // KMIP lifecycle transition still proceeds.
@@ -159,6 +164,7 @@ mod tests {
     use crate::auditlog::{AuditSink, RingSink};
     use crate::kmip30::{KmipAlgorithm, ObjectType, UsageMask};
     use crate::policy::{load_from_str, Engine};
+    use crate::server::auth::AuthContext;
     use crate::store::{MemoryStore, ObjectRecord};
     use std::sync::Arc;
 
@@ -207,7 +213,7 @@ mod tests {
     fn pre_active_to_destroyed() {
         let d = deps_with();
         put(&d, "u", State::PreActive);
-        let r = destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap();
+        let r = destroy(&d, DestroyRequest { uid: "u".into() }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.state, State::Destroyed);
     }
 
@@ -215,7 +221,7 @@ mod tests {
     fn deactivated_to_destroyed() {
         let d = deps_with();
         put(&d, "u", State::Deactivated);
-        let r = destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap();
+        let r = destroy(&d, DestroyRequest { uid: "u".into() }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.state, State::Destroyed);
     }
 
@@ -223,7 +229,7 @@ mod tests {
     fn compromised_to_destroyed_compromised() {
         let d = deps_with();
         put(&d, "u", State::Compromised);
-        let r = destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap();
+        let r = destroy(&d, DestroyRequest { uid: "u".into() }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.state, State::DestroyedCompromised);
     }
 
@@ -231,7 +237,7 @@ mod tests {
     fn active_rejected_must_revoke_first() {
         let d = deps_with();
         put(&d, "u", State::Active);
-        let err = destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap_err();
+        let err = destroy(&d, DestroyRequest { uid: "u".into() }, &AuthContext::open(), "c").unwrap_err();
         // KMIP 3.0 §11 — the FSM rejection reason is
         // `WrongKeyLifecycleState` (0x43), not the generic
         // `PermissionDenied`. AKLC-M-2 msg #5 pins this code.
@@ -245,7 +251,7 @@ mod tests {
     fn already_destroyed_rejected() {
         let d = deps_with();
         put(&d, "u", State::Destroyed);
-        let err = destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap_err();
+        let err = destroy(&d, DestroyRequest { uid: "u".into() }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), crate::error::ResultReason::ObjectDestroyed);
     }
 
@@ -286,7 +292,7 @@ mod tests {
             })
             .unwrap();
 
-        destroy(&d, DestroyRequest { uid: "u".into() }, "c").unwrap();
+        destroy(&d, DestroyRequest { uid: "u".into() }, &AuthContext::open(), "c").unwrap();
 
         let stored = d.store.get("u").unwrap().unwrap();
         assert!(

--- a/kmip/src/ops/destroy.rs
+++ b/kmip/src/ops/destroy.rs
@@ -313,6 +313,7 @@ mod tests {
                 key_compression_type: None,
                 key_wrapping_specification: None,
             },
+            &AuthContext::open(),
             "c",
         )
         .unwrap();

--- a/kmip/src/ops/encapsulate.rs
+++ b/kmip/src/ops/encapsulate.rs
@@ -43,8 +43,10 @@ use super::helpers::{
 pub fn encapsulate(
     deps: &Deps,
     req: EncapsulateRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<EncapsulateResponse> {
+    let session = deps.resolve_tenant_session(auth.identity.as_ref()).ok();
     emit_request(
         deps,
         correlation_id,
@@ -139,7 +141,7 @@ pub fn encapsulate(
             // `policy::rule::is_consumer_op` — the engine hard-excludes it),
             // so this is sound specifically because Encapsulate originates
             // fresh output each call.
-            return rekey_and_encapsulate(deps, &req, &obj, &new_algorithm, correlation_id);
+            return rekey_and_encapsulate(deps, &req, &obj, &new_algorithm, auth, correlation_id);
         }
     }
 
@@ -155,7 +157,7 @@ pub fn encapsulate(
                 "hybrid KEM public key has no stored material".to_string(),
             )
         })?;
-        let session = deps.engine_session.ok_or_else(|| {
+        let session = session.ok_or_else(|| {
             KmipError::failed(
                 ResultReason::CryptographicFailure,
                 "hybrid KEM encapsulate requires an engine session".to_string(),
@@ -179,7 +181,7 @@ pub fn encapsulate(
     // or only nested in CryptographicParameters — prefer the hoisted form.
     let coins = req.input_key_material.clone();
 
-    let (ciphertext, shared_secret) = match deps.engine_session {
+    let (ciphertext, shared_secret) = match session {
         Some(session) => {
             // Resolve the handle by PKCS#11 class: a CreateKeyPair-generated
             // ML-KEM pair stores BOTH halves under one shared CKA_ID, so a
@@ -316,6 +318,7 @@ fn rekey_and_encapsulate(
     req: &EncapsulateRequest,
     old: &ObjectRecord,
     new_algorithm: &str,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<EncapsulateResponse> {
     use crate::kmip30::{ActivateRequest, Attribute, CreateKeyPairRequest, UsageMask};
@@ -344,6 +347,7 @@ fn rekey_and_encapsulate(
             seed: None,
         },
         "CreateKeyPair:KeyAgreement",
+        auth,
         correlation_id,
     )?;
 
@@ -415,6 +419,7 @@ fn rekey_and_encapsulate(
             input_key_material: req.input_key_material.clone(),
             cryptographic_parameters: req.cryptographic_parameters.clone(),
         },
+        auth,
         correlation_id,
     )?;
     resp.rekeyed = Some(crate::kmip30::EncapsulateRekeyInfo {
@@ -527,6 +532,7 @@ mod tests {
     use crate::auditlog::{AuditSink, RingSink};
     use crate::kmip30::{DecapsulateRequest, UsageMask};
     use crate::policy::Engine;
+    use crate::server::auth::AuthContext;
     use crate::store::MemoryStore;
     use std::sync::Arc;
     use super::super::decapsulate::decapsulate;
@@ -582,6 +588,7 @@ mod tests {
                 input_key_material: Some(vec![0x11; 32]),
                 cryptographic_parameters: None,
             },
+            &AuthContext::open(),
             "t",
         )
         .unwrap();
@@ -610,6 +617,7 @@ mod tests {
         let err = encapsulate(
             &d,
             EncapsulateRequest { uid: "rsa".to_string(), ..Default::default() },
+            &AuthContext::open(),
             "t",
         )
         .unwrap_err();
@@ -625,6 +633,7 @@ mod tests {
         let resp = encapsulate(
             &d,
             EncapsulateRequest { uid: "ecdh-pk".to_string(), ..Default::default() },
+            &AuthContext::open(),
             "t",
         )
         .unwrap();
@@ -704,6 +713,7 @@ rules:
         let resp = encapsulate(
             &d,
             EncapsulateRequest { uid: "urn:ecdh-pub".into(), ..Default::default() },
+            &AuthContext::open(),
             "corr-rk",
         )
         .unwrap();

--- a/kmip/src/ops/encapsulate.rs
+++ b/kmip/src/ops/encapsulate.rs
@@ -58,9 +58,8 @@ pub fn encapsulate(
         ),
     );
 
-    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "Encapsulate", KmipError::object_not_found(&req.uid))
-    })?;
+    let obj = super::helpers::authorize_object(deps, auth, &req.uid, || KmipError::object_not_found(&req.uid))
+        .map_err(|e| fail_err(deps, correlation_id, "Encapsulate", e))?;
 
     // K6 — Encapsulate accepts ML-KEM, the hybrid KEMs (X25519MLKEM768 /
     // SecP256r1MLKEM768), classical ECDH/X25519/X448 in DHKEM mode (see
@@ -172,7 +171,7 @@ pub fn encapsulate(
             )
         })?;
         emit_pkcs11(deps, correlation_id, "soft::hybrid_kem_encapsulate", None, 0, "CKR_OK");
-        let ss_uid = store_shared_secret(deps, obj.algorithm, enc.shared_secret)?;
+        let ss_uid = store_shared_secret(deps, obj.algorithm, enc.shared_secret, auth)?;
         emit_success(deps, correlation_id, "Encapsulate");
         return Ok(EncapsulateResponse { uid: ss_uid, data: enc.ciphertext, rekeyed: None });
     }
@@ -283,7 +282,7 @@ pub fn encapsulate(
     };
 
     // Create the NEW managed SecretData object holding the shared secret.
-    let ss_uid = store_shared_secret(deps, obj.algorithm, shared_secret)?;
+    let ss_uid = store_shared_secret(deps, obj.algorithm, shared_secret, auth)?;
 
     emit_success(deps, correlation_id, "Encapsulate");
 
@@ -473,10 +472,11 @@ pub(crate) fn store_shared_secret(
     deps: &Deps,
     source_algorithm: KmipAlgorithm,
     shared_secret: Vec<u8>,
+    auth: &crate::server::auth::AuthContext,
 ) -> Result<String> {
     let uid = format!("urn:pqctoday:obj:{}", Uuid::new_v4());
     let now = OffsetDateTime::now_utc();
-    deps.store.put(ObjectRecord {
+    deps.store.put(super::helpers::stamp_owner(ObjectRecord {
         uid: uid.clone(),
         object_type: ObjectType::SecretData,
         // The shared secret is opaque bytes; record the source KEM
@@ -510,7 +510,7 @@ pub(crate) fn store_shared_secret(
         sensitive: Some(false),
         fresh: Some(true),
         ..ObjectRecord::default()
-    })?;
+    }, auth))?;
     Ok(uid)
 }
 
@@ -757,6 +757,7 @@ rules:
                 data: resp.data.clone(),
                 ..Default::default()
             },
+            &AuthContext::open(),
             "corr-good",
         );
         assert!(good.is_ok(), "new key must decapsulate the ciphertext Encapsulate just produced");

--- a/kmip/src/ops/encrypt.rs
+++ b/kmip/src/ops/encrypt.rs
@@ -197,7 +197,7 @@ pub fn encrypt(
     // stream, `Correlation Value` chains parts, `Final Indicator`
     // closes it (emitting the AEAD tag). CS-BC-M-GCM-3 pins this flow.
     let resp = if req.init_indicator == Some(true) || req.correlation_value.is_some() {
-        encrypt_streaming(deps, &req, &obj, correlation_id)
+        encrypt_streaming(deps, &req, &obj, auth, correlation_id)
     } else if is_ml_kem(obj.algorithm) {
         // Plane-3: branch on algorithm.
         encrypt_ml_kem(deps, &req, &obj, auth, correlation_id)
@@ -264,6 +264,7 @@ fn encrypt_streaming(
     deps: &Deps,
     req: &EncryptRequest,
     obj: &crate::store::ObjectRecord,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<EncryptResponse> {
     use softhsmrustv3::crypto::multipart::{
@@ -350,7 +351,12 @@ fn encrypt_streaming(
         let cv = deps.new_correlation_value();
         deps.streams.lock().unwrap().insert(
             cv.clone(),
-            StreamCtx { cipher, uid: req.uid.clone() },
+            StreamCtx {
+                cipher,
+                uid: req.uid.clone(),
+                // Part F §F7.5 — tag the opening tenant (see StreamCtx).
+                owner: auth.identity.as_ref().map(|i| i.username.clone()),
+            },
         );
         return Ok(EncryptResponse {
             uid: req.uid.clone(),
@@ -366,6 +372,16 @@ fn encrypt_streaming(
     let mut ctx = streams.remove(cv).ok_or_else(|| {
         fail_err(deps, correlation_id, "Encrypt", invalid("unknown-correlation-value"))
     })?;
+    // Part F §F7.5 — a continuation from a different tenant is treated as
+    // an unknown correlation value (anti-oracle), not a distinct error.
+    // NB: `ctx` was already removed above, so on this reject path we must
+    // put it back or a foreign continuation would DESTROY the owner's
+    // in-flight stream — restore it before failing.
+    if ctx.owner != auth.identity.as_ref().map(|i| i.username.clone()) {
+        streams.insert(cv.clone(), ctx);
+        return Err(fail_err(deps, correlation_id, "Encrypt",
+            invalid("unknown-correlation-value")));
+    }
     if ctx.uid != req.uid {
         return Err(fail_err(deps, correlation_id, "Encrypt",
             invalid("correlation-value/uid mismatch")));

--- a/kmip/src/ops/encrypt.rs
+++ b/kmip/src/ops/encrypt.rs
@@ -32,11 +32,16 @@ use crate::policy::{Decision, PolicyRequest};
 
 use super::deps::Deps;
 use super::helpers::{
-    emit_pkcs11, emit_pkcs11_result, emit_request, emit_success, fail_err,
+    authorize_object, emit_pkcs11, emit_pkcs11_result, emit_request, emit_success, fail_err,
     state_name,
 };
 
-pub fn encrypt(deps: &Deps, mut req: EncryptRequest, correlation_id: &str) -> Result<EncryptResponse> {
+pub fn encrypt(
+    deps: &Deps,
+    mut req: EncryptRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<EncryptResponse> {
     let started = OffsetDateTime::now_utc();
     emit_request(
         deps,
@@ -45,9 +50,9 @@ pub fn encrypt(deps: &Deps, mut req: EncryptRequest, correlation_id: &str) -> Re
         format!("uid={} data_len={}", req.uid, req.data.len()),
     );
 
-    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "Encrypt", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    let obj = authorize_object(deps, auth, &req.uid, || KmipError::object_not_found(&req.uid))
+        .map_err(|e| fail_err(deps, correlation_id, "Encrypt", e))?;
 
     if obj.state != State::Active {
         return Err(fail_err(
@@ -178,7 +183,7 @@ pub fn encrypt(deps: &Deps, mut req: EncryptRequest, correlation_id: &str) -> Re
                     ),
                 ));
             }
-            return rekey_and_encrypt(deps, &req, &obj, &new_algorithm, correlation_id);
+            return rekey_and_encrypt(deps, &req, &obj, &new_algorithm, auth, correlation_id);
         }
     }
     if let Some(ov) = forced_cp.as_ref() {
@@ -195,9 +200,9 @@ pub fn encrypt(deps: &Deps, mut req: EncryptRequest, correlation_id: &str) -> Re
         encrypt_streaming(deps, &req, &obj, correlation_id)
     } else if is_ml_kem(obj.algorithm) {
         // Plane-3: branch on algorithm.
-        encrypt_ml_kem(deps, &req, &obj, correlation_id)
+        encrypt_ml_kem(deps, &req, &obj, auth, correlation_id)
     } else {
-        encrypt_classical(deps, &req, &obj, correlation_id)
+        encrypt_classical(deps, &req, &obj, auth, correlation_id)
     }?;
 
     emit_success(deps, correlation_id, "Encrypt");
@@ -213,12 +218,14 @@ fn rekey_and_encrypt(
     req: &EncryptRequest,
     old: &crate::store::ObjectRecord,
     new_algorithm: &str,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<EncryptResponse> {
     // 1+2. Replacement symmetric key (Name carried over) + Activate.
-    let new_uid =
-        super::agility::generate_replacement_symmetric(deps, old, new_algorithm, correlation_id)
-            .map_err(|e| fail_err(deps, correlation_id, "Encrypt", e))?;
+    let new_uid = super::agility::generate_replacement_symmetric(
+        deps, old, new_algorithm, auth, correlation_id,
+    )
+    .map_err(|e| fail_err(deps, correlation_id, "Encrypt", e))?;
 
     // 3. Deactivate + supersede the old key.
     super::agility::supersede_old(deps, old, &new_uid, new_algorithm, correlation_id)?;
@@ -238,6 +245,7 @@ fn rekey_and_encrypt(
             final_indicator: req.final_indicator,
             correlation_value: req.correlation_value.clone(),
         },
+        auth,
         correlation_id,
     )?;
     resp.rekeyed = Some(crate::kmip30::RekeyInfo {
@@ -408,6 +416,7 @@ fn encrypt_ml_kem(
     deps: &Deps,
     req: &EncryptRequest,
     obj: &crate::store::ObjectRecord,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<EncryptResponse> {
     let mech = obj.algorithm.to_pkcs11_mech(PkcsOp::Encrypt).ok_or_else(|| {
@@ -419,7 +428,7 @@ fn encrypt_ml_kem(
 
     // Phase 7b: real bridge call when a session is wired. K15 — the
     // Plane-3 record is emitted after the call with its real rv.
-    let (ciphertext, shared_secret) = match deps.engine_session {
+    let (ciphertext, shared_secret) = match deps.resolve_tenant_session(auth.identity.as_ref()).ok() {
         Some(session) => {
             // WP-4 remediation — class-aware, not the ambiguous class-blind
             // find_by_cka_id: a certified public key now shares its
@@ -471,6 +480,7 @@ fn encrypt_classical(
     deps: &Deps,
     req: &EncryptRequest,
     obj: &crate::store::ObjectRecord,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<EncryptResponse> {
     // KMIP 3.0 §6.1.21 — the request MAY carry its own
@@ -631,7 +641,7 @@ fn encrypt_classical(
         );
         emit_pkcs11_result(deps, correlation_id, "native::encrypt_with_key_bytes", Some(mech), &r);
         r.map_err(|rv| super::helpers::ck_rv_to_kmip_error(rv, "Encrypt"))?
-    } else if let Some(session) = deps.engine_session {
+    } else if let Some(session) = deps.resolve_tenant_session(auth.identity.as_ref()).ok() {
         // WP-4 remediation — class-aware, not the ambiguous class-blind
         // find_by_cka_id: a certified RSA public key now shares its
         // CKA_ID with its private key AND a linked certificate.
@@ -813,7 +823,7 @@ mod tests {
     fn ml_kem_branch_returns_encapsulation_and_shared_secret() {
         let (ring, d) = deps_and_ring();
         put(&d, "k", KmipAlgorithm::MlKem1024, ObjectType::PublicKey, State::Active, UsageMask::KEY_AGREEMENT);
-        let r = encrypt(&d, EncryptRequest { uid: "k".into(), ..Default::default() }, "c").unwrap();
+        let r = encrypt(&d, EncryptRequest { uid: "k".into(), ..Default::default() }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert!(r.shared_secret.is_some(), "ML-KEM must return shared secret");
         assert_eq!(r.ciphertext.len(), 32);
         // K15 — no engine session: the audit names the soft fallback
@@ -832,7 +842,7 @@ mod tests {
             data: b"plaintext".to_vec(),
             iv: Some(vec![0u8; 12]),
             ..Default::default()
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert!(r.shared_secret.is_none(), "classical encrypt has no shared secret");
         // K15 — no key material + no session: the audit names the soft
         // classical-encrypt fallback that actually ran.
@@ -851,7 +861,7 @@ mod tests {
             data: b"x".to_vec(),
             iv: Some(vec![0u8; 12]),
             ..Default::default()
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::IncompatibleCryptographicUsageMask);
     }
 
@@ -867,14 +877,14 @@ mod tests {
             data: b"x".to_vec(),
             iv: Some(vec![0u8; 12]),
             ..Default::default()
-        }, "c").expect("empty mask must not block Encrypt");
+        }, &crate::server::auth::AuthContext::open(), "c").expect("empty mask must not block Encrypt");
     }
 
     #[test]
     fn encrypt_on_destroyed_returns_wrong_lifecycle_state() {
         let (_ring, d) = deps_and_ring();
         put(&d, "a", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Destroyed, UsageMask::ENCRYPT);
-        let err = encrypt(&d, EncryptRequest { uid: "a".into(), ..Default::default() }, "c").unwrap_err();
+        let err = encrypt(&d, EncryptRequest { uid: "a".into(), ..Default::default() }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         // KMIP 3.0 §11 — Destroyed is an FSM-rejection state, not
         // an archive state. CS-AC-M-8 pins WrongKeyLifecycleState
         // for crypto-ops against Destroyed keys.
@@ -893,7 +903,7 @@ mod tests {
         let mut rec = d.store.get("a").unwrap().unwrap();
         rec.archived = true;
         d.store.update(rec).unwrap();
-        let err = encrypt(&d, EncryptRequest { uid: "a".into(), ..Default::default() }, "c").unwrap_err();
+        let err = encrypt(&d, EncryptRequest { uid: "a".into(), ..Default::default() }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::ObjectArchived);
     }
 }
@@ -978,6 +988,7 @@ mod k6_no_silent_substitution_tests {
                 cryptographic_parameters: Some(cp_mode(4)),
                 ..Default::default()
             },
+            &crate::server::auth::AuthContext::open(),
             "c",
         )
         .unwrap_err();
@@ -1002,6 +1013,7 @@ mod k6_no_silent_substitution_tests {
                 cryptographic_parameters: Some(cp_mode(6)),
                 ..Default::default()
             },
+            &crate::server::auth::AuthContext::open(),
             "c-enc",
         )
         .unwrap();
@@ -1016,6 +1028,7 @@ mod k6_no_silent_substitution_tests {
                 cryptographic_parameters: Some(cp_mode(6)),
                 aad: None,
             },
+            &crate::server::auth::AuthContext::open(),
             "c-dec",
         )
         .unwrap();
@@ -1037,6 +1050,7 @@ mod k6_no_silent_substitution_tests {
                 cryptographic_parameters: Some(cp_mode(6)),
                 ..Default::default()
             },
+            &crate::server::auth::AuthContext::open(),
             "c",
         )
         .unwrap_err();
@@ -1071,6 +1085,7 @@ mod k6_no_silent_substitution_tests {
                 }),
                 ..Default::default()
             },
+            &crate::server::auth::AuthContext::open(),
             "c",
         )
         .unwrap_err();
@@ -1105,6 +1120,7 @@ mod k6_no_silent_substitution_tests {
         let err = encrypt(
             &d,
             EncryptRequest { uid: "r".into(), data: b"x".to_vec(), ..Default::default() },
+            &crate::server::auth::AuthContext::open(),
             "c1",
         )
         .unwrap_err();
@@ -1123,6 +1139,7 @@ mod k6_no_silent_substitution_tests {
                 }),
                 ..Default::default()
             },
+            &crate::server::auth::AuthContext::open(),
             "c2",
         )
         .expect("request CP must override object CP for OAEP params");

--- a/kmip/src/ops/get.rs
+++ b/kmip/src/ops/get.rs
@@ -25,16 +25,22 @@ use crate::kmip30::{GetRequest, GetResponse, KeyBlock, KeyFormatType, ObjectType
 use crate::policy::{Decision, PolicyRequest};
 
 use super::deps::Deps;
-use super::helpers::{canonical_name, emit_pkcs11, emit_request, emit_success, fail_err, state_name};
+use super::helpers::{authorize_object, canonical_name, emit_pkcs11, emit_request, emit_success, fail_err, state_name};
 
-pub fn get(deps: &Deps, req: GetRequest, correlation_id: &str) -> Result<GetResponse> {
+pub fn get(
+    deps: &Deps,
+    req: GetRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<GetResponse> {
     let started = OffsetDateTime::now_utc();
     emit_request(deps, correlation_id, "Get", format!("uid={}", req.uid));
 
-    let obj = deps
-        .store
-        .get(&req.uid)?
-        .ok_or_else(|| fail_err(deps, correlation_id, "Get", KmipError::object_not_found(&req.uid)))?;
+    // Part F §F7.4 — owner-checked lookup. Same `ObjectNotFound` this
+    // handler already used for a genuinely missing UID now also covers
+    // "exists but belongs to a different tenant" (anti-oracle).
+    let obj = authorize_object(deps, auth, &req.uid, || KmipError::object_not_found(&req.uid))
+        .map_err(|e| fail_err(deps, correlation_id, "Get", e))?;
 
     // Per the lifecycle table in docs/IMPLEMENTATION_PLAN.md §3.4, Get is
     // allowed in every state including Deactivated / Compromised
@@ -178,7 +184,7 @@ pub fn get(deps: &Deps, req: GetRequest, correlation_id: &str) -> Result<GetResp
                 },
             ));
         }
-        match deps.engine_session {
+        match deps.resolve_tenant_session(auth.identity.as_ref()).ok() {
             Some(session) => {
                 // CreateKeyPair stores BOTH halves under one shared CKA_ID,
                 // so a bare `find_by_cka_id` would return whichever the
@@ -338,6 +344,7 @@ mod tests {
     use crate::auditlog::{AuditSink, RingSink};
     use crate::kmip30::{KmipAlgorithm, UsageMask};
     use crate::policy::{load_from_str, Engine};
+    use crate::server::auth::AuthContext;
     use crate::store::{MemoryStore, ObjectRecord};
     use std::sync::Arc;
 
@@ -395,7 +402,7 @@ mod tests {
         d.store.update(rec).unwrap();
         let err = get(&d, GetRequest {
             uid: "u".into(), key_format_type: None, key_wrapping_specification: None,
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), crate::error::ResultReason::ObjectArchived);
         // Recover semantics: storage status back On-line → Get succeeds.
         let mut rec = d.store.get("u").unwrap().unwrap();
@@ -403,14 +410,14 @@ mod tests {
         d.store.update(rec).unwrap();
         assert!(get(&d, GetRequest {
             uid: "u".into(), key_format_type: None, key_wrapping_specification: None,
-        }, "c").is_ok());
+        }, &AuthContext::open(), "c").is_ok());
     }
 
     #[test]
     fn get_symmetric_returns_raw_format() {
         let d = deps_with();
         put(&d, "u", ObjectType::SymmetricKey, State::Active);
-        let r = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: None }, "c").unwrap();
+        let r = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.key_block.key_format_type, KeyFormatType::Raw);
         assert_eq!(r.key_block.cryptographic_length, 256);
     }
@@ -421,7 +428,7 @@ mod tests {
         // FAIL, never surface as a zero-length OpaqueObject KeyValue.
         let d = deps_with();
         put(&d, "u", ObjectType::PrivateKey, State::Active);
-        let err = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: None }, "c").unwrap_err();
+        let err = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), crate::error::ResultReason::NotExtractable);
     }
 
@@ -432,7 +439,7 @@ mod tests {
         let mut obj = d.store.get("u").unwrap().unwrap();
         obj.sensitive = Some(true);
         d.store.update(obj).unwrap();
-        let err = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: None }, "c").unwrap_err();
+        let err = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), crate::error::ResultReason::Sensitive);
     }
 
@@ -444,7 +451,7 @@ mod tests {
         obj.sensitive = Some(true);
         obj.key_material = Some(vec![0x11; 32]);
         d.store.update(obj).unwrap();
-        let err = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: None }, "c").unwrap_err();
+        let err = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), crate::error::ResultReason::Sensitive);
     }
 
@@ -470,7 +477,7 @@ mod tests {
             encoding_option: None,
             mac_signature_key_information_present: false,
         };
-        let r = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: Some(spec.clone()) }, "c").unwrap();
+        let r = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: Some(spec.clone()) }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.key_block.key_wrapping_data, Some(spec));
         assert!(!r.key_block.key_value.is_empty(), "wrapped material returned");
         // AES-KW output = TTLV(KeyValue) length + 8-byte integrity block.
@@ -486,7 +493,7 @@ mod tests {
         obj.key_material = Some(vec![0x11; 32]);
         d.store.update(obj).unwrap();
         // Without wrapping.
-        let err = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: None }, "c").unwrap_err();
+        let err = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), crate::error::ResultReason::NotExtractable);
         // With wrapping — Extractable=false is unconditional.
         let spec = crate::kmip30::KeyWrappingSpec {
@@ -496,7 +503,7 @@ mod tests {
             encoding_option: None,
             mac_signature_key_information_present: false,
         };
-        let err = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: Some(spec) }, "c").unwrap_err();
+        let err = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: Some(spec) }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), crate::error::ResultReason::NotExtractable);
     }
 
@@ -504,14 +511,14 @@ mod tests {
     fn get_destroyed_returns_object_destroyed() {
         let d = deps_with();
         put(&d, "u", ObjectType::SymmetricKey, State::Destroyed);
-        let err = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: None }, "c").unwrap_err();
+        let err = get(&d, GetRequest { uid: "u".into(), key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), crate::error::ResultReason::ObjectDestroyed);
     }
 
     #[test]
     fn get_missing_uid() {
         let d = deps_with();
-        let err = get(&d, GetRequest { uid: "ghost".into(), key_format_type: None, key_wrapping_specification: None }, "c").unwrap_err();
+        let err = get(&d, GetRequest { uid: "ghost".into(), key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), crate::error::ResultReason::ObjectNotFound);
     }
 
@@ -530,7 +537,7 @@ mod tests {
             uid: uid.into(),
             key_format_type: requested,
             key_wrapping_specification: None,
-        }, "c")
+        }, &AuthContext::open(), "c")
     }
 
     #[test]

--- a/kmip/src/ops/get.rs
+++ b/kmip/src/ops/get.rs
@@ -291,7 +291,7 @@ pub fn get(
             // checks, TTLV KeyValue encode, AES-KW) is shared with
             // Export via `helpers::wrap_key_value`.
             let wrapped =
-                super::helpers::wrap_key_value(deps, "Get", spec, &key_value, correlation_id)?;
+                super::helpers::wrap_key_value(deps, "Get", spec, &key_value, auth, correlation_id)?;
             (wrapped, Some(spec.clone()))
         }
     };

--- a/kmip/src/ops/get_attribute_list.rs
+++ b/kmip/src/ops/get_attribute_list.rs
@@ -12,11 +12,12 @@ use crate::kmip30::{GetAttributeListRequest, GetAttributeListResponse};
 use crate::policy::{Decision, PolicyRequest};
 
 use super::deps::Deps;
-use super::helpers::{canonical_name, emit_request, emit_success, fail_err, state_name};
+use super::helpers::{authorize_object, canonical_name, emit_request, emit_success, fail_err, state_name};
 
 pub fn get_attribute_list(
     deps: &Deps,
     req: GetAttributeListRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<GetAttributeListResponse> {
     let started = OffsetDateTime::now_utc();
@@ -27,9 +28,15 @@ pub fn get_attribute_list(
         format!("uid={}", req.uid),
     );
 
-    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "GetAttributeList", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    // Never found in any prior by-UID enumeration until this pass:
+    // GetAttributeList only returns attribute NAMES, not values, but a
+    // foreign tenant's object existing at all is still information a
+    // caller shouldn't get for free — same ObjectNotFound this handler
+    // already used for a genuinely missing UID now also covers "exists
+    // but belongs to someone else" (anti-oracle).
+    let obj = authorize_object(deps, auth, &req.uid, || KmipError::object_not_found(&req.uid))
+        .map_err(|e| fail_err(deps, correlation_id, "GetAttributeList", e))?;
 
     let empty: HashMap<String, String> = HashMap::new();
     let algo = canonical_name(obj.algorithm);
@@ -195,7 +202,12 @@ mod tests {
         ..ObjectRecord::default()
 }).unwrap();
 
-        let r = get_attribute_list(&d, GetAttributeListRequest { uid: "u".into() }, "c").unwrap();
+        let r = get_attribute_list(
+            &d,
+            GetAttributeListRequest { uid: "u".into() },
+            &crate::server::auth::AuthContext::open(),
+            "c",
+        ).unwrap();
         assert!(r.attribute_references.contains(&"Cryptographic Algorithm".to_string()));
         assert!(r.attribute_references.contains(&"State".to_string()));
         assert!(r.attribute_references.contains(&"Cryptographic Length".to_string()));

--- a/kmip/src/ops/get_attributes.rs
+++ b/kmip/src/ops/get_attributes.rs
@@ -699,7 +699,7 @@ mod tests {
             }),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
 
         let r = get_attributes(&d, GetAttributesRequest {
             uid: resp.uid,

--- a/kmip/src/ops/get_attributes.rs
+++ b/kmip/src/ops/get_attributes.rs
@@ -28,11 +28,12 @@ use crate::policy::{Decision, PolicyRequest};
 use crate::store::ObjectRecord;
 
 use super::deps::Deps;
-use super::helpers::{canonical_name, emit_request, emit_success, fail_err, state_name};
+use super::helpers::{authorize_object, canonical_name, emit_request, emit_success, fail_err, state_name};
 
 pub fn get_attributes(
     deps: &Deps,
     req: GetAttributesRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<GetAttributesResponse> {
     let started = OffsetDateTime::now_utc();
@@ -43,11 +44,13 @@ pub fn get_attributes(
         format!("uid={} refs={}", req.uid, req.attribute_references.len()),
     );
 
-    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        // OASIS corpus BL-M-20-30.xml pins ItemNotFound here (msg #7,
-        // GetAttributes after Obliterate) — K2 keeps this site on the
-        // generic reason; do NOT sweep to ObjectNotFound.
-        fail_err(deps, correlation_id, "GetAttributes", KmipError::not_found(&req.uid))
+    // Part F §F7.4 — owner-checked lookup (closes the gap
+    // `ops::tenancy_e2e` documented empirically). Same ItemNotFound this
+    // handler already used for a genuinely missing UID (OASIS corpus
+    // BL-M-20-30.xml pins it — K2, do NOT sweep to ObjectNotFound) now
+    // also covers "exists but belongs to a different tenant".
+    let obj = authorize_object(deps, auth, &req.uid, || KmipError::not_found(&req.uid)).map_err(|e| {
+        fail_err(deps, correlation_id, "GetAttributes", e)
     })?;
 
     // Plane-1 gate. Read-only — uncommon to deny but spec allows it.
@@ -417,6 +420,7 @@ mod tests {
     use crate::auditlog::{AuditSink, RingSink};
     use crate::kmip30::{KmipAlgorithm, ObjectType, State, UsageMask};
     use crate::policy::{load_from_str, Engine};
+    use crate::server::auth::AuthContext;
     use crate::store::MemoryStore;
     use std::sync::Arc;
 
@@ -473,7 +477,7 @@ mod tests {
         let r = get_attributes(&d, GetAttributesRequest {
             uid: "u".into(),
             attribute_references: vec![],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert!(r.attributes.iter().any(|a| matches!(a, Attribute::CryptographicAlgorithm(_))));
     }
 
@@ -484,7 +488,7 @@ mod tests {
         let r = get_attributes(&d, GetAttributesRequest {
             uid: "u".into(),
             attribute_references: vec![],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert!(r.attributes.iter().any(|a| matches!(a, Attribute::CryptographicAlgorithm(_))));
         assert!(r.attributes.iter().any(|a| matches!(a, Attribute::CryptographicLength(_))));
         assert!(r.attributes.iter().any(|a| matches!(a, Attribute::State(_))));
@@ -497,7 +501,7 @@ mod tests {
         let r = get_attributes(&d, GetAttributesRequest {
             uid: "u".into(),
             attribute_references: vec!["State".into()],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.attributes.len(), 1);
         assert!(matches!(r.attributes[0], Attribute::State(_)));
     }
@@ -520,7 +524,7 @@ mod tests {
         let r = get_attributes(&d, GetAttributesRequest {
             uid: "km".into(),
             attribute_references: vec!["Digest".into()],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.attributes.len(), 1);
         match &r.attributes[0] {
             Attribute::Digest(dg) => {
@@ -548,7 +552,7 @@ mod tests {
         let r = get_attributes(&d, GetAttributesRequest {
             uid: "dv".into(),
             attribute_references: vec!["Digest".into()],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         match &r.attributes[0] {
             Attribute::Digest(dg) => assert_eq!(dg.digest_value, vec![0x42; 32]),
             other => panic!("expected Digest, got {other:?}"),
@@ -564,7 +568,7 @@ mod tests {
         let r = get_attributes(&d, GetAttributesRequest {
             uid: "u".into(),
             attribute_references: vec![],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert!(
             !r.attributes.iter().any(|a| matches!(a, Attribute::Digest(_))),
             "Digest must be omitted when no material was ever available"
@@ -595,7 +599,7 @@ mod tests {
         let r = get_attributes(&d, GetAttributesRequest {
             uid: "ln".into(),
             attribute_references: vec![],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert!(r.attributes.iter().any(|a| matches!(a, Attribute::PublicKeyLink(u) if u == "pub-1")));
         assert!(r.attributes.iter().any(|a| matches!(a, Attribute::PrivateKeyLink(u) if u == "prv-1")));
         assert!(r.attributes.iter().any(|a| matches!(a, Attribute::NextLink(u) if u == "next-1")));
@@ -623,7 +627,7 @@ mod tests {
         let r = get_attributes(&d, GetAttributesRequest {
             uid: "ul".into(),
             attribute_references: vec!["UsageLimits".into()],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.attributes.len(), 1);
         match &r.attributes[0] {
             Attribute::UsageLimits { total, count, unit } => {
@@ -644,7 +648,7 @@ mod tests {
         let r = get_attributes(&d, GetAttributesRequest {
             uid: "u".into(),
             attribute_references: vec!["RandomNumberGenerator".into()],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         match &r.attributes[0] {
             Attribute::RandomNumberGenerator(rng) => {
                 assert_eq!(rng.rng_algorithm, 0x01);
@@ -661,7 +665,7 @@ mod tests {
         let err = get_attributes(&d, GetAttributesRequest {
             uid: "missing".into(),
             attribute_references: vec![],
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         // OASIS corpus BL-M-20-30.xml pins ItemNotFound for a missing
         // UID on GetAttributes (corpus is authoritative over the sweep).
         assert_eq!(err.result_reason(), crate::error::ResultReason::ItemNotFound);
@@ -700,7 +704,7 @@ mod tests {
         let r = get_attributes(&d, GetAttributesRequest {
             uid: resp.uid,
             attribute_references: vec![],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let found = r.attributes.iter().find_map(|a| match a {
             Attribute::AlternativeName { value, name_type } => Some((value.clone(), *name_type)),
             _ => None,

--- a/kmip/src/ops/helpers.rs
+++ b/kmip/src/ops/helpers.rs
@@ -1226,6 +1226,7 @@ pub fn wrap_key_value(
     op: &str,
     spec: &crate::kmip30::KeyWrappingSpec,
     key_material: &[u8],
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> crate::error::Result<Vec<u8>> {
     use crate::error::ResultReason;
@@ -1254,7 +1255,7 @@ pub fn wrap_key_value(
     let kek = resolve_kek(
         deps, op, &spec.encryption_key_uid,
         crate::kmip30::UsageMask::WRAP_KEY, "WrapKey",
-        correlation_id,
+        auth, correlation_id,
     )?;
     // Wrap target: TTLV-encoded KeyValue (default TTLV Encoding Option);
     // TTLV framing pads to 8 bytes, satisfying AES-KW's input contract.
@@ -1281,6 +1282,7 @@ fn resolve_kek(
     kek_uid: &str,
     required_usage: crate::kmip30::UsageMask,
     usage_name: &str,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> crate::error::Result<Vec<u8>> {
     use crate::error::ResultReason;
@@ -1291,12 +1293,18 @@ fn resolve_kek(
     // `WrongKeyLifecycleState` (0x43). The spec reserves these codes
     // precisely for KeyWrappingSpecification / KeyWrappingData KEK
     // resolution; verified against `kmip-spec-3.0-tags-enums.json`.
+    //
+    // Part F §F7.4 — the KEK is itself a by-UID key reference, so the
+    // owner check applies here exactly like every other by-UID lookup:
+    // a foreign tenant's KEK gets the SAME `Wrapping Object Not Found`
+    // a genuinely missing KEK UID produces (anti-oracle). Without this,
+    // any tenant could wrap/unwrap under another tenant's KEK by
+    // guessing its UID.
     use crate::kmip30::State;
-    let kek_obj = deps
-        .store
-        .get(kek_uid)?
-        .ok_or_else(|| fail_err(deps, correlation_id, op,
-            KmipError::wrapping_object_not_found(kek_uid)))?;
+    let kek_obj = authorize_object(deps, auth, kek_uid, || {
+        KmipError::wrapping_object_not_found(kek_uid)
+    })
+    .map_err(|e| fail_err(deps, correlation_id, op, e))?;
     // Archived (off-line via the Archive op) takes precedence over the
     // lifecycle FSM — the material is unreachable until Recover.
     if kek_obj.archived {
@@ -1325,7 +1333,8 @@ fn resolve_kek(
     match &kek_obj.key_material {
         Some(bytes) => Ok(bytes.clone()),
         None => deps
-            .engine_session
+            .resolve_tenant_session(auth.identity.as_ref())
+            .ok()
             .and_then(|session| {
                 // WP-4 remediation — class-aware, not the ambiguous
                 // class-blind find_by_cka_id (low urgency in practice: the
@@ -1369,6 +1378,7 @@ pub fn unwrap_key_value(
     op: &str,
     kwd: &crate::kmip30::KeyWrappingSpec,
     wrapped: &[u8],
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> crate::error::Result<Vec<u8>> {
     // MAC/Signature Key Information — we support Encrypt-method
@@ -1402,7 +1412,7 @@ pub fn unwrap_key_value(
     let kek = resolve_kek(
         deps, op, &kwd.encryption_key_uid,
         crate::kmip30::UsageMask::UNWRAP_KEY, "UnwrapKey",
-        correlation_id,
+        auth, correlation_id,
     )?;
     let r = softhsmrustv3::native::aes_key_unwrap(&kek, wrapped);
     emit_pkcs11_result(deps, correlation_id, "native::aes_key_unwrap",
@@ -1913,7 +1923,7 @@ mod tests {
     #[test]
     fn wrap_kek_missing_returns_wrapping_object_not_found() {
         let d = wrap_deps();
-        let err = wrap_key_value(&d, "Get", &wrap_spec("nope"), &[0u8; 32], "c").unwrap_err();
+        let err = wrap_key_value(&d, "Get", &wrap_spec("nope"), &[0u8; 32], &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::WrappingObjectNotFound);
     }
 
@@ -1921,7 +1931,7 @@ mod tests {
     fn wrap_kek_archived_returns_wrapping_object_archived() {
         let d = wrap_deps();
         put_kek(&d, "kek", crate::kmip30::State::Active, true);
-        let err = wrap_key_value(&d, "Get", &wrap_spec("kek"), &[0u8; 32], "c").unwrap_err();
+        let err = wrap_key_value(&d, "Get", &wrap_spec("kek"), &[0u8; 32], &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::WrappingObjectArchived);
     }
 
@@ -1929,7 +1939,7 @@ mod tests {
     fn wrap_kek_destroyed_returns_wrapping_object_destroyed() {
         let d = wrap_deps();
         put_kek(&d, "kek", crate::kmip30::State::Destroyed, false);
-        let err = wrap_key_value(&d, "Get", &wrap_spec("kek"), &[0u8; 32], "c").unwrap_err();
+        let err = wrap_key_value(&d, "Get", &wrap_spec("kek"), &[0u8; 32], &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::WrappingObjectDestroyed);
     }
 
@@ -1940,7 +1950,7 @@ mod tests {
         // specific reason for Deactivated/Compromised/PreActive.
         let d = wrap_deps();
         put_kek(&d, "kek", crate::kmip30::State::Deactivated, false);
-        let err = wrap_key_value(&d, "Get", &wrap_spec("kek"), &[0u8; 32], "c").unwrap_err();
+        let err = wrap_key_value(&d, "Get", &wrap_spec("kek"), &[0u8; 32], &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::WrongKeyLifecycleState);
     }
 }

--- a/kmip/src/ops/helpers.rs
+++ b/kmip/src/ops/helpers.rs
@@ -624,6 +624,46 @@ pub fn non_active_state_error(uid: &str, state: crate::kmip30::State) -> KmipErr
     KmipError::wrong_key_lifecycle_state(uid, state_name(state))
 }
 
+/// Part F §F7.3/F7.4 (rust-hsm-perf-bench-scenario-plan-07182026.md) —
+/// the single choke point for owner-checked-by-UID object access.
+/// Fetches `uid` and verifies the requester's identity matches the
+/// object's recorded owner (`ObjectRecord::owner` — exact
+/// `Option<String>` equality; see that field's doc for why this is not
+/// a one-sided "no owner ⇒ public" rule). On ANY mismatch — missing
+/// object OR wrong owner — calls `not_found()` for the error, so a
+/// caller passes whatever "this UID doesn't exist" error THIS
+/// operation already used before ownership existed (`Get` uses
+/// `KmipError::object_not_found`, most others use the generic
+/// `KmipError::not_found`) and gets the exact same code for "not
+/// yours" — the anti-oracle property the user required (2026-07-18):
+/// within any one operation, a foreign tenant's object is
+/// indistinguishable from one that was never created.
+pub(crate) fn authorize_object(
+    deps: &super::deps::Deps,
+    auth: &crate::server::auth::AuthContext,
+    uid: &str,
+    not_found: impl Fn() -> KmipError,
+) -> std::result::Result<crate::store::ObjectRecord, KmipError> {
+    let requester = auth.identity.as_ref().map(|i| i.username.clone());
+    let obj = deps.store.get(uid)?.ok_or_else(&not_found)?;
+    if obj.owner != requester {
+        return Err(not_found());
+    }
+    Ok(obj)
+}
+
+/// Part F §F7.3 — stamp the creating identity onto a freshly-built
+/// `ObjectRecord` BEFORE `store.put(...)`. `None` (Single mode / no
+/// authenticated identity) stamps `owner: None`, matching every
+/// existing test fixture and preserving today's behavior exactly.
+pub(crate) fn stamp_owner(
+    mut record: crate::store::ObjectRecord,
+    auth: &crate::server::auth::AuthContext,
+) -> crate::store::ObjectRecord {
+    record.owner = auth.identity.as_ref().map(|i| i.username.clone());
+    record
+}
+
 pub fn state_name(s: crate::kmip30::State) -> &'static str {
     use crate::kmip30::State::*;
     match s {

--- a/kmip/src/ops/locate.rs
+++ b/kmip/src/ops/locate.rs
@@ -29,8 +29,21 @@ use super::deps::Deps;
 use super::helpers::{emit_request, emit_success, fail_err};
 use crate::error::KmipError;
 
-pub fn locate(deps: &Deps, req: LocateRequest, correlation_id: &str) -> Result<LocateResponse> {
+pub fn locate(
+    deps: &Deps,
+    req: LocateRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<LocateResponse> {
     let started = OffsetDateTime::now_utc();
+    // Part F §F7.4 — Locate results are filtered to the requester's own
+    // objects (user decision, 2026-07-18): exact `Option<String>`
+    // equality against `ObjectRecord::owner`, same rule
+    // `helpers::authorize_object` uses for single-object lookups.
+    // Without this, Locate would be the one operation that still lets a
+    // tenant enumerate every UID in the system even though it can't act
+    // on any of them.
+    let requester = auth.identity.as_ref().map(|i| i.username.clone());
     emit_request(
         deps,
         correlation_id,
@@ -88,7 +101,7 @@ pub fn locate(deps: &Deps, req: LocateRequest, correlation_id: &str) -> Result<L
         } else {
             storage_mask & STORAGE_STATUS_ONLINE != 0
         };
-        storage_ok && filters.matches(r)
+        storage_ok && filters.matches(r) && r.owner == requester
     })?;
 
     // Plane-3 reconciliation: when a real engine is wired, drop records
@@ -116,7 +129,7 @@ pub fn locate(deps: &Deps, req: LocateRequest, correlation_id: &str) -> Result<L
     // `key_material.is_none()` keeps the orphan guard sound for the
     // engine-resident case it was written for while leaving store-backed
     // objects locatable.
-    if let Some(session) = deps.engine_session {
+    if let Some(session) = deps.resolve_tenant_session(auth.identity.as_ref()).ok() {
         matches.retain(|r| {
             // WP-2 remediation — a Certificate's authoritative DER lives in
             // `certificate_value` regardless of creation path (Certify
@@ -352,6 +365,7 @@ mod tests {
     use crate::auditlog::{AuditSink, RingSink};
     use crate::kmip30::UsageMask;
     use crate::policy::{load_from_str, Engine};
+    use crate::server::auth::AuthContext;
     use crate::store::{MemoryStore, ObjectRecord};
     use std::sync::Arc;
 
@@ -425,20 +439,20 @@ mod tests {
         let mut g1 = locate(&d, LocateRequest {
             attributes: vec![Attribute::ObjectGroup("G1".into())],
             ..Default::default()
-        }, "cid").unwrap().uids;
+        }, &AuthContext::open(), "cid").unwrap().uids;
         g1.sort();
         assert_eq!(g1, vec!["a", "b"]);
 
         let g2 = locate(&d, LocateRequest {
             attributes: vec![Attribute::ObjectGroup("G2".into())],
             ..Default::default()
-        }, "cid").unwrap().uids;
+        }, &AuthContext::open(), "cid").unwrap().uids;
         assert_eq!(g2, vec!["c"]);
 
         let none = locate(&d, LocateRequest {
             attributes: vec![Attribute::ObjectGroup("nope".into())],
             ..Default::default()
-        }, "cid").unwrap().uids;
+        }, &AuthContext::open(), "cid").unwrap().uids;
         assert!(none.is_empty());
     }
 
@@ -452,7 +466,7 @@ mod tests {
             let r = locate(&d, LocateRequest {
                 attributes: vec![Attribute::ObjectGroup(g.into())],
                 ..Default::default()
-            }, "cid").unwrap();
+            }, &AuthContext::open(), "cid").unwrap();
             assert_eq!(r.uids, vec!["multi"], "should be found by group {g}");
         }
     }
@@ -480,7 +494,7 @@ mod tests {
                 Attribute::ObjectType(ObjectType::SymmetricKey),
             ],
             ..Default::default()
-        }, "cid").unwrap();
+        }, &AuthContext::open(), "cid").unwrap();
         assert_eq!(r.uids, vec!["b"]);
     }
 
@@ -493,7 +507,7 @@ mod tests {
             attributes: vec![Attribute::CryptographicAlgorithm(KmipAlgorithm::MlDsa87)],
             maximum_items: None,
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["b"]);
     }
 
@@ -506,7 +520,7 @@ mod tests {
             attributes: vec![Attribute::State(State::Active)],
             maximum_items: None,
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["a"]);
     }
 
@@ -523,7 +537,7 @@ mod tests {
             ],
             maximum_items: None,
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["a"]);
     }
 
@@ -537,7 +551,7 @@ mod tests {
             attributes: vec![],
             maximum_items: Some(2),
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids.len(), 2);
     }
 
@@ -554,13 +568,13 @@ mod tests {
             offset_items: Some(1),
             maximum_items: Some(1),
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["b"]);
         // Offset past the end → empty, not a panic.
         let r = locate(&d, LocateRequest {
             offset_items: Some(9),
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert!(r.uids.is_empty());
     }
 
@@ -575,16 +589,16 @@ mod tests {
         let r = locate(&d, LocateRequest {
             storage_status_mask: Some(0x02),
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert!(r.uids.is_empty());
         // On-line (0x01) → results.
         let r = locate(&d, LocateRequest {
             storage_status_mask: Some(0x01),
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["a"]);
         // Absent → spec default is On-line-only → results.
-        let r = locate(&d, LocateRequest::default(), "c").unwrap();
+        let r = locate(&d, LocateRequest::default(), &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["a"]);
     }
 
@@ -626,6 +640,7 @@ mod tests {
                 attributes: vec![Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes)],
                 ..Default::default()
             },
+            &AuthContext::open(),
             "c",
         )
         .unwrap();
@@ -650,25 +665,25 @@ mod tests {
         d.store.update(rec).unwrap();
 
         // Absent mask → On-line only: archived object excluded.
-        let r = locate(&d, LocateRequest::default(), "c").unwrap();
+        let r = locate(&d, LocateRequest::default(), &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["online"]);
         // On-line only (0x01) → archived excluded.
         let r = locate(&d, LocateRequest {
             storage_status_mask: Some(0x01),
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["online"]);
         // Archival only (0x02) → ONLY the archived object.
         let r = locate(&d, LocateRequest {
             storage_status_mask: Some(0x02),
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["arch"]);
         // Both (0x03) → both, in stable (InitialDate, UID) order.
         let r = locate(&d, LocateRequest {
             storage_status_mask: Some(0x03),
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["arch", "online"]);
     }
 
@@ -682,19 +697,19 @@ mod tests {
         put(&d, "dead", KmipAlgorithm::Aes, ObjectType::SymmetricKey, State::Destroyed);
 
         // Default (On-line) → tombstone hidden.
-        let r = locate(&d, LocateRequest::default(), "c").unwrap();
+        let r = locate(&d, LocateRequest::default(), &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["live"]);
         // Destroyed bit (0x04) alone → only the tombstone.
         let r = locate(&d, LocateRequest {
             storage_status_mask: Some(0x04),
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["dead"]);
         // On-line + Destroyed (0x05) → both, in stable (InitialDate, UID) order.
         let r = locate(&d, LocateRequest {
             storage_status_mask: Some(0x05),
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["dead", "live"]);
     }
 
@@ -720,7 +735,7 @@ mod tests {
         let r = locate(&d, LocateRequest {
             attributes: vec![Attribute::CryptographicLength(256)],
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["aes256"]);
     }
 
@@ -751,7 +766,7 @@ mod tests {
         let mut r = locate(&d, LocateRequest {
             attributes: vec![Attribute::CryptographicUsageMask(UsageMask::DECRYPT)],
             ..Default::default()
-        }, "c").unwrap().uids;
+        }, &AuthContext::open(), "c").unwrap().uids;
         r.sort();
         assert_eq!(r, vec!["enc-dec"]);
     }
@@ -769,7 +784,7 @@ mod tests {
         let r = locate(&d, LocateRequest {
             attributes: vec![Attribute::UniqueIdentifier("target".into())],
             ..Default::default()
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(r.uids, vec!["target"]);
     }
 }

--- a/kmip/src/ops/mac_and_hash.rs
+++ b/kmip/src/ops/mac_and_hash.rs
@@ -44,13 +44,20 @@ use super::helpers::{
 
 // ── MAC ────────────────────────────────────────────────────────────────────
 
-pub fn mac(deps: &Deps, req: MacRequest, correlation_id: &str) -> Result<MacResponse> {
+pub fn mac(
+    deps: &Deps,
+    req: MacRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<MacResponse> {
     let started = OffsetDateTime::now_utc();
     emit_request(deps, correlation_id, "MAC", format!("uid={} data_len={}", req.uid, req.data.len()));
 
-    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "MAC", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    let obj = super::helpers::authorize_object(deps, auth, &req.uid, || {
+        KmipError::object_not_found(&req.uid)
+    })
+    .map_err(|e| fail_err(deps, correlation_id, "MAC", e))?;
     require_active(&obj, "MAC")?;
     // KMIP 3.0 §11 Cryptographic Usage Mask — MAC requires the
     // `MAC Generate` bit (0x80); missing → 0x29 (K12, audit K-9).
@@ -74,7 +81,7 @@ pub fn mac(deps: &Deps, req: MacRequest, correlation_id: &str) -> Result<MacResp
 
     // K15 (B-9) — engine-resident keys MAC through the engine; the
     // in-process `hmac` crate runs ONLY for KMIP-store-only keys.
-    let mac_bytes = match (&obj.key_material, deps.engine_session) {
+    let mac_bytes = match (&obj.key_material, deps.resolve_tenant_session(auth.identity.as_ref()).ok()) {
         (None, Some(session)) => {
             let (handle, mech) =
                 engine_hmac_target(deps, correlation_id, "MAC", session, &obj, mac_algo)?;
@@ -109,15 +116,18 @@ pub fn mac(deps: &Deps, req: MacRequest, correlation_id: &str) -> Result<MacResp
 pub fn mac_verify(
     deps: &Deps,
     req: MacVerifyRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<MacVerifyResponse> {
     let started = OffsetDateTime::now_utc();
     emit_request(deps, correlation_id, "MACVerify",
                  format!("uid={} data_len={} mac_len={}", req.uid, req.data.len(), req.mac_data.len()));
 
-    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "MACVerify", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    let obj = super::helpers::authorize_object(deps, auth, &req.uid, || {
+        KmipError::object_not_found(&req.uid)
+    })
+    .map_err(|e| fail_err(deps, correlation_id, "MACVerify", e))?;
     require_active(&obj, "MACVerify")?;
     // KMIP 3.0 §11 Cryptographic Usage Mask — MAC Verify requires the
     // `MAC Verify` bit (0x100); missing → 0x29 (K12, audit K-9).
@@ -138,7 +148,7 @@ pub fn mac_verify(
     // K15 (B-9) — engine-resident keys verify through the engine
     // (`native::verify` HMAC dispatch); in-process recompute-and-compare
     // ONLY for KMIP-store-only keys.
-    let validity = match (&obj.key_material, deps.engine_session) {
+    let validity = match (&obj.key_material, deps.resolve_tenant_session(auth.identity.as_ref()).ok()) {
         (None, Some(session)) => {
             let (handle, mech) =
                 engine_hmac_target(deps, correlation_id, "MACVerify", session, &obj, mac_algo)?;
@@ -399,7 +409,7 @@ mod tests {
             uid: "v".into(),
             cryptographic_parameters: None,
             data: b"x".to_vec(),
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::IncompatibleCryptographicUsageMask);
         // … and a key with only MAC_GENERATE can't MACVerify.
         d.store.put(ObjectRecord {
@@ -416,7 +426,7 @@ mod tests {
             cryptographic_parameters: None,
             data: b"x".to_vec(),
             mac_data: vec![0u8; 32],
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::IncompatibleCryptographicUsageMask);
     }
 
@@ -428,14 +438,14 @@ mod tests {
             uid: "u".into(),
             cryptographic_parameters: None,
             data: b"hello world".to_vec(),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(m.mac_data.len(), 32, "HMAC-SHA-256 output is 32 bytes");
         let v = mac_verify(&d, MacVerifyRequest {
             uid: "u".into(),
             cryptographic_parameters: None,
             data: b"hello world".to_vec(),
             mac_data: m.mac_data,
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(v.validity, SignatureValidity::Valid);
     }
 
@@ -459,13 +469,13 @@ mod tests {
             uid: "u".into(),
             cryptographic_parameters: None,
             data: b"payload".to_vec(),
-        }, "c-soft").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c-soft").unwrap();
         mac_verify(&d, MacVerifyRequest {
             uid: "u".into(),
             cryptographic_parameters: None,
             data: b"payload".to_vec(),
             mac_data: m.mac_data,
-        }, "c-soft").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c-soft").unwrap();
         let p3 = ring.filter_plane(Plane::Pkcs11);
         assert_eq!(p3.len(), 2, "one soft-path record per MAC + MACVerify");
         for e in &p3 {
@@ -485,7 +495,7 @@ mod tests {
             cryptographic_parameters: None,
             data: b"hello world".to_vec(),
             mac_data: vec![0xff; 32],
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(v.validity, SignatureValidity::Invalid);
     }
 

--- a/kmip/src/ops/mod.rs
+++ b/kmip/src/ops/mod.rs
@@ -93,7 +93,10 @@ pub mod certify;
 #[cfg(test)]
 mod tenancy_e2e;
 
-pub use deps::{AsyncJob, AsyncJobState, AsyncJobStore, Deps, DepsConfig, RngSeedMode};
+pub use deps::{
+    AsyncJob, AsyncJobState, AsyncJobStore, Deps, DepsConfig, RngSeedMode, StrictTenantConfig,
+    TenancyMode,
+};
 
 /// K8 test fixture — the BL-M-9-30 Transparent RSA Private Key
 /// components (OASIS corpus, 1024-bit), shared by the Register /

--- a/kmip/src/ops/mod.rs
+++ b/kmip/src/ops/mod.rs
@@ -88,6 +88,11 @@ pub mod split_key;
 pub mod validate;
 pub mod certify;
 
+// Part F §F9 — end-to-end two-tenant isolation proof, driven through the
+// real dispatcher. Test-only.
+#[cfg(test)]
+mod tenancy_e2e;
+
 pub use deps::{AsyncJob, AsyncJobState, AsyncJobStore, Deps, DepsConfig, RngSeedMode};
 
 /// K8 test fixture — the BL-M-9-30 Transparent RSA Private Key

--- a/kmip/src/ops/register_import_export.rs
+++ b/kmip/src/ops/register_import_export.rs
@@ -91,6 +91,7 @@ pub fn register(
         req.object_type,
         &[],
         &mut req.attributes,
+        auth,
     );
 
     // Per §6.1.48 Table 395: if the object is cryptographic, certain

--- a/kmip/src/ops/register_import_export.rs
+++ b/kmip/src/ops/register_import_export.rs
@@ -35,6 +35,7 @@ use super::helpers::{canonical_name, emit_request, emit_success, fail_err};
 pub fn register(
     deps: &Deps,
     mut req: RegisterRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<RegisterResponse> {
     let started = OffsetDateTime::now_utc();
@@ -77,7 +78,7 @@ pub fn register(
     if let Some(kb) = req.managed_object.as_mut() {
         if let Some(kwd) = kb.key_wrapping_data.take() {
             kb.key_value = super::helpers::unwrap_key_value(
-                deps, "Register", &kwd, &kb.key_value, correlation_id,
+                deps, "Register", &kwd, &kb.key_value, auth, correlation_id,
             )?;
         }
     }
@@ -309,9 +310,13 @@ pub fn register(
     // corpus transcript Registers PQC material (QS-M-1 is
     // Query-only, QS-M-2 a Create negative) — the K9 e2e tests in
     // tests/native_bridge_e2e.rs pin the PQC flow.
-    if let (Some(material), Some(fmt), Some(session)) =
-        (key_material.as_ref(), key_format_type, deps.engine_session)
-    {
+    // Part F §F7 — client-supplied private-key material is imported
+    // into the CALLING tenant's own token, not a shared one.
+    if let (Some(material), Some(fmt), Some(session)) = (
+        key_material.as_ref(),
+        key_format_type,
+        deps.resolve_tenant_session(auth.identity.as_ref()).ok(),
+    ) {
         match (req.object_type, kmip_algorithm) {
             (ObjectType::PrivateKey, crate::kmip30::KmipAlgorithm::Rsa) => {
                 // PKCS_1 = 3 (RSAPrivateKey), PKCS_8 = 4
@@ -635,7 +640,7 @@ pub fn register(
     };
 
     let cka_id_for_cert_projection = cka_id_bytes.clone();
-    deps.store.put(ObjectRecord {
+    deps.store.put(super::helpers::stamp_owner(ObjectRecord {
         uid: uid.clone(),
         object_type: req.object_type,
         algorithm: kmip_algorithm,
@@ -683,7 +688,7 @@ pub fn register(
         // regardless of what was actually registered.
         secret_data_type: req.secret_data_type,
         ..ObjectRecord::default()
-    })?;
+    }, auth))?;
 
     // PKCS#11 v3.2 §4.6 — mirror a registered X.509 certificate onto the
     // engine too, same as Certify does (see
@@ -695,6 +700,7 @@ pub fn register(
         if let Some(der) = certificate_value.as_deref() {
             super::cert_projection::project_certificate_to_engine(
                 deps,
+                deps.resolve_tenant_session(auth.identity.as_ref()).ok(),
                 correlation_id,
                 "Register",
                 &uid,
@@ -714,6 +720,7 @@ pub fn register(
 pub fn import_object(
     deps: &Deps,
     req: ImportRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<ImportResponse> {
     let started = OffsetDateTime::now_utc();
@@ -770,8 +777,17 @@ pub fn import_object(
     // object exists with the same Unique Identifier then an error
     // SHALL be returned."
     let existing = deps.store.get(&req.uid)?;
-    if existing.is_some() {
-        if req.replace_existing {
+    if let Some(existing) = existing {
+        // Part F §F7.4 — ReplaceExisting must never overwrite a FOREIGN
+        // tenant's object: without this, any tenant could destroy (by
+        // replacement) another tenant's record just by knowing its UID.
+        // A foreign-owned collision reports the same ObjectAlreadyExists
+        // the no-replace path does — the UID namespace is genuinely
+        // global (one store keyed by UID), so collision-existence is
+        // inherently observable here; what matters is that the foreign
+        // object is untouchable.
+        let requester = auth.identity.as_ref().map(|i| i.username.clone());
+        if req.replace_existing && existing.owner == requester {
             deps.store.remove(&req.uid)?;
         } else {
             return Err(fail_err(deps, correlation_id, "Import", KmipError::failed(
@@ -826,7 +842,7 @@ pub fn import_object(
 
     let cka_id_bytes = Uuid::new_v4().as_bytes().to_vec();
     let cka_id_for_cert_projection = cka_id_bytes.clone();
-    deps.store.put(ObjectRecord {
+    deps.store.put(super::helpers::stamp_owner(ObjectRecord {
         uid: req.uid.clone(),
         object_type: req.object_type,
         algorithm: kmip_algorithm,
@@ -849,7 +865,7 @@ pub fn import_object(
         certificate_length,
         certificate_subject_cn,
         ..ObjectRecord::default()
-    })?;
+    }, auth))?;
 
     // PKCS#11 v3.2 §4.6 — mirror an imported X.509 certificate onto the
     // engine too, same as Register/Certify (see
@@ -859,6 +875,7 @@ pub fn import_object(
         if let Some(der) = certificate_value.as_deref() {
             super::cert_projection::project_certificate_to_engine(
                 deps,
+                deps.resolve_tenant_session(auth.identity.as_ref()).ok(),
                 correlation_id,
                 "Import",
                 &req.uid,
@@ -878,13 +895,19 @@ pub fn import_object(
 pub fn export(
     deps: &Deps,
     req: ExportRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<ExportResponse> {
     emit_request(deps, correlation_id, "Export", format!("uid={}", req.uid));
 
-    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "Export", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup. Export returns KEY MATERIAL,
+    // so this closes a real cross-tenant leak: it was the one
+    // material-returning by-UID handler missed by the original F7.4
+    // enumeration (found during the §L certificate-family audit).
+    let obj = super::helpers::authorize_object(deps, auth, &req.uid, || {
+        KmipError::object_not_found(&req.uid)
+    })
+    .map_err(|e| fail_err(deps, correlation_id, "Export", e))?;
 
     // KMIP 3.0 §11 — `Extractable=false` blocks all material export:
     // `Not Extractable` (0x17). Mirrors the Get check (K7 / B-4).
@@ -987,6 +1010,7 @@ pub fn export(
                         "Export",
                         spec,
                         &key_value,
+                        auth,
                         correlation_id,
                     )?;
                     (wrapped, Some(spec.clone()))
@@ -1224,7 +1248,7 @@ mod tests {
             protection_storage_masks: None,
             certificate_payload: Some((0 /* X.509 */, der.clone())),
             secret_data_type: None,
-        }, "c-wpc-register").unwrap();
+        }, &AuthContext::open(), "c-wpc-register").unwrap();
 
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(rec.certificate_value.as_deref(), Some(der.as_slice()));
@@ -1307,6 +1331,7 @@ mod tests {
                 certificate_payload: Some((0, der.clone())),
                 secret_data_type: None,
             },
+            &AuthContext::open(),
             "c-wp3-register-linked",
         )
         .unwrap();
@@ -1343,7 +1368,7 @@ mod tests {
             protection_storage_masks: None,
             certificate_payload: Some((0, vec![0xde, 0xad, 0xbe, 0xef])),
             secret_data_type: None,
-        }, "c-garbage-der").unwrap_err();
+        }, &AuthContext::open(), "c-garbage-der").unwrap_err();
         assert_eq!(err.result_reason(), crate::error::ResultReason::InvalidField);
     }
 
@@ -1379,6 +1404,7 @@ mod tests {
 
         super::super::cert_projection::project_certificate_to_engine(
             &d,
+            d.engine_session,
             "c-skip-audit",
             "TestOp",
             "urn:test:unparseable-cert",
@@ -1413,7 +1439,7 @@ mod tests {
             managed_object: Some(raw_aes128_kb()),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(rec.algorithm, KmipAlgorithm::Aes);
         assert_eq!(rec.cryptographic_length, 128);
@@ -1437,9 +1463,9 @@ mod tests {
             protection_storage_masks: None,
             certificate_payload: None,
         };
-        let resp = register(&d, req(), "c").unwrap();
+        let resp = register(&d, req(), &AuthContext::open(), "c").unwrap();
         assert_eq!(resp.uid, "urn:fixed");
-        let err = register(&d, req(), "c").unwrap_err();
+        let err = register(&d, req(), &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::ObjectAlreadyExists);
     }
 
@@ -1458,7 +1484,7 @@ mod tests {
             // Client permits Software (0x01) among others — server can satisfy it.
             protection_storage_masks: Some(0x03),
             certificate_payload: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(rec.protection_storage_mask, Some(0x01));
     }
@@ -1479,7 +1505,7 @@ mod tests {
             managed_object: Some(raw_aes128_kb()),
             protection_storage_masks: Some(0x02),
             certificate_payload: None,
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
     }
 
@@ -1499,7 +1525,7 @@ mod tests {
             managed_object: Some(raw_aes128_kb()),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
 
         let err = import_object(&d, ImportRequest {
             uid: "u".into(),
@@ -1512,7 +1538,7 @@ mod tests {
             ],
             managed_object: Some(raw_aes128_kb()),
             certificate_payload: None,
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::ObjectAlreadyExists);
     }
 
@@ -1531,7 +1557,7 @@ mod tests {
             managed_object: Some(raw_aes128_kb()),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
 
         let new_kb = KeyBlock { key_value: vec![0xAA; 16], ..raw_aes128_kb() };
         import_object(&d, ImportRequest {
@@ -1545,7 +1571,7 @@ mod tests {
             ],
             managed_object: Some(new_kb),
             certificate_payload: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
 
         let rec = d.store.get("u").unwrap().unwrap();
         assert_eq!(rec.key_material.unwrap(), vec![0xAA; 16]);
@@ -1566,14 +1592,14 @@ mod tests {
             managed_object: Some(raw_aes128_kb()),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let exp = export(&d, ExportRequest {
             uid: r.uid.clone(),
             key_format_type: None,
             key_wrap_type: None,
             key_compression_type: None,
             key_wrapping_specification: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(exp.uid, r.uid);
         assert_eq!(exp.object_type, ObjectType::SymmetricKey);
         assert!(exp.attributes.iter().any(|a| matches!(a, Attribute::Name(n) if n == "named")));
@@ -1594,7 +1620,7 @@ mod tests {
             managed_object: Some(raw_aes128_kb()),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         // Force Destroyed state via store.
         let mut rec = d.store.get(&r.uid).unwrap().unwrap();
         rec.state = State::Destroyed;
@@ -1605,7 +1631,7 @@ mod tests {
             key_wrap_type: None,
             key_compression_type: None,
             key_wrapping_specification: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert!(exp.managed_object.is_none(), "Destroyed objects MUST NOT return key material");
     }
 
@@ -1625,7 +1651,7 @@ mod tests {
             managed_object: Some(raw_aes128_kb()),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&r.uid).unwrap().unwrap();
         assert_eq!(rec.sensitive, Some(true));
         assert_eq!(rec.always_sensitive, Some(true));
@@ -1648,7 +1674,7 @@ mod tests {
             managed_object: Some(raw_aes128_kb()),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap().uid
+        }, &AuthContext::open(), "c").unwrap().uid
     }
 
     #[test]
@@ -1663,7 +1689,7 @@ mod tests {
             key_wrap_type: None,
             key_compression_type: None,
             key_wrapping_specification: None,
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::Sensitive);
     }
 
@@ -1677,7 +1703,7 @@ mod tests {
             key_wrap_type: None,
             key_compression_type: None,
             key_wrapping_specification: None,
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::NotExtractable);
     }
 
@@ -1691,7 +1717,7 @@ mod tests {
             key_wrap_type: None,
             key_compression_type: None,
             key_wrapping_specification: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert!(exp.managed_object.is_some());
     }
 
@@ -1729,7 +1755,7 @@ mod tests {
             key_wrap_type: None,
             key_compression_type: None,
             key_wrapping_specification: Some(kws(kek_uid)),
-        }, "c")
+        }, &AuthContext::open(), "c")
     }
 
     #[test]
@@ -1809,7 +1835,7 @@ mod tests {
             }),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c")
+        }, &AuthContext::open(), "c")
     }
 
     #[test]
@@ -1920,7 +1946,7 @@ mod tests {
             }),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c")
+        }, &AuthContext::open(), "c")
     }
 
     #[test]
@@ -1963,7 +1989,7 @@ mod tests {
             }),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&r.uid).unwrap().unwrap();
         assert_eq!(rec.key_format_type, Some(0x0B));
         let stored = rec.key_material.expect("material stored");
@@ -1993,7 +2019,7 @@ mod tests {
             }),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::KeyFormatTypeNotSupported);
     }
 
@@ -2012,7 +2038,7 @@ mod tests {
             }),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap().uid
+        }, &AuthContext::open(), "c").unwrap().uid
     }
 
     #[test]
@@ -2026,7 +2052,7 @@ mod tests {
             key_wrap_type: None,
             key_compression_type: None,
             key_wrapping_specification: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let kb = exp.managed_object.unwrap();
         assert_eq!(kb.key_format_type, KeyFormatType::TransparentSymmetricKey);
         assert_eq!(kb.key_value, vec![0x01; 16]);
@@ -2043,7 +2069,7 @@ mod tests {
             key_wrap_type: None,
             key_compression_type: None,
             key_wrapping_specification: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(exp.managed_object.unwrap().key_format_type, KeyFormatType::Raw);
         // TransparentSymmetricKey → PKCS#8 is not.
         let err = export(&d, ExportRequest {
@@ -2052,7 +2078,7 @@ mod tests {
             key_wrap_type: None,
             key_compression_type: None,
             key_wrapping_specification: None,
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::KeyFormatTypeNotSupported);
     }
 
@@ -2077,7 +2103,7 @@ mod tests {
             }),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
 
         let rec = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(rec.secret_data_type, Some(0x02));
@@ -2137,7 +2163,7 @@ mod tests {
             }),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c-register-ec").expect("Register an external ECDSA SPKI must succeed");
+        }, &AuthContext::open(), "c-register-ec").expect("Register an external ECDSA SPKI must succeed");
 
         // Byte-identical round trip through Get.
         let got = super::super::get::get(&deps, crate::kmip30::GetRequest {
@@ -2170,11 +2196,12 @@ mod tests {
             }),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c-register-ec-2").expect("Register on the CA-fixture session must also succeed");
+        }, &AuthContext::open(), "c-register-ec-2").expect("Register on the CA-fixture session must also succeed");
 
         let cert = super::super::certify::certify(
             &ca.deps,
             crate::kmip30::CertifyRequest { uid: Some(reregistered.uid.clone()), ..Default::default() },
+            &AuthContext::open(),
             "c-certify-external-ec",
         ).expect("Certify a Registered external ECDSA public key by UID must succeed");
         let cert_rec = ca.deps.store.get(&cert.uid).unwrap().unwrap();
@@ -2224,7 +2251,7 @@ mod tests {
             }),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
 
         let _ = session::finalize();
@@ -2266,7 +2293,7 @@ mod tests {
             }),
             protection_storage_masks: None,
             certificate_payload: None,
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::KeyFormatTypeNotSupported);
 
         let _ = session::finalize();

--- a/kmip/src/ops/register_import_export.rs
+++ b/kmip/src/ops/register_import_export.rs
@@ -1171,6 +1171,7 @@ mod tests {
     use crate::auditlog::{AuditSink, RingSink};
     use crate::kmip30::KmipAlgorithm;
     use crate::policy::{load_from_str, Engine};
+    use crate::server::auth::AuthContext;
     use crate::store::MemoryStore;
     use std::sync::Arc;
 
@@ -2085,7 +2086,7 @@ mod tests {
             uid: resp.uid,
             key_format_type: None,
             key_wrapping_specification: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(got.secret_data_type, Some(0x02));
     }
 
@@ -2143,7 +2144,7 @@ mod tests {
             uid: resp.uid.clone(),
             key_format_type: None,
             key_wrapping_specification: None,
-        }, "c-get-ec").expect("Get must succeed");
+        }, &AuthContext::open(), "c-get-ec").expect("Get must succeed");
         assert_eq!(
             got.key_block.key_value, external_spki,
             "Get must return the EXACT bytes that were Registered"

--- a/kmip/src/ops/rekey.rs
+++ b/kmip/src/ops/rekey.rs
@@ -190,6 +190,7 @@ pub fn rekey(
         ))
     })?;
     let cka_id_bytes = Uuid::new_v4().as_bytes().to_vec();
+    let session = deps.resolve_tenant_session(auth.identity.as_ref()).ok();
     let digest_value = super::create::engine_generate_symmetric(
         deps,
         correlation_id,
@@ -199,6 +200,7 @@ pub fn rekey(
         mech,
         &cka_id_bytes,
         usage,
+        session,
     )
     .map_err(&fail)?;
 

--- a/kmip/src/ops/rekey.rs
+++ b/kmip/src/ops/rekey.rs
@@ -229,8 +229,10 @@ pub fn rekey(deps: &Deps, req: ReKeyRequest, correlation_id: &str) -> Result<ReK
 pub fn rekey_key_pair(
     deps: &Deps,
     req: ReKeyKeyPairRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<ReKeyKeyPairResponse> {
+    let session = deps.resolve_tenant_session(auth.identity.as_ref()).ok();
     let started = OffsetDateTime::now_utc();
     emit_request(
         deps,
@@ -350,6 +352,7 @@ pub fn rekey_key_pair(
     let generated = super::create_key_pair::engine_generate_keypair(
         deps,
         correlation_id,
+        session,
         algo,
         key_length,
         mech,
@@ -623,6 +626,7 @@ mod tests {
     use crate::auditlog::{AuditSink, RingSink};
     use crate::kmip30::{Attribute, KmipAlgorithm, UsageMask};
     use crate::policy::{load_from_str, Engine};
+    use crate::server::auth::AuthContext;
     use crate::store::MemoryStore;
     use std::sync::Arc;
 
@@ -856,7 +860,7 @@ mod tests {
             common_attributes: vec![],
             private_key_attributes: vec![],
             public_key_attributes: vec![],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
 
         let new_priv = d.store.get(&resp.private_key_uid).unwrap().unwrap();
         let new_pub = d.store.get(&resp.public_key_uid).unwrap().unwrap();
@@ -892,7 +896,7 @@ mod tests {
             common_attributes: vec![],
             private_key_attributes: vec![Attribute::Name("new-priv".into())],
             public_key_attributes: vec![Attribute::Name("new-pub".into())],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let new_priv = d.store.get(&resp.private_key_uid).unwrap().unwrap();
         let new_pub = d.store.get(&resp.public_key_uid).unwrap().unwrap();
         assert_eq!(new_priv.name.as_deref(), Some("new-priv"));
@@ -907,14 +911,14 @@ mod tests {
         let err = rekey_key_pair(&d, ReKeyKeyPairRequest {
             uid: "ghost".into(), offset: None,
             common_attributes: vec![], private_key_attributes: vec![], public_key_attributes: vec![],
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::ObjectNotFound);
 
         put_aes(&d, "sym", State::Active);
         let err = rekey_key_pair(&d, ReKeyKeyPairRequest {
             uid: "sym".into(), offset: None,
             common_attributes: vec![], private_key_attributes: vec![], public_key_attributes: vec![],
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidObjectType);
 
         let (priv_uid, _) = put_pair(&d);
@@ -924,7 +928,7 @@ mod tests {
         let err = rekey_key_pair(&d, ReKeyKeyPairRequest {
             uid: priv_uid, offset: None,
             common_attributes: vec![], private_key_attributes: vec![], public_key_attributes: vec![],
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::WrongKeyLifecycleState);
     }
 

--- a/kmip/src/ops/rekey.rs
+++ b/kmip/src/ops/rekey.rs
@@ -111,7 +111,12 @@ const LINK_REPLACEMENT_OBJECT: &str = "ReplacementObjectLink";
 
 // ── Re-key (§6.1.51) ────────────────────────────────────────────────────────
 
-pub fn rekey(deps: &Deps, req: ReKeyRequest, correlation_id: &str) -> Result<ReKeyResponse> {
+pub fn rekey(
+    deps: &Deps,
+    req: ReKeyRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<ReKeyResponse> {
     let started = OffsetDateTime::now_utc();
     emit_request(
         deps,
@@ -121,10 +126,10 @@ pub fn rekey(deps: &Deps, req: ReKeyRequest, correlation_id: &str) -> Result<ReK
     );
     let fail = |e: KmipError| fail_err(deps, correlation_id, "ReKey", e);
 
-    let orig = deps
-        .store
-        .get(&req.uid)?
-        .ok_or_else(|| fail(KmipError::object_not_found(&req.uid)))?;
+    // Part F §F7.4 — owner-checked lookup; the replacement inherits this
+    // owner via `inherited_replacement_base`'s clone-from-orig.
+    let orig = super::helpers::authorize_object(deps, auth, &req.uid, || KmipError::object_not_found(&req.uid))
+        .map_err(&fail)?;
 
     // §6.1.51 — "a replacement key for an existing symmetric key";
     // anything else → `Invalid Object Type` (Table 407).
@@ -253,10 +258,11 @@ pub fn rekey_key_pair(
     // pair". The canonical handle is the private key (§6.1 preamble placeholder
     // order); a public-half UID is resolved to its pair mate via the
     // PrivateKeyLink so clients holding either half succeed.
-    let target = deps
-        .store
-        .get(&req.uid)?
-        .ok_or_else(|| fail(KmipError::object_not_found(&req.uid)))?;
+    // Part F §F7.4 — owner-checked lookup. The new halves below inherit
+    // this owner via `inherited_replacement_base`'s clone-from-orig, so
+    // a rekey correctly stays with the same tenant.
+    let target = super::helpers::authorize_object(deps, auth, &req.uid, || KmipError::object_not_found(&req.uid))
+        .map_err(&fail)?;
     let (old_priv, old_pub) = match target.object_type {
         ObjectType::PrivateKey => {
             let pub_rec = pair_mate(deps, &target, "PublicKeyLink").map_err(&fail)?;
@@ -714,7 +720,7 @@ mod tests {
         put_aes(&d, "orig", State::Active);
         let resp = rekey(&d, ReKeyRequest {
             uid: "orig".into(), offset: None, template_attribute: vec![],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_ne!(resp.uid, "orig", "Unique Identifier — new value generated");
 
         let new = d.store.get(&resp.uid).unwrap().unwrap();
@@ -758,7 +764,7 @@ mod tests {
                 Attribute::CryptographicUsageMask(UsageMask::WRAP_KEY),
                 Attribute::Name("rotated-aes".into()),
             ],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let new = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(new.cryptographic_length, 128, "request length wins over inherited 256");
         assert_eq!(new.usage_mask, UsageMask::WRAP_KEY);
@@ -781,7 +787,7 @@ mod tests {
         let off = 3600u32; // replacement activates in an hour
         let resp = rekey(&d, ReKeyRequest {
             uid: "orig".into(), offset: Some(off), template_attribute: vec![],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let new = d.store.get(&resp.uid).unwrap().unwrap();
 
         // AT2 = IT2 + Offset (IT2 = the re-key instant).
@@ -811,7 +817,7 @@ mod tests {
         put_aes(&d, "orig", State::PreActive);
         let resp = rekey(&d, ReKeyRequest {
             uid: "orig".into(), offset: None, template_attribute: vec![],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert_eq!(d.store.get(&resp.uid).unwrap().unwrap().state, State::PreActive);
         let old = d.store.get("orig").unwrap().unwrap();
         assert_eq!(old.state, State::PreActive, "no PreActive→Deactivated transition");
@@ -826,25 +832,25 @@ mod tests {
         // Object Not Found.
         let err = rekey(&d, ReKeyRequest {
             uid: "ghost".into(), offset: None, template_attribute: vec![],
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::ObjectNotFound);
         // Invalid Object Type — ReKey on an asymmetric half.
         let (priv_uid, _) = put_pair(&d);
         let err = rekey(&d, ReKeyRequest {
             uid: priv_uid, offset: None, template_attribute: vec![],
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidObjectType);
         // Wrong Key Lifecycle State — Deactivated original.
         put_aes(&d, "dead", State::Deactivated);
         let err = rekey(&d, ReKeyRequest {
             uid: "dead".into(), offset: None, template_attribute: vec![],
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::WrongKeyLifecycleState);
         // Wrong Key Lifecycle State — Compromised original.
         put_aes(&d, "comp", State::Compromised);
         let err = rekey(&d, ReKeyRequest {
             uid: "comp".into(), offset: None, template_attribute: vec![],
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::WrongKeyLifecycleState);
     }
 
@@ -950,7 +956,7 @@ mod tests {
         put_aes(&d, "orig", State::Active);
         let resp = rekey(&d, ReKeyRequest {
             uid: "orig".into(), offset: None, template_attribute: vec![],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let new = d.store.get(&resp.uid).unwrap().unwrap();
         assert_eq!(new.cryptographic_length, 256, "inherited length outranks the default");
         assert_eq!(new.usage_mask, UsageMask::ENCRYPT | UsageMask::DECRYPT);

--- a/kmip/src/ops/rekey.rs
+++ b/kmip/src/ops/rekey.rs
@@ -954,7 +954,7 @@ mod tests {
                     Attribute::CryptographicUsageMask(UsageMask::EXPORT),
                 ],
             }]),
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         put_aes(&d, "orig", State::Active);
         let resp = rekey(&d, ReKeyRequest {
             uid: "orig".into(), offset: None, template_attribute: vec![],

--- a/kmip/src/ops/related_certs.rs
+++ b/kmip/src/ops/related_certs.rs
@@ -51,6 +51,7 @@ use spki::AlgorithmIdentifierOwned;
 
 use crate::error::{KmipError, Result, ResultReason};
 
+#[cfg(test)]
 use super::deps::Deps;
 
 /// RelatedCertificate — RFC 9763, id-pe 36.
@@ -95,7 +96,7 @@ pub fn extract_related_cert_claim(ext_value: &[u8]) -> Result<(String, Vec<u8>)>
 /// `self_index` is skipped (a certificate never counts as its own
 /// companion).
 pub fn resolve_related_cert(
-    deps: &Deps,
+    session: Option<u32>,
     hash_algorithm_oid: &str,
     claimed_hash: &[u8],
     all_der: &[Vec<u8>],
@@ -110,7 +111,13 @@ pub fn resolve_related_cert(
             ),
         ));
     }
-    let _session = deps.engine_session.ok_or_else(|| {
+    // Presence gate only — `native::digest` is session-less by design
+    // (no stored object is touched, nothing lands in any token), so no
+    // handle is actually consumed here. The caller-resolved tenant
+    // session (Part F §F7) stands in for the old bare
+    // `deps.engine_session` read purely as the fail-closed
+    // "an engine is initialized for this caller" check.
+    let _session = session.ok_or_else(|| {
         KmipError::failed(ResultReason::CryptographicFailure, "RelatedCertificate: no engine session to compute digests")
     })?;
 
@@ -190,7 +197,7 @@ pub(crate) mod tests {
         let real_hash = softhsmrustv3::native::digest(softhsmrustv3::constants::CKM_SHA256, &companion).unwrap();
 
         let all = vec![b"self placeholder DER".to_vec(), companion];
-        let verdict = resolve_related_cert(&deps, SHA256_OID, &real_hash, &all, 0).unwrap();
+        let verdict = resolve_related_cert(deps.engine_session, SHA256_OID, &real_hash, &all, 0).unwrap();
         assert_eq!(verdict, RelatedCertVerdict::Bound);
     }
 
@@ -199,7 +206,7 @@ pub(crate) mod tests {
         let (deps, _g) = deps_with_session();
         let claimed = vec![0x11u8; 32];
         let all = vec![b"self placeholder DER".to_vec()];
-        let verdict = resolve_related_cert(&deps, SHA256_OID, &claimed, &all, 0).unwrap();
+        let verdict = resolve_related_cert(deps.engine_session, SHA256_OID, &claimed, &all, 0).unwrap();
         assert_eq!(verdict, RelatedCertVerdict::Unknown);
     }
 
@@ -208,14 +215,14 @@ pub(crate) mod tests {
         let (deps, _g) = deps_with_session();
         let claimed = vec![0x11u8; 32]; // matches nothing real
         let all = vec![b"self placeholder DER".to_vec(), b"an unrelated companion DER".to_vec()];
-        let verdict = resolve_related_cert(&deps, SHA256_OID, &claimed, &all, 0).unwrap();
+        let verdict = resolve_related_cert(deps.engine_session, SHA256_OID, &claimed, &all, 0).unwrap();
         assert_eq!(verdict, RelatedCertVerdict::Invalid);
     }
 
     #[test]
     fn unsupported_hash_algorithm_is_honest_not_guessed() {
         let (deps, _g) = deps_with_session();
-        let err = resolve_related_cert(&deps, "2.16.840.1.101.3.4.2.3" /* SHA-512 */, &[0u8; 64], &[vec![], vec![]], 0)
+        let err = resolve_related_cert(deps.engine_session, "2.16.840.1.101.3.4.2.3" /* SHA-512 */, &[0u8; 64], &[vec![], vec![]], 0)
             .unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::OperationNotSupported);
     }

--- a/kmip/src/ops/revoke.rs
+++ b/kmip/src/ops/revoke.rs
@@ -33,7 +33,12 @@ use super::helpers::{
     canonical_name, emit_request, emit_state_change, emit_success, fail_err, state_name,
 };
 
-pub fn revoke(deps: &Deps, req: RevokeRequest, correlation_id: &str) -> Result<RevokeResponse> {
+pub fn revoke(
+    deps: &Deps,
+    req: RevokeRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<RevokeResponse> {
     let started = OffsetDateTime::now_utc();
     emit_request(
         deps,
@@ -42,10 +47,11 @@ pub fn revoke(deps: &Deps, req: RevokeRequest, correlation_id: &str) -> Result<R
         format!("uid={} reason={:?}", req.uid, req.reason),
     );
 
-    let mut obj = deps
-        .store
-        .get(&req.uid)?
-        .ok_or_else(|| fail_err(deps, correlation_id, "Revoke", KmipError::object_not_found(&req.uid)))?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    let mut obj = super::helpers::authorize_object(deps, auth, &req.uid, || {
+        KmipError::object_not_found(&req.uid)
+    })
+    .map_err(|e| fail_err(deps, correlation_id, "Revoke", e))?;
 
     // KMIP 3.0 §3 state-transition list — only Revoke transitions
     // permitted (enumerated by the spec under the State attribute
@@ -99,7 +105,9 @@ pub fn revoke(deps: &Deps, req: RevokeRequest, correlation_id: &str) -> Result<R
     if obj.object_type == ObjectType::Certificate
         && matches!(target_state, State::Compromised | State::DestroyedCompromised)
     {
-        if let Some(session) = deps.engine_session {
+        // Part F §F7 — the revoked cert's engine mirror lives in the
+        // caller's own token (ownership verified above).
+        if let Some(session) = deps.resolve_tenant_session(auth.identity.as_ref()).ok() {
             if let Ok(Some(handle)) =
                 super::helpers::find_handle_for_object(session, &obj.pkcs11_cka_id, obj.object_type)
             {
@@ -199,7 +207,7 @@ mod tests {
     fn unspecified_reason_yields_deactivated() {
         let d = deps_with(ALLOW);
         active(&d, "u");
-        let resp = revoke(&d, RevokeRequest { uid: "u".into(), reason: RevocationReason::Unspecified }, "c").unwrap();
+        let resp = revoke(&d, RevokeRequest { uid: "u".into(), reason: RevocationReason::Unspecified }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(resp.state, State::Deactivated);
     }
 
@@ -207,7 +215,7 @@ mod tests {
     fn key_compromise_yields_compromised() {
         let d = deps_with(ALLOW);
         active(&d, "u2");
-        let resp = revoke(&d, RevokeRequest { uid: "u2".into(), reason: RevocationReason::KeyCompromise }, "c").unwrap();
+        let resp = revoke(&d, RevokeRequest { uid: "u2".into(), reason: RevocationReason::KeyCompromise }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(resp.state, State::Compromised);
     }
 
@@ -240,7 +248,7 @@ mod tests {
         }).unwrap();
         let resp = revoke(&d, RevokeRequest {
             uid: "d".into(), reason: RevocationReason::KeyCompromise,
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(resp.state, State::Compromised);
     }
 
@@ -270,7 +278,7 @@ mod tests {
         }).unwrap();
         let resp = revoke(&d, RevokeRequest {
             uid: "p".into(), reason: RevocationReason::CaCompromise,
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(resp.state, State::Compromised);
     }
 
@@ -300,7 +308,7 @@ mod tests {
         }).unwrap();
         let err = revoke(&d, RevokeRequest {
             uid: "pu".into(), reason: RevocationReason::Unspecified,
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), crate::error::ResultReason::WrongKeyLifecycleState);
     }
 

--- a/kmip/src/ops/rng_and_pkcs11.rs
+++ b/kmip/src/ops/rng_and_pkcs11.rs
@@ -97,7 +97,12 @@ const C_INITIALIZE: u32 = 1;
 const C_FINALIZE: u32 = 2;
 const C_GET_INFO: u32 = 3;
 
-pub fn pkcs11(deps: &Deps, req: Pkcs11Request, correlation_id: &str) -> Result<Pkcs11Response> {
+pub fn pkcs11(
+    deps: &Deps,
+    req: Pkcs11Request,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<Pkcs11Response> {
     emit_request(
         deps,
         correlation_id,
@@ -137,7 +142,13 @@ pub fn pkcs11(deps: &Deps, req: Pkcs11Request, correlation_id: &str) -> Result<P
         C_GET_INFO => {
             if !deps.pkcs11_virtual_initialized.load(Ordering::SeqCst) {
                 (softhsmrustv3::constants::CKR_CRYPTOKI_NOT_INITIALIZED as i32, None)
-            } else if deps.engine_session.is_some() {
+            } else if deps.resolve_tenant_session(auth.identity.as_ref()).is_ok() {
+                // Part F §F7 — presence check only: C_GetInfo is global
+                // library identity (no session parameter, no tenant
+                // data), but "is a real engine wired for THIS caller"
+                // must account for tenancy mode, which the old bare
+                // `engine_session.is_some()` did not (always false in
+                // Strict/Auto).
                 // The real engine (bootstrapped at server startup, so
                 // its own global init state is already true) — genuine
                 // CK_INFO bytes, 72 B per PKCS#11 v3.2 §5.4.
@@ -274,7 +285,7 @@ mod tests {
             function: 0x01, // C_Initialize (KMIP 3.0 §11.39 PKCS#11 Function enum)
             correlation_value: Some(vec![0xCA, 0xFE]),
             input_parameters: None,
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(r.return_code, 0);
         assert_eq!(r.correlation_value, Some(vec![0xCA, 0xFE]));
         assert_eq!(r.function, 0x01);
@@ -292,46 +303,46 @@ mod tests {
     #[test]
     fn pkcs11_initialize_then_getinfo_then_finalize_round_trips() {
         let d = deps_with();
-        assert_eq!(pkcs11(&d, pkcs11_req(C_INITIALIZE), "c").unwrap().return_code, 0);
-        assert_eq!(pkcs11(&d, pkcs11_req(C_GET_INFO), "c").unwrap().return_code, 0);
-        assert_eq!(pkcs11(&d, pkcs11_req(C_FINALIZE), "c").unwrap().return_code, 0);
+        assert_eq!(pkcs11(&d, pkcs11_req(C_INITIALIZE), &crate::server::auth::AuthContext::open(), "c").unwrap().return_code, 0);
+        assert_eq!(pkcs11(&d, pkcs11_req(C_GET_INFO), &crate::server::auth::AuthContext::open(), "c").unwrap().return_code, 0);
+        assert_eq!(pkcs11(&d, pkcs11_req(C_FINALIZE), &crate::server::auth::AuthContext::open(), "c").unwrap().return_code, 0);
     }
 
     #[test]
     fn pkcs11_double_initialize_without_finalize_fails() {
         let d = deps_with();
-        assert_eq!(pkcs11(&d, pkcs11_req(C_INITIALIZE), "c").unwrap().return_code, 0);
-        let second = pkcs11(&d, pkcs11_req(C_INITIALIZE), "c").unwrap();
+        assert_eq!(pkcs11(&d, pkcs11_req(C_INITIALIZE), &crate::server::auth::AuthContext::open(), "c").unwrap().return_code, 0);
+        let second = pkcs11(&d, pkcs11_req(C_INITIALIZE), &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(second.return_code, softhsmrustv3::constants::CKR_CRYPTOKI_ALREADY_INITIALIZED as i32);
     }
 
     #[test]
     fn pkcs11_finalize_without_initialize_fails() {
         let d = deps_with();
-        let r = pkcs11(&d, pkcs11_req(C_FINALIZE), "c").unwrap();
+        let r = pkcs11(&d, pkcs11_req(C_FINALIZE), &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(r.return_code, softhsmrustv3::constants::CKR_CRYPTOKI_NOT_INITIALIZED as i32);
     }
 
     #[test]
     fn pkcs11_get_info_before_initialize_fails() {
         let d = deps_with();
-        let r = pkcs11(&d, pkcs11_req(C_GET_INFO), "c").unwrap();
+        let r = pkcs11(&d, pkcs11_req(C_GET_INFO), &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(r.return_code, softhsmrustv3::constants::CKR_CRYPTOKI_NOT_INITIALIZED as i32);
     }
 
     #[test]
     fn pkcs11_unsupported_function_returns_function_not_supported() {
         let d = deps_with();
-        let r = pkcs11(&d, pkcs11_req(0xffff), "c").unwrap();
+        let r = pkcs11(&d, pkcs11_req(0xffff), &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(r.return_code, softhsmrustv3::constants::CKR_FUNCTION_NOT_SUPPORTED as i32);
     }
 
     #[test]
     fn pkcs11_finalize_allows_reinitialize() {
         let d = deps_with();
-        assert_eq!(pkcs11(&d, pkcs11_req(C_INITIALIZE), "c").unwrap().return_code, 0);
-        assert_eq!(pkcs11(&d, pkcs11_req(C_FINALIZE), "c").unwrap().return_code, 0);
+        assert_eq!(pkcs11(&d, pkcs11_req(C_INITIALIZE), &crate::server::auth::AuthContext::open(), "c").unwrap().return_code, 0);
+        assert_eq!(pkcs11(&d, pkcs11_req(C_FINALIZE), &crate::server::auth::AuthContext::open(), "c").unwrap().return_code, 0);
         // A fresh C_Initialize after C_Finalize must succeed again.
-        assert_eq!(pkcs11(&d, pkcs11_req(C_INITIALIZE), "c").unwrap().return_code, 0);
+        assert_eq!(pkcs11(&d, pkcs11_req(C_INITIALIZE), &crate::server::auth::AuthContext::open(), "c").unwrap().return_code, 0);
     }
 }

--- a/kmip/src/ops/session_and_auth.rs
+++ b/kmip/src/ops/session_and_auth.rs
@@ -53,6 +53,7 @@ fn credential_object_type(credential_type: u32) -> ObjectType {
 pub fn create_credential(
     deps: &Deps,
     req: CreateCredentialRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<CreateCredentialResponse> {
     emit_request(
@@ -103,7 +104,7 @@ pub fn create_credential(
 
     // K4 — persist under the true Credential Object Type, not Secret Data.
     let uid =
-        persist_simple_record(deps, credential_object_type(req.credential_type), req.attributes)?;
+        persist_simple_record(deps, credential_object_type(req.credential_type), req.attributes, auth)?;
     emit_success(deps, correlation_id, "CreateCredential");
     Ok(CreateCredentialResponse { uid })
 }
@@ -113,12 +114,13 @@ pub fn create_credential(
 pub fn create_group(
     deps: &Deps,
     req: CreateGroupRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<CreateGroupResponse> {
     emit_request(deps, correlation_id, "CreateGroup", format!("attrs={}", req.attributes.len()));
     // K4 — KMIP 3.0 Object Type enum defines Group (0x0c); persist under it so
     // GetAttributes/Locate report the true type (was Secret Data).
-    let uid = persist_simple_record(deps, ObjectType::Group, req.attributes)?;
+    let uid = persist_simple_record(deps, ObjectType::Group, req.attributes, auth)?;
     emit_success(deps, correlation_id, "CreateGroup");
     Ok(CreateGroupResponse { uid })
 }
@@ -128,11 +130,12 @@ pub fn create_group(
 pub fn create_user(
     deps: &Deps,
     req: CreateUserRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<CreateUserResponse> {
     emit_request(deps, correlation_id, "CreateUser", format!("attrs={}", req.attributes.len()));
     // K4 — KMIP 3.0 Object Type enum defines User (0x0b); persist under it.
-    let uid = persist_simple_record(deps, ObjectType::User, req.attributes)?;
+    let uid = persist_simple_record(deps, ObjectType::User, req.attributes, auth)?;
     emit_success(deps, correlation_id, "CreateUser");
     Ok(CreateUserResponse { uid })
 }
@@ -242,6 +245,7 @@ fn persist_simple_record(
     deps: &Deps,
     object_type: ObjectType,
     attrs: Vec<Attribute>,
+    auth: &crate::server::auth::AuthContext,
 ) -> Result<String> {
     let uid = format!("urn:pqctoday:obj:{}", Uuid::new_v4());
     let now = OffsetDateTime::now_utc();
@@ -249,7 +253,7 @@ fn persist_simple_record(
         Attribute::Name(n) => Some(n.clone()),
         _ => None,
     });
-    deps.store.put(ObjectRecord {
+    deps.store.put(super::helpers::stamp_owner(ObjectRecord {
         uid: uid.clone(),
         object_type,
         // No cryptographic algorithm for a User / Group / Credential —
@@ -271,7 +275,7 @@ fn persist_simple_record(
         key_material: None,
         key_format_type: None,
     ..ObjectRecord::default()
-})?;
+}, auth))?;
     Ok(uid)
 }
 
@@ -305,7 +309,7 @@ mod tests {
                 username: "alice".into(),
                 password: Some("secret".into()),
             }),
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert!(d.store.get(&r.uid).unwrap().is_some());
     }
 
@@ -316,7 +320,7 @@ mod tests {
             credential_type: 0x01,
             attributes: vec![],
             password_credential: None,
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::MissingData);
     }
 
@@ -326,10 +330,10 @@ mod tests {
         // (0x0b/0x0c/0x0d–0x10), not Secret Data, so GetAttributes/Locate report it.
         let d = deps_with();
 
-        let u = create_user(&d, CreateUserRequest { attributes: vec![Attribute::Name("bob".into())] }, "u").unwrap();
+        let u = create_user(&d, CreateUserRequest { attributes: vec![Attribute::Name("bob".into())] }, &AuthContext::open(), "u").unwrap();
         assert_eq!(d.store.get(&u.uid).unwrap().unwrap().object_type, ObjectType::User);
 
-        let g = create_group(&d, CreateGroupRequest { attributes: vec![Attribute::Name("admins".into())] }, "g").unwrap();
+        let g = create_group(&d, CreateGroupRequest { attributes: vec![Attribute::Name("admins".into())] }, &AuthContext::open(), "g").unwrap();
         assert_eq!(d.store.get(&g.uid).unwrap().unwrap().object_type, ObjectType::Group);
 
         // Password/Username (0x01) → PasswordCredential; Device (0x02) → DeviceCredential;
@@ -337,18 +341,18 @@ mod tests {
         let c1 = create_credential(&d, CreateCredentialRequest {
             credential_type: 0x01, attributes: vec![],
             password_credential: Some(PasswordCredential { username: "a".into(), password: Some("p".into()) }),
-        }, "c1").unwrap();
+        }, &AuthContext::open(), "c1").unwrap();
         assert_eq!(d.store.get(&c1.uid).unwrap().unwrap().object_type, ObjectType::PasswordCredential);
 
         let c2 = create_credential(&d, CreateCredentialRequest {
             credential_type: 0x02, attributes: vec![], password_credential: None,
-        }, "c2").unwrap();
+        }, &AuthContext::open(), "c2").unwrap();
         assert_eq!(d.store.get(&c2.uid).unwrap().unwrap().object_type, ObjectType::DeviceCredential);
 
         let c5 = create_credential(&d, CreateCredentialRequest {
             credential_type: 0x05, attributes: vec![],
             password_credential: Some(PasswordCredential { username: "a".into(), password: Some("h".into()) }),
-        }, "c5").unwrap();
+        }, &AuthContext::open(), "c5").unwrap();
         assert_eq!(d.store.get(&c5.uid).unwrap().unwrap().object_type, ObjectType::HashedPasswordCredential);
     }
 
@@ -362,7 +366,7 @@ mod tests {
             credential_type: 0x02, // Device
             attributes: vec![],
             password_credential: None,
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         assert!(!resp.uid.is_empty());
     }
 
@@ -373,7 +377,7 @@ mod tests {
             credential_type: 0xFF, // unassigned
             attributes: vec![],
             password_credential: None,
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::InvalidField);
     }
 
@@ -478,7 +482,7 @@ mod tests {
         let d = deps_with();
         let r = create_group(&d, CreateGroupRequest {
             attributes: vec![Attribute::Name("admins".into())],
-        }, "c").unwrap();
+        }, &AuthContext::open(), "c").unwrap();
         let rec = d.store.get(&r.uid).unwrap().unwrap();
         assert_eq!(rec.name.as_deref(), Some("admins"));
     }

--- a/kmip/src/ops/sign.rs
+++ b/kmip/src/ops/sign.rs
@@ -53,11 +53,9 @@ pub fn sign(
         },
     ));
 
-    // ── Plane 2: store lookup ───────────────────────────────────────────
-    let obj = deps
-        .store
-        .get(&req.uid)?
-        .ok_or_else(|| fail_err(deps, correlation_id, "Sign", KmipError::object_not_found(&req.uid)))?;
+    // ── Plane 2: store lookup (Part F §F7.4 — owner-checked) ─────────────
+    let obj = super::helpers::authorize_object(deps, auth, &req.uid, || KmipError::object_not_found(&req.uid))
+        .map_err(|e| fail_err(deps, correlation_id, "Sign", e))?;
 
     // ── Lifecycle gate (KMIP 3.0 §3.x — Sign requires Active) ───────────
     if obj.state != State::Active {

--- a/kmip/src/ops/sign.rs
+++ b/kmip/src/ops/sign.rs
@@ -34,7 +34,13 @@ use crate::policy::{Decision, PolicyRequest};
 
 use super::deps::Deps;
 
-pub fn sign(deps: &Deps, req: SignRequest, correlation_id: &str) -> Result<SignResponse> {
+pub fn sign(
+    deps: &Deps,
+    req: SignRequest,
+    auth: &crate::server::auth::AuthContext,
+    correlation_id: &str,
+) -> Result<SignResponse> {
+    let session = deps.resolve_tenant_session(auth.identity.as_ref()).ok();
     let started = OffsetDateTime::now_utc();
     deps.sink.emit(AuditEvent::at(
         started,
@@ -175,7 +181,7 @@ pub fn sign(deps: &Deps, req: SignRequest, correlation_id: &str) -> Result<SignR
             // → activate → deactivate+supersede the old → re-issue the Sign) and
             // return the signature under the migrated algorithm. The application
             // signed with an unchanged call; the engine migrated the key.
-            return rekey_and_sign(deps, &req, &obj, &new_algorithm, correlation_id);
+            return rekey_and_sign(deps, &req, &obj, &new_algorithm, auth, correlation_id);
         }
     };
 
@@ -185,7 +191,7 @@ pub fn sign(deps: &Deps, req: SignRequest, correlation_id: &str) -> Result<SignR
     // worse than no log). Falls back to a deterministic SHA-256
     // placeholder (audited as `soft::placeholder_sign`) for unit tests
     // that don't bootstrap an engine.
-    let signature = match deps.engine_session {
+    let signature = match session {
         Some(session) => {
             // KMIP UID → CKA_ID → engine handle → native::sign. Filter
             // by ObjectType because pub + prv share CKA_ID per PKCS#11
@@ -326,6 +332,7 @@ fn rekey_and_sign(
     req: &SignRequest,
     old: &crate::store::ObjectRecord,
     new_algorithm: &str,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<SignResponse> {
     use crate::kmip30::UsageMask;
@@ -337,6 +344,7 @@ fn rekey_and_sign(
         new_algorithm,
         UsageMask::SIGN | UsageMask::VERIFY,
         "CreateKeyPair:Sign",
+        auth,
         correlation_id,
     )
     .map_err(|e| fail_err(deps, correlation_id, "Sign", e))?;
@@ -372,6 +380,7 @@ fn rekey_and_sign(
             data: req.data.clone(),
             cryptographic_parameters: req.cryptographic_parameters.clone(),
         },
+        auth,
         correlation_id,
     )?;
     resp.rekeyed = Some(crate::kmip30::SignRekeyInfo {
@@ -416,6 +425,7 @@ mod tests {
     use crate::auditlog::RingSink;
     use crate::kmip30::{KmipAlgorithm, ObjectType, UsageMask};
     use crate::policy::{load_from_str, Engine};
+    use crate::server::auth::AuthContext;
     use crate::store::{MemoryStore, ObjectRecord};
     use std::sync::Arc;
 
@@ -508,7 +518,7 @@ rules:
             uid: "u".into(),
             data: b"x".to_vec(),
             cryptographic_parameters: None,
-        }, "c").unwrap_err();
+        }, &AuthContext::open(), "c").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::IncompatibleCryptographicUsageMask);
     }
 
@@ -523,6 +533,7 @@ rules:
                 data: b"hello".to_vec(),
             cryptographic_parameters: None,
         },
+            &AuthContext::open(),
             "corr-sign",
         )
         .unwrap();
@@ -548,6 +559,7 @@ rules:
             SignRequest { uid: "urn:nope".into(), data: vec![],
             cryptographic_parameters: None,
         },
+            &AuthContext::open(),
             "corr-404",
         )
         .unwrap_err();
@@ -586,7 +598,7 @@ rules:
         d.store.put(rec).unwrap();
         let err = sign(&d, SignRequest { uid: "urn:pre".into(), data: vec![],
             cryptographic_parameters: None,
-        }, "corr").unwrap_err();
+        }, &AuthContext::open(), "corr").unwrap_err();
         // KMIP 3.0 §11 — PreActive is a lifecycle-state failure.
         assert_eq!(err.result_reason(), ResultReason::WrongKeyLifecycleState);
     }
@@ -603,6 +615,7 @@ rules:
             SignRequest { uid: "urn:ecdsa".into(), data: b"x".to_vec(),
             cryptographic_parameters: None,
         },
+            &AuthContext::open(),
             "corr-rk",
         )
         .unwrap();

--- a/kmip/src/ops/signature_verify.rs
+++ b/kmip/src/ops/signature_verify.rs
@@ -42,6 +42,7 @@ use super::helpers::{
 pub fn signature_verify(
     deps: &Deps,
     req: SignatureVerifyRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<SignatureVerifyResponse> {
     let started = OffsetDateTime::now_utc();
@@ -52,9 +53,11 @@ pub fn signature_verify(
         format!("uid={} data_len={} sig_len={}", req.uid, req.data.len(), req.signature.len()),
     );
 
-    let obj = deps.store.get(&req.uid)?.ok_or_else(|| {
-        fail_err(deps, correlation_id, "SignatureVerify", KmipError::object_not_found(&req.uid))
-    })?;
+    // Part F §F7.4 — owner-checked lookup (see get.rs for the pattern).
+    let obj = super::helpers::authorize_object(deps, auth, &req.uid, || {
+        KmipError::object_not_found(&req.uid)
+    })
+    .map_err(|e| fail_err(deps, correlation_id, "SignatureVerify", e))?;
 
     // KMIP 3.0 §3.x lifecycle — Verify allowed in Active / Deactivated /
     // Compromised (need to verify legacy artefacts). Blocked in PreActive
@@ -148,7 +151,7 @@ pub fn signature_verify(
     // audit record is emitted after `native::verify` returns with the
     // call's real rv. Falls back to the SHA-256 stamp comparison
     // (audited as `soft::placeholder_verify`) for unit tests.
-    let validity = match deps.engine_session {
+    let validity = match deps.resolve_tenant_session(auth.identity.as_ref()).ok() {
         Some(session) => {
             let handle =
                 super::helpers::find_handle_for_object(session, &obj.pkcs11_cka_id, obj.object_type)
@@ -356,7 +359,7 @@ mod tests {
             data: b"x".to_vec(),
             signature: vec![0u8; 32],
             cryptographic_parameters: None,
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         assert_eq!(
             err.result_reason(),
             crate::error::ResultReason::IncompatibleCryptographicUsageMask
@@ -369,7 +372,7 @@ mod tests {
         active(&d, "u");
         let data = b"hello world".to_vec();
         let sig = placeholder_signature("u", &data);
-        let r = signature_verify(&d, SignatureVerifyRequest { uid: "u".into(), data, signature: sig, cryptographic_parameters: None }, "c").unwrap();
+        let r = signature_verify(&d, SignatureVerifyRequest { uid: "u".into(), data, signature: sig, cryptographic_parameters: None }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(r.validity, SignatureValidity::Valid);
     }
 
@@ -382,7 +385,7 @@ mod tests {
             data: b"hello".to_vec(),
             signature: vec![0xff; 32],
             cryptographic_parameters: None,
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         assert_eq!(r.validity, SignatureValidity::Invalid);
     }
 
@@ -419,7 +422,7 @@ mod tests {
             data: vec![],
             signature: vec![],
             cryptographic_parameters: None,
-        }, "c").unwrap();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap();
         // success — Verify is permitted in Deactivated state per §3.4
     }
 
@@ -456,7 +459,7 @@ mod tests {
             data: vec![],
             signature: vec![],
             cryptographic_parameters: None,
-        }, "c").unwrap_err();
+        }, &crate::server::auth::AuthContext::open(), "c").unwrap_err();
         // KMIP 3.0 §11 — Destroyed is an FSM-rejection state. See
         // `ops::helpers::non_active_state_error` for the citation.
         assert_eq!(err.result_reason(), ResultReason::WrongKeyLifecycleState);

--- a/kmip/src/ops/spki_verify.rs
+++ b/kmip/src/ops/spki_verify.rs
@@ -36,6 +36,7 @@ use spki::{AlgorithmIdentifierOwned, SubjectPublicKeyInfoOwned};
 
 use crate::error::{KmipError, Result, ResultReason};
 
+#[cfg(test)]
 use super::deps::Deps;
 
 /// The three-way verdict [`verify_with_spki`] returns — mirrors KMIP's
@@ -154,8 +155,16 @@ impl Drop for DestroyOnDrop {
 /// returns. `Ok(SpkiVerdict::UnsupportedAlgorithm)` (not an `Err`) for a
 /// `sig_alg` OID this server has no mechanism for, matching KMIP's
 /// honest-degrade contract for Signature Verify / Validate.
+///
+/// Part F §F7 — `session` is the CALLER's already-resolved
+/// `deps.resolve_tenant_session(...)` result (this helper has no auth
+/// context of its own; reading the bare `deps.engine_session` field
+/// here, as it did before, silently ignored tenancy). The key material
+/// verified against is caller-supplied bytes, not a stored object — but
+/// the transient import still creates (and destroys) an object inside
+/// whatever token `session` names, so it must be the caller's own.
 pub fn verify_with_spki(
-    deps: &Deps,
+    session: Option<u32>,
     spki: &SubjectPublicKeyInfoOwned,
     sig_alg: &AlgorithmIdentifierOwned,
     msg: &[u8],
@@ -163,7 +172,7 @@ pub fn verify_with_spki(
 ) -> Result<SpkiVerdict> {
     use softhsmrustv3::constants::CKR_SIGNATURE_INVALID;
 
-    let session = deps.engine_session.ok_or_else(|| {
+    let session = session.ok_or_else(|| {
         KmipError::failed(
             ResultReason::CryptographicFailure,
             "verify_with_spki: no engine session — cannot verify without key material",
@@ -318,7 +327,7 @@ mod tests {
         let spki = SubjectPublicKeyInfoOwned::from_der(&spki_der).unwrap();
         let sig_alg = alg_id(OID_ECDSA_SHA256);
 
-        let verdict = verify_with_spki(&deps, &spki, &sig_alg, msg, &der_sig).unwrap();
+        let verdict = verify_with_spki(deps.engine_session, &spki, &sig_alg, msg, &der_sig).unwrap();
         assert_eq!(verdict, SpkiVerdict::Valid);
 
         let mut tampered = der_sig.clone();
@@ -328,7 +337,7 @@ mod tests {
         // a valid Ecdsa-Sig-Value (CryptographicFailure) or it parses but
         // no longer verifies (Invalid) — either is an honest "not valid",
         // never a false Valid.
-        match verify_with_spki(&deps, &spki, &sig_alg, msg, &tampered) {
+        match verify_with_spki(deps.engine_session, &spki, &sig_alg, msg, &tampered) {
             Ok(v) => assert_eq!(v, SpkiVerdict::Invalid),
             Err(e) => assert_eq!(e.result_reason(), ResultReason::CryptographicFailure),
         }
@@ -356,7 +365,7 @@ mod tests {
         // not in the supported table.
         let sig_alg = alg_id("1.2.840.113549.1.1.4");
 
-        let verdict = verify_with_spki(&deps, &spki, &sig_alg, b"x", b"not a real signature").unwrap();
+        let verdict = verify_with_spki(deps.engine_session, &spki, &sig_alg, b"x", b"not a real signature").unwrap();
         assert_eq!(verdict, SpkiVerdict::UnsupportedAlgorithm);
 
         softhsmrustv3::native::close_session(session).unwrap();
@@ -393,7 +402,7 @@ mod tests {
         let spki = SubjectPublicKeyInfoOwned::from_der(&spki_der).unwrap();
         let sig_alg = alg_id(OID_ECDSA_SHA256);
 
-        let err = verify_with_spki(&deps, &spki, &sig_alg, b"x", b"y").unwrap_err();
+        let err = verify_with_spki(deps.engine_session, &spki, &sig_alg, b"x", b"y").unwrap_err();
         assert_eq!(err.result_reason(), ResultReason::CryptographicFailure);
         softhsmrustv3::native::close_session(session).unwrap();
     }
@@ -425,7 +434,7 @@ mod tests {
         // Transient imports use CKA_ID = TRANSIENT_ID = b"\x00", distinct
         // from this test's own b"\x01" keys, so a lookup by that ID
         // finding nothing after the call proves cleanup ran.
-        verify_with_spki(&deps, &spki, &sig_alg, msg, &der_sig).unwrap();
+        verify_with_spki(deps.engine_session, &spki, &sig_alg, msg, &der_sig).unwrap();
         let leftover = softhsmrustv3::native::find_all_by_cka_id(session, b"\x00").unwrap();
         assert!(leftover.is_empty(), "transient verify object was not destroyed: {leftover:?}");
 

--- a/kmip/src/ops/split_key.rs
+++ b/kmip/src/ops/split_key.rs
@@ -84,6 +84,7 @@ fn is_gf_method(m: SplitKeyMethod) -> bool {
 pub fn create_split_key(
     deps: &Deps,
     req: CreateSplitKeyRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<CreateSplitKeyResponse> {
     emit_request(
@@ -96,7 +97,9 @@ pub fn create_split_key(
         ),
     );
 
-    let session = deps.engine_session.ok_or_else(|| {
+    // Part F §F7 — caller's own token: the source key lives there and
+    // every generated share lands there.
+    let session = deps.resolve_tenant_session(auth.identity.as_ref()).ok().ok_or_else(|| {
         fail_err(
             deps,
             correlation_id,
@@ -147,9 +150,12 @@ pub fn create_split_key(
     // generate a fresh one from the request's Attributes.
     let (secret_handle, algorithm, length_bits) = match &req.uid {
         Some(uid) => {
-            let obj = deps.store.get(uid)?.ok_or_else(|| {
-                fail_err(deps, correlation_id, "CreateSplitKey", KmipError::not_found(uid))
-            })?;
+            // Part F §F7.4 — owner-checked: splitting a foreign tenant's
+            // key fails as the same ItemNotFound a missing UID produces.
+            let obj = super::helpers::authorize_object(deps, auth, uid, || {
+                KmipError::not_found(uid)
+            })
+            .map_err(|e| fail_err(deps, correlation_id, "CreateSplitKey", e))?;
             let handle =
                 find_handle_for_object(session, &obj.pkcs11_cka_id, obj.object_type)
                     .map_err(|rv| ck_rv_to_kmip_error(rv, "CreateSplitKey:find"))?
@@ -215,7 +221,7 @@ pub fn create_split_key(
         cka_id.extend_from_slice(&key_part_identifier.to_be_bytes());
 
         let uid = format!("urn:pqctoday:obj:{}", Uuid::new_v4());
-        deps.store.put(ObjectRecord {
+        deps.store.put(super::helpers::stamp_owner(ObjectRecord {
             uid: uid.clone(),
             object_type: ObjectType::SplitKey,
             algorithm,
@@ -240,7 +246,7 @@ pub fn create_split_key(
             protection_storage_mask: Some(0x01),
             lease_time: Some(3600),
             ..ObjectRecord::default()
-        })?;
+        }, auth))?;
         uids.push(uid);
     }
 
@@ -253,6 +259,7 @@ pub fn create_split_key(
 pub fn join_split_key(
     deps: &Deps,
     req: JoinSplitKeyRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<JoinSplitKeyResponse> {
     emit_request(
@@ -262,7 +269,8 @@ pub fn join_split_key(
         format!("object_type={:?} uids={}", req.object_type, req.uids.len()),
     );
 
-    let session = deps.engine_session.ok_or_else(|| {
+    // Part F §F7 — caller's own token, same as CreateSplitKey.
+    let session = deps.resolve_tenant_session(auth.identity.as_ref()).ok().ok_or_else(|| {
         fail_err(
             deps,
             correlation_id,
@@ -282,9 +290,12 @@ pub fn join_split_key(
 
     let mut records = Vec::with_capacity(req.uids.len());
     for uid in &req.uids {
-        let obj = deps.store.get(uid)?.ok_or_else(|| {
-            fail_err(deps, correlation_id, "JoinSplitKey", KmipError::not_found(uid))
-        })?;
+        // Part F §F7.4 — owner-checked: joining foreign tenants' shares
+        // fails as the same ItemNotFound a missing UID produces.
+        let obj = super::helpers::authorize_object(deps, auth, uid, || {
+            KmipError::not_found(uid)
+        })
+        .map_err(|e| fail_err(deps, correlation_id, "JoinSplitKey", e))?;
         if obj.object_type != ObjectType::SplitKey {
             return Err(fail_err(
                 deps,
@@ -377,7 +388,7 @@ pub fn join_split_key(
 
     let now = OffsetDateTime::now_utc();
     let uid = format!("urn:pqctoday:obj:{}", Uuid::new_v4());
-    deps.store.put(ObjectRecord {
+    deps.store.put(super::helpers::stamp_owner(ObjectRecord {
         uid: uid.clone(),
         object_type: req.object_type,
         algorithm,
@@ -397,7 +408,7 @@ pub fn join_split_key(
         protection_storage_mask: Some(0x01),
         lease_time: Some(3600),
         ..ObjectRecord::default()
-    })?;
+    }, auth))?;
 
     emit_success(deps, correlation_id, "JoinSplitKey");
     Ok(JoinSplitKeyResponse { uid })

--- a/kmip/src/ops/tenancy_e2e.rs
+++ b/kmip/src/ops/tenancy_e2e.rs
@@ -36,9 +36,11 @@ mod tests {
     use crate::dispatcher::{dispatch_with_transport_identity, one_off_request};
     use crate::error::ResultReason;
     use crate::kmip30::{
-        ActivateRequest, Attribute, CreateKeyPairRequest, CreateRequest, DecryptRequest,
-        EncryptRequest, GetAttributesRequest, KmipAlgorithm, ObjectType, RequestPayload,
-        ResponsePayload, ResultStatus, SignRequest, UsageMask,
+        ActivateRequest, AsynchronousIndicator, Attribute, CreateKeyPairRequest, CreateRequest,
+        CryptographicParameters, DecryptRequest, EncryptRequest, GetAttributesRequest,
+        HashRequest, HashingAlgorithm, KmipAlgorithm, ObjectType, PollRequest,
+        QueryAsynchronousRequestsRequest, RequestBatchItem, RequestHeader, RequestMessage,
+        RequestPayload, ResponsePayload, ResultStatus, SignRequest, UsageMask,
     };
     use crate::ops::deps::{Deps, DepsConfig, StrictTenantConfig, TenancyMode};
     use crate::ops::helpers::engine_lock;
@@ -786,6 +788,172 @@ mod tests {
             ResultStatus::Success,
             "Alice can add an attribute to her own key: {:?}",
             alice_add_resp.batch_items[0].result_reason
+        );
+    }
+
+    /// §F7.5 (async_jobs owner-scoped) — the sharpest edge: `Poll`
+    /// returns the deferred operation's FULL response payload, so a
+    /// foreign tenant Polling another's async correlation value would
+    /// receive that tenant's result (for a deferred Get/Export/Decrypt,
+    /// key material). Bob can neither Poll nor see (via
+    /// QueryAsynchronousRequests) Alice's async job; Alice's own Poll
+    /// works. Driven through the real dispatcher with a Mandatory-async
+    /// Hash — the correlation values are monotonic/predictable, so this
+    /// is a real guess-the-CV attack, not a theoretical one.
+    #[test]
+    fn cross_tenant_async_poll_and_query_are_owner_scoped() {
+        let _guard = engine_lock();
+        let alice = Identity { username: "alice-async".into() };
+        let bob = Identity { username: "bob-async".into() };
+        let sink: Arc<dyn crate::auditlog::AuditSink> = Arc::new(RingSink::new(64));
+        let deps = Deps::new(Engine::permissive(), Arc::new(MemoryStore::new()), sink, DepsConfig::default());
+
+        // A Mandatory-async Hash enqueues a real job (Hash is
+        // async-eligible) and returns OperationPending + a correlation
+        // value, per §8.1.2.
+        let async_hash = || {
+            let payload = RequestPayload::Hash(HashRequest {
+                cryptographic_parameters: CryptographicParameters {
+                    hashing_algorithm: Some(HashingAlgorithm::Sha256),
+                    ..Default::default()
+                },
+                data: b"defer me".to_vec(),
+            });
+            RequestMessage {
+                header: RequestHeader {
+                    asynchronous_indicator: Some(AsynchronousIndicator::Mandatory),
+                    ..RequestHeader::v3()
+                },
+                batch_items: vec![RequestBatchItem {
+                    operation: payload.operation(),
+                    payload,
+                }],
+            }
+        };
+
+        let alice_enqueue = dispatch_with_transport_identity(&deps, async_hash(), Some(alice.clone()));
+        assert_eq!(
+            alice_enqueue.batch_items[0].result_status,
+            ResultStatus::OperationPending,
+            "Mandatory-async Hash enqueues: {:?}",
+            alice_enqueue.batch_items[0].result_reason
+        );
+        let alice_cv = alice_enqueue.batch_items[0]
+            .asynchronous_correlation_value
+            .clone()
+            .expect("async job returns a correlation value");
+
+        let poll = |cv: &[u8]| {
+            one_off_request(RequestPayload::Poll(PollRequest {
+                asynchronous_correlation_value: cv.to_vec(),
+            }))
+        };
+
+        // Bob polls Alice's correlation value — MUST fail as an invalid
+        // correlation value, indistinguishable from a nonexistent one
+        // (anti-oracle). This is what stops him reading her deferred
+        // result.
+        let bob_poll = dispatch_with_transport_identity(&deps, poll(&alice_cv), Some(bob.clone()));
+        assert_eq!(
+            bob_poll.batch_items[0].result_status,
+            ResultStatus::OperationFailed,
+            "Bob must NOT be able to Poll Alice's async job"
+        );
+        assert_eq!(
+            bob_poll.batch_items[0].result_reason,
+            Some(ResultReason::InvalidAsynchronousCorrelationValue.to_wire_value()),
+            "cross-tenant Poll fails as InvalidAsynchronousCorrelationValue — same as a \
+             genuinely unknown correlation value"
+        );
+
+        // Bob's QueryAsynchronousRequests must not list Alice's job.
+        let bob_query = dispatch_with_transport_identity(
+            &deps,
+            one_off_request(RequestPayload::QueryAsynchronousRequests(
+                QueryAsynchronousRequestsRequest::default(),
+            )),
+            Some(bob),
+        );
+        let ResponsePayload::QueryAsynchronousRequests(bob_jobs) =
+            bob_query.batch_items[0].payload.clone().unwrap()
+        else {
+            panic!("expected QueryAsynchronousRequests response");
+        };
+        assert!(
+            bob_jobs.requests.iter().all(|r| r.asynchronous_correlation_value != alice_cv),
+            "Bob must NOT see Alice's job in his async-request listing"
+        );
+
+        // Alice polls her own job — succeeds (the job may still be
+        // pending or already complete; either is a Poll SUCCESS-shape
+        // for HER, never the InvalidAsynchronousCorrelationValue Bob
+        // got). The owner check is a real gate, not a blanket deny.
+        let alice_poll = dispatch_with_transport_identity(&deps, poll(&alice_cv), Some(alice));
+        assert_ne!(
+            alice_poll.batch_items[0].result_reason,
+            Some(ResultReason::InvalidAsynchronousCorrelationValue.to_wire_value()),
+            "Alice's own Poll must NOT be rejected as an invalid correlation value: {:?}",
+            alice_poll.batch_items[0].result_status
+        );
+    }
+
+    /// §F7.5 (object_defaults per-tenant) — one tenant's Set Defaults
+    /// affects only its own factory operations. Alice sets a default
+    /// Name for SymmetricKey; her later Create picks it up, Bob's does
+    /// not. Store-backed (no engine session): Create with no session
+    /// still persists a record with the merged template, so the applied
+    /// default is observable on the stored object.
+    #[test]
+    fn set_defaults_is_per_tenant() {
+        let _guard = engine_lock();
+        let alice = Identity { username: "alice-defaults".into() };
+        let bob = Identity { username: "bob-defaults".into() };
+        let sink: Arc<dyn crate::auditlog::AuditSink> = Arc::new(RingSink::new(64));
+        let deps = Deps::new(Engine::permissive(), Arc::new(MemoryStore::new()), sink, DepsConfig::default());
+
+        // Alice sets a per-Object-Type default Name for symmetric keys.
+        let set_req = one_off_request(RequestPayload::SetDefaults(crate::kmip30::SetDefaultsRequest {
+            defaults_information: Some(vec![crate::kmip30::ObjectDefaults {
+                object_types: vec![ObjectType::SymmetricKey],
+                attributes: vec![Attribute::Name("alice-default-name".into())],
+            }]),
+        }));
+        let set_resp = dispatch_with_transport_identity(&deps, set_req, Some(alice.clone()));
+        assert_eq!(set_resp.batch_items[0].result_status, ResultStatus::Success);
+
+        let create_aes = || {
+            one_off_request(RequestPayload::Create(CreateRequest {
+                object_type: ObjectType::SymmetricKey,
+                template_attribute: vec![
+                    Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
+                    Attribute::CryptographicLength(256),
+                    Attribute::CryptographicUsageMask(UsageMask::ENCRYPT | UsageMask::DECRYPT),
+                ],
+            }))
+        };
+
+        // Alice's Create inherits her default Name.
+        let alice_create = dispatch_with_transport_identity(&deps, create_aes(), Some(alice));
+        let ResponsePayload::Create(alice_obj) = alice_create.batch_items[0].payload.clone().unwrap() else {
+            panic!("expected Create response");
+        };
+        let alice_rec = deps.store.get(&alice_obj.uid).unwrap().unwrap();
+        assert_eq!(
+            alice_rec.name.as_deref(),
+            Some("alice-default-name"),
+            "Alice's Create must inherit her own Set Defaults Name"
+        );
+
+        // Bob's Create — same request, but he set no defaults — gets no
+        // Name (Alice's default is invisible to him).
+        let bob_create = dispatch_with_transport_identity(&deps, create_aes(), Some(bob));
+        let ResponsePayload::Create(bob_obj) = bob_create.batch_items[0].payload.clone().unwrap() else {
+            panic!("expected Create response");
+        };
+        let bob_rec = deps.store.get(&bob_obj.uid).unwrap().unwrap();
+        assert_eq!(
+            bob_rec.name, None,
+            "Bob must NOT inherit Alice's per-tenant default"
         );
     }
 }

--- a/kmip/src/ops/tenancy_e2e.rs
+++ b/kmip/src/ops/tenancy_e2e.rs
@@ -6,19 +6,28 @@
 //! identities — not by calling op handlers directly with a hand-built
 //! `AuthContext`.
 //!
-//! STATUS (2026-07-18): this proves what is ACTUALLY wired today.
-//! `CreateKeyPair`, `Activate`, `Sign`, and `Encapsulate` resolve their
-//! own tenant's engine session (the §F7-scoped dispatcher-wiring slice —
-//! see the plan's §G3 for the ~24 remaining op handlers not yet
-//! migrated). It ALSO honestly documents the residual gap the same
-//! section flags: KMIP-level object METADATA (`Get`, `GetAttributes`,
-//! `Locate`) is not yet owner-filtered (§F7.3/F7.4 not built), so while
-//! a cross-tenant `Sign` genuinely fails closed (proven below, via the
-//! engine's own token-scoped handle lookup — not a KMIP-layer check),
-//! a cross-tenant `Get` on the same UID still succeeds today, leaking
-//! the object's existence and metadata. Both facts are asserted, not
-//! just one — this file must fail loudly (not silently pass) the day
-//! either behavior changes without deliberate intent.
+//! STATUS (2026-07-18, rev 2 — F7.3/F7.4 owner enforcement landed): the
+//! two gates now compose. Every by-UID handler wired so far (§F7's
+//! dispatcher slice: `CreateKeyPair`, `Sign`, `Encapsulate`,
+//! `Decapsulate`, `ReKey`, `ReKeyKeyPair`, `Get`, `GetAttributes`,
+//! `Destroy`, `Locate`) does an owner check
+//! (`helpers::authorize_object` / Locate's predicate filter) against the
+//! KMIP store BEFORE anything else, using the SAME not-found error each
+//! operation already used for a genuinely missing UID — so "exists but
+//! not yours" and "doesn't exist" are indistinguishable, satisfying the
+//! anti-oracle requirement at the KMIP layer, not just the engine layer.
+//! `Sign`/`Encapsulate`/`Decapsulate` additionally still hit the
+//! ENGINE's own token-scoped handle lookup (§F2–F5) as a second,
+//! independent barrier — defense in depth, verified below by checking
+//! that the fully-wired path denies at the FIRST gate (the KMIP owner
+//! check), not by relying on the engine gate alone.
+//!
+//! ~19 of the original ~28 `deps.engine_session`-reading files remain
+//! unwired for SESSION resolution (Encrypt, Decrypt, Certify, the
+//! composite/hybrid-cert family, split_key, derive_key's own creation
+//! path, attribute mutation, mac/hash, rng/pkcs11, register/import) —
+//! see the plan's §H3/H4 for the exact list. This file only asserts
+//! properties of the operations it actually exercises.
 
 #[cfg(test)]
 mod tests {
@@ -124,17 +133,17 @@ mod tests {
 
         // ── Bob attempts to Sign using ALICE's private key UID. ─────────
         // His request resolves to HIS OWN engine session (slot 91, a
-        // different PKCS#11 token than Alice's slot 90). The KMIP-store
-        // lookup by UID still finds Alice's ObjectRecord (F7.3/F7.4 owner
-        // tracking is not built — see the module doc), but resolving
-        // that record's engine handle goes through
-        // `helpers::find_handle_for_object(bob_session, cka_id, ...)`,
-        // which is scoped to Bob's slot by the engine's OWN isolation
-        // gate (Part F, already shipped and independently tested in
-        // softhsmrustv3's own suite) — Alice's private-key handle simply
-        // isn't visible there, so the lookup finds nothing and the
-        // operation fails closed BEFORE any cryptographic material could
-        // be touched.
+        // different PKCS#11 token than Alice's slot 90). As of rev 2,
+        // TWO independent gates now deny this: (1) the KMIP-store owner
+        // check (`helpers::authorize_object`, §F7.4) — Bob's identity
+        // doesn't match the record's owner, so the lookup itself fails
+        // before Sign does anything else; (2) even if (1) didn't exist,
+        // resolving the record's engine handle via
+        // `helpers::find_handle_for_object(bob_session, cka_id, ...)` is
+        // scoped to Bob's slot by the engine's OWN isolation gate (§F2–
+        // F5, shipped earlier and independently tested in
+        // softhsmrustv3's own suite) — Alice's handle isn't visible
+        // there either. Sign hits gate (1) first.
         let bob_sign_req = one_off_request(RequestPayload::Sign(SignRequest {
             uid: ckp.private_key_uid.clone(),
             data: b"bob trying to sign with alice's key".to_vec(),
@@ -154,36 +163,207 @@ mod tests {
              though this specific denial is the ENGINE's token-scoping, not yet a KMIP-layer owner check"
         );
 
-        // ── Honest residual-gap check. ───────────────────────────────────
-        // Bob's GetAttributes on Alice's private-key UID — deliberately
-        // NOT `Get` (which fails for a totally different, benign reason
-        // for ANY caller, including Alice herself: ML-DSA private keys
-        // are CKA_SENSITIVE by default, so `Get` always refuses to
-        // return material — that's a pre-existing sensitivity gate, not
-        // tenancy). `GetAttributes` only returns metadata (Cryptographic
-        // Algorithm, State, …), never key material, and — per
-        // `get_attributes.rs` — never touches `deps.engine_session` at
-        // all, so it is a clean, unconfounded test of whether the KMIP
-        // STORE itself is owner-filtered. It is not (F7.3 not built), so
-        // this metadata read still succeeds today, revealing that the
-        // object exists and its algorithm/state. This assertion
-        // documents TODAY'S actual (undesired) state, not the desired
-        // end state — when F7.3/F7.4 lands, this must flip to
-        // OperationFailed/ItemNotFound and this comment updated, exactly
-        // like the two P0b-era gap tests in softhsmrustv3's own suite
-        // were flipped once its gate landed.
+        // ── GAP CLOSED (rev 2, F7.3/F7.4): Bob's GetAttributes on
+        // Alice's private-key UID now fails too. Deliberately NOT `Get`
+        // (which fails for a totally different, benign reason for ANY
+        // caller, including Alice herself: ML-DSA private keys are
+        // CKA_SENSITIVE by default, so `Get` always refuses to return
+        // material — that's a pre-existing sensitivity gate, not
+        // tenancy; `get_owner_check_denies_before_engine_is_even_reached`
+        // below isolates the ownership property on a non-sensitive
+        // object instead). `GetAttributes` returns metadata only, never
+        // key material, and never touches the engine — so this is a
+        // clean, unconfounded proof that the KMIP STORE itself is now
+        // owner-filtered, not just the engine. ──────────────────────────
         let get_attrs_req = one_off_request(RequestPayload::GetAttributes(GetAttributesRequest {
             uid: ckp.private_key_uid.clone(),
             attribute_references: vec![],
         }));
-        let bob_get_attrs_resp = dispatch_with_transport_identity(&deps, get_attrs_req, Some(bob));
+        let bob_get_attrs_resp = dispatch_with_transport_identity(&deps, get_attrs_req, Some(bob.clone()));
         assert_eq!(
             bob_get_attrs_resp.batch_items[0].result_status,
+            ResultStatus::OperationFailed,
+            "Bob must NOT be able to read Alice's key's metadata"
+        );
+        assert_eq!(
+            bob_get_attrs_resp.batch_items[0].result_reason,
+            Some(ResultReason::ItemNotFound.to_wire_value()),
+            "cross-tenant GetAttributes fails as ItemNotFound — the SAME reason this operation \
+             already used for a genuinely missing UID (OASIS BL-M-20-30.xml), so a foreign tenant's \
+             object stays indistinguishable from a nonexistent one at the KMIP layer, not just the \
+             engine layer"
+        );
+
+        // Alice's own GetAttributes on her own key still works — the
+        // owner check is a real gate, not an accidental blanket deny.
+        let alice_get_attrs_req = one_off_request(RequestPayload::GetAttributes(GetAttributesRequest {
+            uid: ckp.private_key_uid.clone(),
+            attribute_references: vec![],
+        }));
+        let alice_get_attrs_resp =
+            dispatch_with_transport_identity(&deps, alice_get_attrs_req, Some(alice.clone()));
+        assert_eq!(
+            alice_get_attrs_resp.batch_items[0].result_status,
             ResultStatus::Success,
-            "KNOWN GAP (§F7.3/F7.4, not yet built): KMIP-level GetAttributes is not owner-filtered — \
-             Bob can still read Alice's key's metadata even though he cannot use the key \
-             cryptographically: {:?}",
-            bob_get_attrs_resp.batch_items[0].result_reason
+            "Alice can still read her own key's metadata: {:?}",
+            alice_get_attrs_resp.batch_items[0].result_reason
+        );
+
+        // ── Destroy is owner-checked too: Bob cannot destroy Alice's key. ──
+        let bob_destroy_req = one_off_request(RequestPayload::Destroy(crate::kmip30::DestroyRequest {
+            uid: ckp.private_key_uid.clone(),
+        }));
+        let bob_destroy_resp = dispatch_with_transport_identity(&deps, bob_destroy_req, Some(bob));
+        assert_eq!(
+            bob_destroy_resp.batch_items[0].result_status,
+            ResultStatus::OperationFailed,
+            "Bob must NOT be able to destroy Alice's key"
+        );
+        assert_eq!(
+            bob_destroy_resp.batch_items[0].result_reason,
+            Some(ResultReason::ObjectNotFound.to_wire_value()),
+            "cross-tenant Destroy fails as ObjectNotFound — this handler's own pre-existing \
+             not-found reason, now also covering the owner mismatch"
+        );
+
+        // The key survives Bob's failed attempt — Alice can still get its
+        // metadata (proves Destroy didn't partially execute before the
+        // owner check, and that the owner check runs BEFORE any mutation).
+        let alice_get_attrs_req2 = one_off_request(RequestPayload::GetAttributes(GetAttributesRequest {
+            uid: ckp.private_key_uid.clone(),
+            attribute_references: vec![],
+        }));
+        let alice_get_attrs_resp2 =
+            dispatch_with_transport_identity(&deps, alice_get_attrs_req2, Some(alice));
+        assert_eq!(
+            alice_get_attrs_resp2.batch_items[0].result_status,
+            ResultStatus::Success,
+            "the key must still exist after Bob's rejected Destroy attempt"
+        );
+    }
+
+    /// Isolates the ownership property on `Get` specifically, using a
+    /// non-sensitive `SymmetricKey` so the pre-existing sensitivity gate
+    /// (which would fail `Get` for ANY caller on a sensitive private
+    /// key, tenancy aside — see the comment in the test above) can't
+    /// confound the result. A real engine session is not needed here:
+    /// `Create` on a symmetric key with no engine wired falls back to
+    /// the crate's engine-less placeholder path (existing, pre-F7
+    /// behavior), which is enough to prove the OWNERSHIP gate — the
+    /// property this test is actually about — fires before anything
+    /// else. Single mode (no tenancy config) so `Create`'s `auth` is a
+    /// deliberately DIFFERENT open/anonymous context per call — proving
+    /// that even within nominally "no tenancy configured" behavior, an
+    /// object stamped with a real owner (because ITS creator happened to
+    /// have an identity) is still protected from a later anonymous or
+    /// differently-identified caller.
+    #[test]
+    fn get_owner_check_denies_before_engine_is_even_reached() {
+        let _guard = engine_lock();
+        let alice = Identity { username: "alice-get-only".into() };
+        let bob = Identity { username: "bob-get-only".into() };
+        let sink: Arc<dyn crate::auditlog::AuditSink> = Arc::new(RingSink::new(64));
+        let deps = Deps::new(Engine::permissive(), Arc::new(MemoryStore::new()), sink, DepsConfig::default());
+
+        let create_req = one_off_request(RequestPayload::Create(crate::kmip30::CreateRequest {
+            object_type: crate::kmip30::ObjectType::SymmetricKey,
+            template_attribute: vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
+                Attribute::CryptographicLength(256),
+                Attribute::CryptographicUsageMask(UsageMask::ENCRYPT | UsageMask::DECRYPT),
+            ],
+        }));
+        let create_resp = dispatch_with_transport_identity(&deps, create_req, Some(alice.clone()));
+        assert_eq!(create_resp.batch_items[0].result_status, ResultStatus::Success);
+        let ResponsePayload::Create(created) = create_resp.batch_items[0].payload.clone().unwrap() else {
+            panic!("expected Create response");
+        };
+
+        let bob_get = one_off_request(RequestPayload::Get(crate::kmip30::GetRequest {
+            uid: created.uid.clone(),
+            key_format_type: None,
+            key_wrapping_specification: None,
+        }));
+        let bob_get_resp = dispatch_with_transport_identity(&deps, bob_get, Some(bob));
+        assert_eq!(
+            bob_get_resp.batch_items[0].result_status,
+            ResultStatus::OperationFailed,
+            "Bob must not be able to Get Alice's symmetric key"
+        );
+        assert_eq!(
+            bob_get_resp.batch_items[0].result_reason,
+            Some(ResultReason::ObjectNotFound.to_wire_value())
+        );
+
+        let alice_get = one_off_request(RequestPayload::Get(crate::kmip30::GetRequest {
+            uid: created.uid,
+            key_format_type: None,
+            key_wrapping_specification: None,
+        }));
+        let alice_get_resp = dispatch_with_transport_identity(&deps, alice_get, Some(alice));
+        assert_eq!(
+            alice_get_resp.batch_items[0].result_status,
+            ResultStatus::Success,
+            "Alice can still Get her own symmetric key: {:?}",
+            alice_get_resp.batch_items[0].result_reason
+        );
+    }
+
+    /// Locate results are filtered per tenant: each identity sees only
+    /// the objects it created, never the other's — even when both exist
+    /// in the same shared store side by side.
+    #[test]
+    fn locate_is_scoped_to_the_requesters_own_objects() {
+        let _guard = engine_lock();
+        let alice = Identity { username: "alice-locate".into() };
+        let bob = Identity { username: "bob-locate".into() };
+        let sink: Arc<dyn crate::auditlog::AuditSink> = Arc::new(RingSink::new(64));
+        let deps = Deps::new(Engine::permissive(), Arc::new(MemoryStore::new()), sink, DepsConfig::default());
+
+        let make_key = |identity: &Identity, name: &str| {
+            let req = one_off_request(RequestPayload::Create(crate::kmip30::CreateRequest {
+                object_type: crate::kmip30::ObjectType::SymmetricKey,
+                template_attribute: vec![
+                    Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
+                    Attribute::CryptographicLength(256),
+                    Attribute::CryptographicUsageMask(UsageMask::ENCRYPT | UsageMask::DECRYPT),
+                    Attribute::Name(name.to_string()),
+                ],
+            }));
+            let resp = dispatch_with_transport_identity(&deps, req, Some(identity.clone()));
+            assert_eq!(resp.batch_items[0].result_status, ResultStatus::Success);
+            let ResponsePayload::Create(created) = resp.batch_items[0].payload.clone().unwrap() else {
+                panic!("expected Create response");
+            };
+            created.uid
+        };
+
+        let alice_uid = make_key(&alice, "alice-only-key");
+        let bob_uid = make_key(&bob, "bob-only-key");
+        assert_ne!(alice_uid, bob_uid);
+
+        let locate_req = || one_off_request(RequestPayload::Locate(crate::kmip30::LocateRequest::default()));
+
+        let alice_locate = dispatch_with_transport_identity(&deps, locate_req(), Some(alice.clone()));
+        assert_eq!(alice_locate.batch_items[0].result_status, ResultStatus::Success);
+        let ResponsePayload::Locate(alice_found) = alice_locate.batch_items[0].payload.clone().unwrap() else {
+            panic!("expected Locate response");
+        };
+        assert!(alice_found.uids.contains(&alice_uid), "Alice must see her own key");
+        assert!(
+            !alice_found.uids.contains(&bob_uid),
+            "Alice must NOT see Bob's key in her Locate results"
+        );
+
+        let bob_locate = dispatch_with_transport_identity(&deps, locate_req(), Some(bob));
+        assert_eq!(bob_locate.batch_items[0].result_status, ResultStatus::Success);
+        let ResponsePayload::Locate(bob_found) = bob_locate.batch_items[0].payload.clone().unwrap() else {
+            panic!("expected Locate response");
+        };
+        assert!(bob_found.uids.contains(&bob_uid), "Bob must see his own key");
+        assert!(
+            !bob_found.uids.contains(&alice_uid),
+            "Bob must NOT see Alice's key in his Locate results"
         );
     }
 }

--- a/kmip/src/ops/tenancy_e2e.rs
+++ b/kmip/src/ops/tenancy_e2e.rs
@@ -6,28 +6,29 @@
 //! identities — not by calling op handlers directly with a hand-built
 //! `AuthContext`.
 //!
-//! STATUS (2026-07-18, rev 2 — F7.3/F7.4 owner enforcement landed): the
-//! two gates now compose. Every by-UID handler wired so far (§F7's
-//! dispatcher slice: `CreateKeyPair`, `Sign`, `Encapsulate`,
+//! STATUS (2026-07-18, rev 3 — Encrypt/Decrypt wired, §J): the two
+//! gates compose. Every by-UID handler wired so far (§F7's dispatcher
+//! slice, plus §J's addition: `CreateKeyPair`, `Sign`, `Encapsulate`,
 //! `Decapsulate`, `ReKey`, `ReKeyKeyPair`, `Get`, `GetAttributes`,
-//! `Destroy`, `Locate`) does an owner check
-//! (`helpers::authorize_object` / Locate's predicate filter) against the
-//! KMIP store BEFORE anything else, using the SAME not-found error each
-//! operation already used for a genuinely missing UID — so "exists but
-//! not yours" and "doesn't exist" are indistinguishable, satisfying the
-//! anti-oracle requirement at the KMIP layer, not just the engine layer.
-//! `Sign`/`Encapsulate`/`Decapsulate` additionally still hit the
+//! `GetAttributeList`, `Destroy`, `Locate`, `Encrypt`, `Decrypt`) does
+//! an owner check (`helpers::authorize_object` / Locate's predicate
+//! filter) against the KMIP store BEFORE anything else, using the SAME
+//! not-found error each operation already used for a genuinely missing
+//! UID — so "exists but not yours" and "doesn't exist" are
+//! indistinguishable, satisfying the anti-oracle requirement at the
+//! KMIP layer, not just the engine layer. `Sign`/`Encapsulate`/
+//! `Decapsulate`/`Encrypt`/`Decrypt` additionally still hit the
 //! ENGINE's own token-scoped handle lookup (§F2–F5) as a second,
 //! independent barrier — defense in depth, verified below by checking
 //! that the fully-wired path denies at the FIRST gate (the KMIP owner
 //! check), not by relying on the engine gate alone.
 //!
-//! ~19 of the original ~28 `deps.engine_session`-reading files remain
-//! unwired for SESSION resolution (Encrypt, Decrypt, Certify, the
-//! composite/hybrid-cert family, split_key, derive_key's own creation
-//! path, attribute mutation, mac/hash, rng/pkcs11, register/import) —
-//! see the plan's §H3/H4 for the exact list. This file only asserts
-//! properties of the operations it actually exercises.
+//! ~17 of the original ~28 `deps.engine_session`-reading files remain
+//! unwired for SESSION resolution (Certify, the composite/hybrid-cert
+//! family, split_key, derive_key's own creation path, attribute
+//! mutation, mac/hash, rng/pkcs11, register/import) — see the plan's
+//! §H3/§J for the exact list. This file only asserts properties of the
+//! operations it actually exercises.
 
 #[cfg(test)]
 mod tests {
@@ -35,8 +36,9 @@ mod tests {
     use crate::dispatcher::{dispatch_with_transport_identity, one_off_request};
     use crate::error::ResultReason;
     use crate::kmip30::{
-        ActivateRequest, Attribute, CreateKeyPairRequest, GetAttributesRequest, KmipAlgorithm,
-        RequestPayload, ResponsePayload, ResultStatus, SignRequest, UsageMask,
+        ActivateRequest, Attribute, CreateKeyPairRequest, CreateRequest, DecryptRequest,
+        EncryptRequest, GetAttributesRequest, KmipAlgorithm, ObjectType, RequestPayload,
+        ResponsePayload, ResultStatus, SignRequest, UsageMask,
     };
     use crate::ops::deps::{Deps, DepsConfig, StrictTenantConfig, TenancyMode};
     use crate::ops::helpers::engine_lock;
@@ -365,5 +367,139 @@ mod tests {
             !bob_found.uids.contains(&alice_uid),
             "Bob must NOT see Alice's key in his Locate results"
         );
+    }
+
+    /// §J (Encrypt/Decrypt now wired) — two real engine sessions again
+    /// (Strict mode, slots 90/91, via `two_tenant_deps`), proving BOTH
+    /// gates now apply to the symmetric-crypto path the way they
+    /// already did for Sign: Bob's Encrypt/Decrypt against Alice's key
+    /// UID fails at the KMIP owner check (`authorize_object`) before
+    /// `resolve_tenant_session` or the engine's own token-scoping is
+    /// ever reached, and Alice's own round trip through the real
+    /// engine still works end to end.
+    #[test]
+    fn cross_tenant_encrypt_and_decrypt_fail_closed() {
+        let _guard = engine_lock();
+        let (deps, alice, bob) = two_tenant_deps();
+
+        let create_req = one_off_request(RequestPayload::Create(CreateRequest {
+            object_type: ObjectType::SymmetricKey,
+            template_attribute: vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
+                Attribute::CryptographicLength(256),
+                Attribute::CryptographicUsageMask(UsageMask::ENCRYPT | UsageMask::DECRYPT),
+            ],
+        }));
+        let create_resp = dispatch_with_transport_identity(&deps, create_req, Some(alice.clone()));
+        assert_eq!(
+            create_resp.batch_items[0].result_status,
+            ResultStatus::Success,
+            "Alice creates her own AES key: {:?}",
+            create_resp.batch_items[0].result_reason
+        );
+        let ResponsePayload::Create(created) = create_resp.batch_items[0].payload.clone().unwrap() else {
+            panic!("expected Create response");
+        };
+        let activate_req = one_off_request(RequestPayload::Activate(ActivateRequest {
+            uid: created.uid.clone(),
+        }));
+        let activate_resp = dispatch_with_transport_identity(&deps, activate_req, Some(alice.clone()));
+        assert_eq!(activate_resp.batch_items[0].result_status, ResultStatus::Success);
+
+        // Alice encrypts with her own key through her own real engine
+        // session (slot 90) — proves the wiring works end to end, not
+        // just that it compiles.
+        let iv = vec![0x11u8; 12];
+        let alice_enc_req = one_off_request(RequestPayload::Encrypt(EncryptRequest {
+            uid: created.uid.clone(),
+            data: b"alice's secret".to_vec(),
+            iv: Some(iv.clone()),
+            cryptographic_parameters: None,
+            aad: None,
+            init_indicator: None,
+            final_indicator: None,
+            correlation_value: None,
+        }));
+        let alice_enc_resp = dispatch_with_transport_identity(&deps, alice_enc_req, Some(alice.clone()));
+        assert_eq!(
+            alice_enc_resp.batch_items[0].result_status,
+            ResultStatus::Success,
+            "Alice can Encrypt with her own key: {:?}",
+            alice_enc_resp.batch_items[0].result_reason
+        );
+        let ResponsePayload::Encrypt(alice_enc) = alice_enc_resp.batch_items[0].payload.clone().unwrap() else {
+            panic!("expected Encrypt response");
+        };
+
+        // Bob attempts to Encrypt using ALICE's key UID — denied at the
+        // KMIP owner check (authorize_object), the same ObjectNotFound
+        // this handler already used for a genuinely missing UID.
+        let bob_enc_req = one_off_request(RequestPayload::Encrypt(EncryptRequest {
+            uid: created.uid.clone(),
+            data: b"bob trying to use alice's key".to_vec(),
+            iv: Some(iv.clone()),
+            cryptographic_parameters: None,
+            aad: None,
+            init_indicator: None,
+            final_indicator: None,
+            correlation_value: None,
+        }));
+        let bob_enc_resp = dispatch_with_transport_identity(&deps, bob_enc_req, Some(bob.clone()));
+        assert_eq!(
+            bob_enc_resp.batch_items[0].result_status,
+            ResultStatus::OperationFailed,
+            "Bob must NOT be able to Encrypt with Alice's key"
+        );
+        assert_eq!(
+            bob_enc_resp.batch_items[0].result_reason,
+            Some(ResultReason::ObjectNotFound.to_wire_value())
+        );
+
+        // Bob attempts to Decrypt Alice's own ciphertext using her key
+        // UID — same denial, before his session (slot 91) ever gets
+        // near it.
+        let mut ct_and_tag = alice_enc.ciphertext.clone();
+        if let Some(tag) = &alice_enc.authenticated_encryption_tag {
+            ct_and_tag.extend_from_slice(tag);
+        }
+        let bob_dec_req = one_off_request(RequestPayload::Decrypt(DecryptRequest {
+            uid: created.uid.clone(),
+            data: ct_and_tag.clone(),
+            iv: Some(iv.clone()),
+            cryptographic_parameters: None,
+            aad: None,
+        }));
+        let bob_dec_resp = dispatch_with_transport_identity(&deps, bob_dec_req, Some(bob));
+        assert_eq!(
+            bob_dec_resp.batch_items[0].result_status,
+            ResultStatus::OperationFailed,
+            "Bob must NOT be able to Decrypt with Alice's key"
+        );
+        assert_eq!(
+            bob_dec_resp.batch_items[0].result_reason,
+            Some(ResultReason::ObjectNotFound.to_wire_value())
+        );
+
+        // Alice's own Decrypt of her own ciphertext still works — the
+        // owner check is a real gate, not a blanket deny, and the round
+        // trip through the real engine is intact end to end.
+        let alice_dec_req = one_off_request(RequestPayload::Decrypt(DecryptRequest {
+            uid: created.uid,
+            data: ct_and_tag,
+            iv: Some(iv),
+            cryptographic_parameters: None,
+            aad: None,
+        }));
+        let alice_dec_resp = dispatch_with_transport_identity(&deps, alice_dec_req, Some(alice));
+        assert_eq!(
+            alice_dec_resp.batch_items[0].result_status,
+            ResultStatus::Success,
+            "Alice can still Decrypt her own ciphertext: {:?}",
+            alice_dec_resp.batch_items[0].result_reason
+        );
+        let ResponsePayload::Decrypt(alice_dec) = alice_dec_resp.batch_items[0].payload.clone().unwrap() else {
+            panic!("expected Decrypt response");
+        };
+        assert_eq!(alice_dec.data, b"alice's secret");
     }
 }

--- a/kmip/src/ops/tenancy_e2e.rs
+++ b/kmip/src/ops/tenancy_e2e.rs
@@ -502,4 +502,185 @@ mod tests {
         };
         assert_eq!(alice_dec.data, b"alice's secret");
     }
+
+    /// §L (Register/Export wired) — Register stamps the caller as owner,
+    /// and Export (the one MATERIAL-RETURNING by-UID handler missed by
+    /// the original F7.4 enumeration, found in the §L audit) is
+    /// owner-checked: Bob can neither Export nor Get Alice's registered
+    /// key, while Alice's own Export round-trips her exact bytes. Store-
+    /// backed raw material — no engine session involved, so this
+    /// isolates the OWNERSHIP property with no tenancy-provisioning
+    /// confound (plain Single-mode deps, identities only).
+    #[test]
+    fn register_stamps_owner_and_export_is_owner_checked() {
+        let _guard = engine_lock();
+        let alice = Identity { username: "alice-export".into() };
+        let bob = Identity { username: "bob-export".into() };
+        let sink: Arc<dyn crate::auditlog::AuditSink> = Arc::new(RingSink::new(64));
+        let deps = Deps::new(Engine::permissive(), Arc::new(MemoryStore::new()), sink, DepsConfig::default());
+
+        let key_bytes = vec![0xA5u8; 32];
+        let register_req = one_off_request(RequestPayload::Register(crate::kmip30::RegisterRequest {
+            object_type: ObjectType::SymmetricKey,
+            attributes: vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
+                Attribute::CryptographicLength(256),
+                Attribute::CryptographicUsageMask(UsageMask::ENCRYPT | UsageMask::DECRYPT),
+            ],
+            managed_object: Some(crate::kmip30::KeyBlock {
+                key_format_type: crate::kmip30::KeyFormatType::Raw,
+                cryptographic_algorithm: KmipAlgorithm::Aes,
+                cryptographic_length: 256,
+                key_value: key_bytes.clone(),
+                key_wrapping_data: None,
+            }),
+            protection_storage_masks: None,
+            certificate_payload: None,
+            secret_data_type: None,
+        }));
+        let register_resp = dispatch_with_transport_identity(&deps, register_req, Some(alice.clone()));
+        assert_eq!(
+            register_resp.batch_items[0].result_status,
+            ResultStatus::Success,
+            "Alice registers her own key: {:?}",
+            register_resp.batch_items[0].result_reason
+        );
+        let ResponsePayload::Register(registered) = register_resp.batch_items[0].payload.clone().unwrap() else {
+            panic!("expected Register response");
+        };
+
+        let export_req = |uid: &str| {
+            one_off_request(RequestPayload::Export(crate::kmip30::ExportRequest {
+                uid: uid.to_string(),
+                key_format_type: None,
+                key_wrap_type: None,
+                key_compression_type: None,
+                key_wrapping_specification: None,
+            }))
+        };
+
+        let bob_export = dispatch_with_transport_identity(&deps, export_req(&registered.uid), Some(bob));
+        assert_eq!(
+            bob_export.batch_items[0].result_status,
+            ResultStatus::OperationFailed,
+            "Bob must NOT be able to Export Alice's key material"
+        );
+        assert_eq!(
+            bob_export.batch_items[0].result_reason,
+            Some(ResultReason::ObjectNotFound.to_wire_value()),
+            "cross-tenant Export fails as ObjectNotFound — anti-oracle"
+        );
+
+        let alice_export = dispatch_with_transport_identity(&deps, export_req(&registered.uid), Some(alice));
+        assert_eq!(
+            alice_export.batch_items[0].result_status,
+            ResultStatus::Success,
+            "Alice can still Export her own key: {:?}",
+            alice_export.batch_items[0].result_reason
+        );
+        let ResponsePayload::Export(exported) = alice_export.batch_items[0].payload.clone().unwrap() else {
+            panic!("expected Export response");
+        };
+        assert_eq!(
+            exported.managed_object.expect("Alice's export carries her key material").key_value,
+            key_bytes,
+            "Alice's Export must round-trip her exact registered bytes"
+        );
+    }
+
+    /// §L (KEK owner check in `resolve_kek`) — a wrap key referenced by
+    /// UID inside a KeyWrappingSpecification is itself a by-UID key
+    /// reference, and using a FOREIGN tenant's KEK must fail exactly
+    /// like a nonexistent one (`Wrapping Object Not Found`, the same
+    /// reason a genuinely missing KEK UID produces). Before §L, any
+    /// tenant could wrap/unwrap under another tenant's KEK by knowing
+    /// its UID. All store-backed raw material — no engine sessions.
+    #[test]
+    fn cross_tenant_kek_is_invisible_for_wrapping() {
+        let _guard = engine_lock();
+        let alice = Identity { username: "alice-kek".into() };
+        let bob = Identity { username: "bob-kek".into() };
+        let sink: Arc<dyn crate::auditlog::AuditSink> = Arc::new(RingSink::new(64));
+        let deps = Deps::new(Engine::permissive(), Arc::new(MemoryStore::new()), sink, DepsConfig::default());
+
+        let register = |identity: &Identity, usage: UsageMask, activation_past: bool, bytes: Vec<u8>| {
+            let mut attrs = vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::Aes),
+                Attribute::CryptographicLength(256),
+                Attribute::CryptographicUsageMask(usage),
+            ];
+            if activation_past {
+                // Past ActivationDate ⇒ born Active (compute_initial_state)
+                // — resolve_kek requires an Active KEK.
+                attrs.push(Attribute::ActivationDate(
+                    time::OffsetDateTime::now_utc().unix_timestamp() - 3600,
+                ));
+            }
+            let req = one_off_request(RequestPayload::Register(crate::kmip30::RegisterRequest {
+                object_type: ObjectType::SymmetricKey,
+                attributes: attrs,
+                managed_object: Some(crate::kmip30::KeyBlock {
+                    key_format_type: crate::kmip30::KeyFormatType::Raw,
+                    cryptographic_algorithm: KmipAlgorithm::Aes,
+                    cryptographic_length: 256,
+                    key_value: bytes,
+                    key_wrapping_data: None,
+                }),
+                protection_storage_masks: None,
+                certificate_payload: None,
+                secret_data_type: None,
+            }));
+            let resp = dispatch_with_transport_identity(&deps, req, Some(identity.clone()));
+            assert_eq!(resp.batch_items[0].result_status, ResultStatus::Success);
+            let ResponsePayload::Register(r) = resp.batch_items[0].payload.clone().unwrap() else {
+                panic!("expected Register response");
+            };
+            r.uid
+        };
+
+        // Alice's KEK (Active, WrapKey usage) and Bob's own data key.
+        let alice_kek_uid = register(&alice, UsageMask::WRAP_KEY, true, vec![0x11u8; 32]);
+        let bob_key_uid = register(&bob, UsageMask::ENCRYPT | UsageMask::DECRYPT, false, vec![0x22u8; 32]);
+
+        let wrapped_get = |key_uid: &str, kek_uid: &str| {
+            one_off_request(RequestPayload::Get(crate::kmip30::GetRequest {
+                uid: key_uid.to_string(),
+                key_format_type: None,
+                key_wrapping_specification: Some(crate::kmip30::KeyWrappingSpec {
+                    wrapping_method: 0x01, // Encrypt
+                    encryption_key_uid: kek_uid.to_string(),
+                    cryptographic_parameters: None, // defaults to NISTKeyWrap
+                    encoding_option: None,
+                    mac_signature_key_information_present: false,
+                }),
+            }))
+        };
+
+        // Bob requests HIS OWN key wrapped under ALICE's KEK — the data
+        // key is his, so the object gate passes; the KEK gate must not.
+        let bob_get = dispatch_with_transport_identity(&deps, wrapped_get(&bob_key_uid, &alice_kek_uid), Some(bob.clone()));
+        assert_eq!(
+            bob_get.batch_items[0].result_status,
+            ResultStatus::OperationFailed,
+            "Bob must NOT be able to wrap under Alice's KEK"
+        );
+        assert_eq!(
+            bob_get.batch_items[0].result_reason,
+            Some(ResultReason::WrappingObjectNotFound.to_wire_value()),
+            "a foreign KEK fails as Wrapping Object Not Found — the SAME reason a \
+             genuinely missing KEK UID produces (anti-oracle at the KEK layer)"
+        );
+
+        // Alice wrapping her own... key under her own KEK works — the KEK
+        // owner check is a real gate, not a blanket deny. (Her KEK wraps
+        // ITSELF here — a legal, if unusual, request that avoids needing
+        // a second Alice-owned object.)
+        let alice_get = dispatch_with_transport_identity(&deps, wrapped_get(&alice_kek_uid, &alice_kek_uid), Some(alice));
+        assert_eq!(
+            alice_get.batch_items[0].result_status,
+            ResultStatus::Success,
+            "Alice can wrap under her own KEK: {:?}",
+            alice_get.batch_items[0].result_reason
+        );
+    }
 }

--- a/kmip/src/ops/tenancy_e2e.rs
+++ b/kmip/src/ops/tenancy_e2e.rs
@@ -683,4 +683,109 @@ mod tests {
             alice_get.batch_items[0].result_reason
         );
     }
+
+    /// §M (final sweep — MAC + attribute mutation wired) — the two
+    /// remaining non-crypto-material by-UID op families are owner-checked
+    /// too: Bob can neither MAC with Alice's registered HMAC key nor
+    /// mutate its attributes, while Alice's own MAC and AddAttribute
+    /// succeed. Store-backed HMAC material (no engine session), so this
+    /// isolates the ownership property with no provisioning confound.
+    #[test]
+    fn cross_tenant_mac_and_attribute_ops_are_owner_checked() {
+        let _guard = engine_lock();
+        let alice = Identity { username: "alice-mac".into() };
+        let bob = Identity { username: "bob-mac".into() };
+        let sink: Arc<dyn crate::auditlog::AuditSink> = Arc::new(RingSink::new(64));
+        let deps = Deps::new(Engine::permissive(), Arc::new(MemoryStore::new()), sink, DepsConfig::default());
+
+        // Alice registers a store-backed HMAC key, born Active (past
+        // ActivationDate), with MAC_GENERATE|MAC_VERIFY usage.
+        let register_req = one_off_request(RequestPayload::Register(crate::kmip30::RegisterRequest {
+            object_type: ObjectType::SymmetricKey,
+            attributes: vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::HmacSha256),
+                Attribute::CryptographicLength(256),
+                Attribute::CryptographicUsageMask(UsageMask::MAC_GENERATE | UsageMask::MAC_VERIFY),
+                Attribute::ActivationDate(time::OffsetDateTime::now_utc().unix_timestamp() - 3600),
+            ],
+            managed_object: Some(crate::kmip30::KeyBlock {
+                key_format_type: crate::kmip30::KeyFormatType::Raw,
+                cryptographic_algorithm: KmipAlgorithm::HmacSha256,
+                cryptographic_length: 256,
+                key_value: vec![0x5Au8; 32],
+                key_wrapping_data: None,
+            }),
+            protection_storage_masks: None,
+            certificate_payload: None,
+            secret_data_type: None,
+        }));
+        let register_resp = dispatch_with_transport_identity(&deps, register_req, Some(alice.clone()));
+        assert_eq!(
+            register_resp.batch_items[0].result_status,
+            ResultStatus::Success,
+            "Alice registers her HMAC key: {:?}",
+            register_resp.batch_items[0].result_reason
+        );
+        let ResponsePayload::Register(registered) = register_resp.batch_items[0].payload.clone().unwrap() else {
+            panic!("expected Register response");
+        };
+
+        let mac_req = |uid: &str| {
+            one_off_request(RequestPayload::Mac(crate::kmip30::MacRequest {
+                uid: uid.to_string(),
+                cryptographic_parameters: None,
+                data: b"authenticate me".to_vec(),
+            }))
+        };
+
+        // Bob's MAC with Alice's key — denied at the owner check.
+        let bob_mac = dispatch_with_transport_identity(&deps, mac_req(&registered.uid), Some(bob.clone()));
+        assert_eq!(
+            bob_mac.batch_items[0].result_status,
+            ResultStatus::OperationFailed,
+            "Bob must NOT be able to MAC with Alice's key"
+        );
+        assert_eq!(
+            bob_mac.batch_items[0].result_reason,
+            Some(ResultReason::ObjectNotFound.to_wire_value())
+        );
+
+        // Alice's own MAC works.
+        let alice_mac = dispatch_with_transport_identity(&deps, mac_req(&registered.uid), Some(alice.clone()));
+        assert_eq!(
+            alice_mac.batch_items[0].result_status,
+            ResultStatus::Success,
+            "Alice can MAC with her own key: {:?}",
+            alice_mac.batch_items[0].result_reason
+        );
+
+        // Bob's AddAttribute on Alice's key — denied.
+        let bob_add = one_off_request(RequestPayload::AddAttribute(crate::kmip30::AddAttributeRequest {
+            uid: registered.uid.clone(),
+            new_attribute: Attribute::Name("bob-was-here".into()),
+        }));
+        let bob_add_resp = dispatch_with_transport_identity(&deps, bob_add, Some(bob));
+        assert_eq!(
+            bob_add_resp.batch_items[0].result_status,
+            ResultStatus::OperationFailed,
+            "Bob must NOT be able to mutate Alice's key's attributes"
+        );
+        assert_eq!(
+            bob_add_resp.batch_items[0].result_reason,
+            Some(ResultReason::ObjectNotFound.to_wire_value())
+        );
+
+        // Alice's own AddAttribute works — a real gate, not a blanket deny.
+        let alice_add = one_off_request(RequestPayload::AddAttribute(crate::kmip30::AddAttributeRequest {
+            uid: registered.uid,
+            new_attribute: Attribute::Name("alices-mac-key".into()),
+        }));
+        let alice_add_resp = dispatch_with_transport_identity(&deps, alice_add, Some(alice));
+        assert_eq!(
+            alice_add_resp.batch_items[0].result_status,
+            ResultStatus::Success,
+            "Alice can add an attribute to her own key: {:?}",
+            alice_add_resp.batch_items[0].result_reason
+        );
+    }
 }

--- a/kmip/src/ops/tenancy_e2e.rs
+++ b/kmip/src/ops/tenancy_e2e.rs
@@ -1,0 +1,189 @@
+//! Part F §F9 (rust-hsm-perf-bench-scenario-plan-07182026.md, workspace
+//! root) — end-to-end proof that per-tenant KMIP sessions (§F7.1/F7.2)
+//! plus the engine-side isolation gate (§F2–F5) actually keep two KMIP
+//! clients apart, driven through the REAL dispatcher
+//! (`dispatch_with_transport_identity`) with two distinct authenticated
+//! identities — not by calling op handlers directly with a hand-built
+//! `AuthContext`.
+//!
+//! STATUS (2026-07-18): this proves what is ACTUALLY wired today.
+//! `CreateKeyPair`, `Activate`, `Sign`, and `Encapsulate` resolve their
+//! own tenant's engine session (the §F7-scoped dispatcher-wiring slice —
+//! see the plan's §G3 for the ~24 remaining op handlers not yet
+//! migrated). It ALSO honestly documents the residual gap the same
+//! section flags: KMIP-level object METADATA (`Get`, `GetAttributes`,
+//! `Locate`) is not yet owner-filtered (§F7.3/F7.4 not built), so while
+//! a cross-tenant `Sign` genuinely fails closed (proven below, via the
+//! engine's own token-scoped handle lookup — not a KMIP-layer check),
+//! a cross-tenant `Get` on the same UID still succeeds today, leaking
+//! the object's existence and metadata. Both facts are asserted, not
+//! just one — this file must fail loudly (not silently pass) the day
+//! either behavior changes without deliberate intent.
+
+#[cfg(test)]
+mod tests {
+    use crate::auditlog::RingSink;
+    use crate::dispatcher::{dispatch_with_transport_identity, one_off_request};
+    use crate::error::ResultReason;
+    use crate::kmip30::{
+        ActivateRequest, Attribute, CreateKeyPairRequest, GetAttributesRequest, KmipAlgorithm,
+        RequestPayload, ResponsePayload, ResultStatus, SignRequest, UsageMask,
+    };
+    use crate::ops::deps::{Deps, DepsConfig, StrictTenantConfig, TenancyMode};
+    use crate::ops::helpers::engine_lock;
+    use crate::policy::Engine;
+    use crate::server::auth::Identity;
+    use crate::store::MemoryStore;
+    use std::sync::Arc;
+
+    /// Two tenants, `Strict` mode, on dedicated PKCS#11 slots (90/91 —
+    /// outside every range used elsewhere in this crate's test suite:
+    /// slot 0 for the many single-session fixtures, 60–72 for
+    /// `ops::deps::tests`). No `finalize()` here (see the note on
+    /// `ops::deps::tests::strict_mode_provisions_configured_tenant_and_caches_it`
+    /// for why that call is itself a cross-test hazard) — `engine_lock()`
+    /// below serialises this test against every other `src/ops/*.rs`
+    /// internal test that shares the same lock.
+    fn two_tenant_deps() -> (Deps, Identity, Identity) {
+        let alice = Identity { username: "alice-f9".into() };
+        let bob = Identity { username: "bob-f9".into() };
+        let config = DepsConfig {
+            tenancy_mode: TenancyMode::Strict,
+            strict_tenants: vec![
+                StrictTenantConfig {
+                    identity: alice.clone(),
+                    slot: 90,
+                    so_pin: "so-pin-90".into(),
+                    user_pin: "user-pin-90".into(),
+                },
+                StrictTenantConfig {
+                    identity: bob.clone(),
+                    slot: 91,
+                    so_pin: "so-pin-91".into(),
+                    user_pin: "user-pin-91".into(),
+                },
+            ],
+            ..DepsConfig::default()
+        };
+        let sink: Arc<dyn crate::auditlog::AuditSink> = Arc::new(RingSink::new(256));
+        let deps = Deps::new(Engine::permissive(), Arc::new(MemoryStore::new()), sink, config);
+        (deps, alice, bob)
+    }
+
+    #[test]
+    fn cross_tenant_sign_fails_closed_but_metadata_get_still_leaks() {
+        let _guard = engine_lock();
+        let (deps, alice, bob) = two_tenant_deps();
+
+        // ── Alice creates her own ML-DSA-65 signing key pair, through
+        // the REAL dispatcher — this is what auto-provisions her token
+        // on slot 90 on first use. ──────────────────────────────────────
+        let create_req = one_off_request(RequestPayload::CreateKeyPair(CreateKeyPairRequest {
+            common_attributes: vec![
+                Attribute::CryptographicAlgorithm(KmipAlgorithm::MlDsa65),
+                Attribute::CryptographicUsageMask(UsageMask::SIGN | UsageMask::VERIFY),
+            ],
+            private_key_attributes: vec![],
+            public_key_attributes: vec![],
+            seed: None,
+        }));
+        let create_resp = dispatch_with_transport_identity(&deps, create_req, Some(alice.clone()));
+        assert_eq!(
+            create_resp.batch_items[0].result_status,
+            ResultStatus::Success,
+            "Alice creates her own key pair: {:?}",
+            create_resp.batch_items[0].result_reason
+        );
+        let ResponsePayload::CreateKeyPair(ckp) = create_resp.batch_items[0].payload.clone().unwrap() else {
+            panic!("expected CreateKeyPair response");
+        };
+
+        // Activate the private key (freshly-created keys are PreActive;
+        // Sign requires Active).
+        let activate_req = one_off_request(RequestPayload::Activate(ActivateRequest {
+            uid: ckp.private_key_uid.clone(),
+        }));
+        let activate_resp = dispatch_with_transport_identity(&deps, activate_req, Some(alice.clone()));
+        assert_eq!(activate_resp.batch_items[0].result_status, ResultStatus::Success);
+
+        // ── Alice signs with her OWN key — must succeed. Proves her own
+        // tenant session works end-to-end through the real dispatcher
+        // (auto-provisioned token, real engine sign). ──────────────────
+        let sign_req = one_off_request(RequestPayload::Sign(SignRequest {
+            uid: ckp.private_key_uid.clone(),
+            data: b"alice's data".to_vec(),
+            cryptographic_parameters: None,
+        }));
+        let alice_sign_resp = dispatch_with_transport_identity(&deps, sign_req, Some(alice.clone()));
+        assert_eq!(
+            alice_sign_resp.batch_items[0].result_status,
+            ResultStatus::Success,
+            "Alice can sign with her own key: {:?}",
+            alice_sign_resp.batch_items[0].result_reason
+        );
+
+        // ── Bob attempts to Sign using ALICE's private key UID. ─────────
+        // His request resolves to HIS OWN engine session (slot 91, a
+        // different PKCS#11 token than Alice's slot 90). The KMIP-store
+        // lookup by UID still finds Alice's ObjectRecord (F7.3/F7.4 owner
+        // tracking is not built — see the module doc), but resolving
+        // that record's engine handle goes through
+        // `helpers::find_handle_for_object(bob_session, cka_id, ...)`,
+        // which is scoped to Bob's slot by the engine's OWN isolation
+        // gate (Part F, already shipped and independently tested in
+        // softhsmrustv3's own suite) — Alice's private-key handle simply
+        // isn't visible there, so the lookup finds nothing and the
+        // operation fails closed BEFORE any cryptographic material could
+        // be touched.
+        let bob_sign_req = one_off_request(RequestPayload::Sign(SignRequest {
+            uid: ckp.private_key_uid.clone(),
+            data: b"bob trying to sign with alice's key".to_vec(),
+            cryptographic_parameters: None,
+        }));
+        let bob_sign_resp = dispatch_with_transport_identity(&deps, bob_sign_req, Some(bob.clone()));
+        assert_eq!(
+            bob_sign_resp.batch_items[0].result_status,
+            ResultStatus::OperationFailed,
+            "Bob must NOT be able to sign with Alice's key"
+        );
+        assert_eq!(
+            bob_sign_resp.batch_items[0].result_reason,
+            Some(ResultReason::ObjectNotFound.to_wire_value()),
+            "cross-tenant Sign fails as ObjectNotFound — anti-oracle: indistinguishable from a UID \
+             that doesn't exist at all, matching the user's Item-Not-Found decision (§A2/rev 5) even \
+             though this specific denial is the ENGINE's token-scoping, not yet a KMIP-layer owner check"
+        );
+
+        // ── Honest residual-gap check. ───────────────────────────────────
+        // Bob's GetAttributes on Alice's private-key UID — deliberately
+        // NOT `Get` (which fails for a totally different, benign reason
+        // for ANY caller, including Alice herself: ML-DSA private keys
+        // are CKA_SENSITIVE by default, so `Get` always refuses to
+        // return material — that's a pre-existing sensitivity gate, not
+        // tenancy). `GetAttributes` only returns metadata (Cryptographic
+        // Algorithm, State, …), never key material, and — per
+        // `get_attributes.rs` — never touches `deps.engine_session` at
+        // all, so it is a clean, unconfounded test of whether the KMIP
+        // STORE itself is owner-filtered. It is not (F7.3 not built), so
+        // this metadata read still succeeds today, revealing that the
+        // object exists and its algorithm/state. This assertion
+        // documents TODAY'S actual (undesired) state, not the desired
+        // end state — when F7.3/F7.4 lands, this must flip to
+        // OperationFailed/ItemNotFound and this comment updated, exactly
+        // like the two P0b-era gap tests in softhsmrustv3's own suite
+        // were flipped once its gate landed.
+        let get_attrs_req = one_off_request(RequestPayload::GetAttributes(GetAttributesRequest {
+            uid: ckp.private_key_uid.clone(),
+            attribute_references: vec![],
+        }));
+        let bob_get_attrs_resp = dispatch_with_transport_identity(&deps, get_attrs_req, Some(bob));
+        assert_eq!(
+            bob_get_attrs_resp.batch_items[0].result_status,
+            ResultStatus::Success,
+            "KNOWN GAP (§F7.3/F7.4, not yet built): KMIP-level GetAttributes is not owner-filtered — \
+             Bob can still read Alice's key's metadata even though he cannot use the key \
+             cryptographically: {:?}",
+            bob_get_attrs_resp.batch_items[0].result_reason
+        );
+    }
+}

--- a/kmip/src/ops/validate.rs
+++ b/kmip/src/ops/validate.rs
@@ -84,6 +84,7 @@ use super::spki_verify::{verify_with_spki, SpkiVerdict};
 pub fn validate(
     deps: &Deps,
     req: ValidateRequest,
+    auth: &crate::server::auth::AuthContext,
     correlation_id: &str,
 ) -> Result<ValidateResponse> {
     emit_request(
@@ -104,9 +105,13 @@ pub fn validate(
     // §6.1.62 Table 442 (Object Not Found / Invalid Object Type).
     let mut ders: Vec<Vec<u8>> = Vec::with_capacity(req.certificates.len() + req.uids.len());
     for uid in &req.uids {
-        let obj = deps.store.get(uid)?.ok_or_else(|| {
-            fail_err(deps, correlation_id, "Validate", KmipError::object_not_found(uid))
-        })?;
+        // Part F §F7.4 — owner-checked: referencing a foreign tenant's
+        // stored certificate fails as the same ObjectNotFound a missing
+        // UID produces (anti-oracle).
+        let obj = super::helpers::authorize_object(deps, auth, uid, || {
+            KmipError::object_not_found(uid)
+        })
+        .map_err(|e| fail_err(deps, correlation_id, "Validate", e))?;
         if obj.object_type != ObjectType::Certificate {
             return Err(fail_err(
                 deps,
@@ -147,17 +152,21 @@ pub fn validate(
         return Ok(ValidateResponse { validity: SignatureValidity::Unknown });
     }
 
+    // Part F §F7 — every engine touch downstream (the transient-import
+    // verify helpers) happens inside the CALLER's own token.
+    let session = deps.resolve_tenant_session(auth.identity.as_ref()).ok();
     let validity =
-        validate_chain(deps, &ders, req.validity_date.unwrap_or_else(OffsetDateTime::now_utc));
+        validate_chain(session, &ders, req.validity_date.unwrap_or_else(OffsetDateTime::now_utc));
     emit_success(deps, correlation_id, "Validate");
     Ok(ValidateResponse { validity })
 }
 
 /// Core chain check. See the module doc for the exact Valid/Invalid/
-/// Unknown contract. Takes `deps` (unlike the pre-port version) because
-/// signature verification now goes through the engine via
+/// Unknown contract. Takes the caller's resolved tenant `session` (Part
+/// F §F7 — was `deps`, needed only to reach `deps.engine_session`)
+/// because signature verification goes through the engine via
 /// `verify_with_spki`, not a self-contained `ring` call.
-pub(crate) fn validate_chain(deps: &Deps, ders: &[Vec<u8>], at: OffsetDateTime) -> SignatureValidity {
+pub(crate) fn validate_chain(session: Option<u32>, ders: &[Vec<u8>], at: OffsetDateTime) -> SignatureValidity {
     // 1. Parse every certificate. Any parse failure → Invalid.
     let mut certs: Vec<X509Certificate> = Vec::with_capacity(ders.len());
     for der in ders {
@@ -244,9 +253,9 @@ pub(crate) fn validate_chain(deps: &Deps, ders: &[Vec<u8>], at: OffsetDateTime) 
                 // first on the issuance side (`certify.rs::resolve_ca`).
                 let verdict = match super::composite_sig::profile_for_oid(&sig_alg.oid.to_string()) {
                     Some(profile) => super::composite_sig::verify_composite_signature(
-                        deps, profile, &issuer_spki, tbs_bytes, sig_bytes,
+                        session, profile, &issuer_spki, tbs_bytes, sig_bytes,
                     ),
-                    None => verify_with_spki(deps, &issuer_spki, &sig_alg, tbs_bytes, sig_bytes),
+                    None => verify_with_spki(session, &issuer_spki, &sig_alg, tbs_bytes, sig_bytes),
                 };
 
                 match verdict {
@@ -287,7 +296,7 @@ pub(crate) fn validate_chain(deps: &Deps, ders: &[Vec<u8>], at: OffsetDateTime) 
                             Ok(None) => {} // not Catalyst-shaped — nothing more to check
                             Ok(Some(fields)) => {
                                 let alt_verdict = super::catalyst::tbs_minus_alt_sig_value(&typed_tbs).and_then(
-                                    |tbs_minus_alt| super::catalyst::verify_alt_signature(deps, &fields, &tbs_minus_alt),
+                                    |tbs_minus_alt| super::catalyst::verify_alt_signature(session, &fields, &tbs_minus_alt),
                                 );
                                 match alt_verdict {
                                     Ok(SpkiVerdict::Valid) => {}
@@ -307,7 +316,7 @@ pub(crate) fn validate_chain(deps: &Deps, ders: &[Vec<u8>], at: OffsetDateTime) 
                         // signature above is confirmed" reasoning.
                         match super::chameleon::reconstruct_delta(&typed_tbs) {
                             Ok(None) => {} // not Chameleon-shaped — nothing more to check
-                            Ok(Some(delta)) => match super::chameleon::verify_delta_signature(deps, &delta) {
+                            Ok(Some(delta)) => match super::chameleon::verify_delta_signature(session, &delta) {
                                 Ok(SpkiVerdict::Valid) => {}
                                 Ok(SpkiVerdict::Invalid) => return SignatureValidity::Invalid,
                                 Ok(SpkiVerdict::UnsupportedAlgorithm) | Err(_) => degrade_unknown = true,
@@ -329,7 +338,7 @@ pub(crate) fn validate_chain(deps: &Deps, ders: &[Vec<u8>], at: OffsetDateTime) 
                     Ok(None) => {} // no RelatedCertificate extension — nothing to check
                     Ok(Some(ext)) => match super::related_certs::extract_related_cert_claim(ext.value) {
                         Ok((hash_alg_oid, claimed_hash)) => match super::related_certs::resolve_related_cert(
-                            deps, &hash_alg_oid, &claimed_hash, ders, idx,
+                            session, &hash_alg_oid, &claimed_hash, ders, idx,
                         ) {
                             Ok(super::related_certs::RelatedCertVerdict::Bound) => {}
                             Ok(super::related_certs::RelatedCertVerdict::Unknown) => degrade_unknown = true,
@@ -439,7 +448,7 @@ mod tests {
         let (deps, _g) = deps_with_session();
         let der = self_signed_der();
         assert_eq!(
-            validate_chain(&deps, &[der], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[der], OffsetDateTime::now_utc()),
             SignatureValidity::Valid
         );
     }
@@ -452,7 +461,7 @@ mod tests {
         let deps = deps_with();
         let der = self_signed_der();
         let far_future = OffsetDateTime::now_utc() + ::time::Duration::days(365 * 100);
-        assert_eq!(validate_chain(&deps, &[der], far_future), SignatureValidity::Invalid);
+        assert_eq!(validate_chain(deps.engine_session, &[der], far_future), SignatureValidity::Invalid);
     }
 
     #[test]
@@ -461,7 +470,7 @@ mod tests {
         let deps = deps_with();
         let der = self_signed_der();
         let far_past = OffsetDateTime::from_unix_timestamp(0).unwrap();
-        assert_eq!(validate_chain(&deps, &[der], far_past), SignatureValidity::Invalid);
+        assert_eq!(validate_chain(deps.engine_session, &[der], far_past), SignatureValidity::Invalid);
     }
 
     #[test]
@@ -478,7 +487,7 @@ mod tests {
 
         // Leaf alone — issuer (CA) absent.
         assert_eq!(
-            validate_chain(&deps, &[leaf.der().to_vec()], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[leaf.der().to_vec()], OffsetDateTime::now_utc()),
             SignatureValidity::Unknown
         );
     }
@@ -498,7 +507,7 @@ mod tests {
         // single self-signed check.
         assert_eq!(
             validate_chain(
-                &deps,
+                deps.engine_session,
                 &[leaf.der().to_vec(), ca_cert.der().to_vec()],
                 OffsetDateTime::now_utc()
             ),
@@ -520,7 +529,7 @@ mod tests {
         der[n - 1] ^= 0x01;
         // Either the signature fails (Invalid) — the intended outcome.
         assert_eq!(
-            validate_chain(&deps, &[der], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[der], OffsetDateTime::now_utc()),
             SignatureValidity::Invalid
         );
     }
@@ -530,7 +539,7 @@ mod tests {
         // Fails at parse (step 1), before any engine call.
         let deps = deps_with();
         assert_eq!(
-            validate_chain(&deps, &[vec![0xff, 0x00, 0x01]], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[vec![0xff, 0x00, 0x01]], OffsetDateTime::now_utc()),
             SignatureValidity::Invalid
         );
     }
@@ -541,6 +550,7 @@ mod tests {
         let err = validate(
             &d,
             ValidateRequest { certificates: vec![], uids: vec!["nope".into()], validity_date: None },
+            &crate::server::auth::AuthContext::open(),
             "c",
         )
         .unwrap_err();
@@ -563,6 +573,7 @@ mod tests {
         let err = validate(
             &d,
             ValidateRequest { certificates: vec![], uids: vec!["sym".into()], validity_date: None },
+            &crate::server::auth::AuthContext::open(),
             "c",
         )
         .unwrap_err();
@@ -576,6 +587,7 @@ mod tests {
         let r = validate(
             &d,
             ValidateRequest { certificates: vec![], uids: vec!["ca".into()], validity_date: None },
+            &crate::server::auth::AuthContext::open(),
             "c",
         )
         .unwrap();
@@ -622,7 +634,7 @@ mod tests {
         .expect("bootstrap ML-DSA CA cert");
 
         assert_eq!(
-            validate_chain(&deps, &[cert_der], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[cert_der], OffsetDateTime::now_utc()),
             SignatureValidity::Valid,
             "a self-signed ML-DSA chain must validate — ring never supported this"
         );
@@ -661,6 +673,7 @@ mod tests {
         let r = validate(
             &d,
             ValidateRequest { certificates: vec![], uids: vec!["ca-registered".into()], validity_date: None },
+            &crate::server::auth::AuthContext::open(),
             "c",
         )
         .unwrap();
@@ -707,7 +720,7 @@ mod tests {
         .expect("bootstrap composite CA cert");
 
         assert_eq!(
-            validate_chain(&deps, &[cert_der.clone()], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[cert_der.clone()], OffsetDateTime::now_utc()),
             SignatureValidity::Valid,
             "a self-signed composite chain must validate — both components verify independently"
         );
@@ -716,7 +729,7 @@ mod tests {
         let last = tampered.len() - 1;
         tampered[last] ^= 0xff;
         assert_eq!(
-            validate_chain(&deps, &[tampered], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[tampered], OffsetDateTime::now_utc()),
             SignatureValidity::Invalid,
             "a tampered composite signature must never come back Valid"
         );
@@ -736,7 +749,7 @@ mod tests {
 
         let (valid_cert_der, _tbs) = super::super::catalyst::tests::build_catalyst_tbs_and_sign(session, false);
         assert_eq!(
-            validate_chain(&deps, &[valid_cert_der], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[valid_cert_der], OffsetDateTime::now_utc()),
             SignatureValidity::Valid,
             "a self-signed Catalyst cert with a genuine alt signature must validate"
         );
@@ -747,7 +760,7 @@ mod tests {
         // whichever signature happens to be examined first.
         let (tampered_alt_cert_der, _tbs2) = super::super::catalyst::tests::build_catalyst_tbs_and_sign(session, true);
         assert_eq!(
-            validate_chain(&deps, &[tampered_alt_cert_der], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[tampered_alt_cert_der], OffsetDateTime::now_utc()),
             SignatureValidity::Invalid,
             "a tampered Catalyst alt signature must invalidate the chain even though the primary signature is untouched"
         );
@@ -780,7 +793,7 @@ mod tests {
         // Both companions supplied together — Bound, both self-signed,
         // both primary signatures verify → Valid overall.
         assert_eq!(
-            validate_chain(&deps, &[cert_a_der.clone(), cert_b_der.clone()], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[cert_a_der.clone(), cert_b_der.clone()], OffsetDateTime::now_utc()),
             SignatureValidity::Valid,
             "cert B's real companion (cert A) supplied alongside it must bind and validate"
         );
@@ -788,7 +801,7 @@ mod tests {
         // Cert B alone — nothing else supplied to check the claim
         // against → Unknown, not Invalid (honest "can't confirm").
         assert_eq!(
-            validate_chain(&deps, &[cert_b_der.clone()], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[cert_b_der.clone()], OffsetDateTime::now_utc()),
             SignatureValidity::Unknown,
             "no companion supplied at all must degrade to Unknown, not guess Invalid"
         );
@@ -798,7 +811,7 @@ mod tests {
         // Invalid, a real checkable failure.
         let unrelated_der = params_with_cn("related-unrelated").self_signed(&rcgen::KeyPair::generate().unwrap()).unwrap().der().to_vec();
         assert_eq!(
-            validate_chain(&deps, &[cert_b_der, unrelated_der], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[cert_b_der, unrelated_der], OffsetDateTime::now_utc()),
             SignatureValidity::Invalid,
             "an unrelated companion that doesn't hash-match the claim must be Invalid"
         );
@@ -816,7 +829,7 @@ mod tests {
 
         let (valid_cert_der, _tbs) = super::super::chameleon::tests::build_chameleon_primary_tbs(session, false);
         assert_eq!(
-            validate_chain(&deps, &[valid_cert_der], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[valid_cert_der], OffsetDateTime::now_utc()),
             SignatureValidity::Valid,
             "a self-signed Chameleon cert with a genuine delta signature must validate"
         );
@@ -827,7 +840,7 @@ mod tests {
         let (tampered_delta_cert_der, _tbs2) =
             super::super::chameleon::tests::build_chameleon_primary_tbs(session, true);
         assert_eq!(
-            validate_chain(&deps, &[tampered_delta_cert_der], OffsetDateTime::now_utc()),
+            validate_chain(deps.engine_session, &[tampered_delta_cert_der], OffsetDateTime::now_utc()),
             SignatureValidity::Invalid,
             "a tampered Chameleon delta signature must invalidate the chain even though the primary signature is untouched"
         );

--- a/kmip/src/server/auth.rs
+++ b/kmip/src/server/auth.rs
@@ -33,7 +33,12 @@ use time::OffsetDateTime;
 use crate::kmip30::Credential;
 
 /// The authenticated principal a request acts as.
-#[derive(Clone, Debug, PartialEq, Eq)]
+///
+/// `Hash` (added for the Part F tenant registry,
+/// rust-hsm-perf-bench-scenario-plan-07182026.md §F7) lets `Identity`
+/// key a `HashMap` directly — one tenant token per authenticated
+/// principal.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Identity {
     /// KMIP username (configured-auth) or mTLS client-cert subject CN.
     pub username: String,

--- a/kmip/src/store/traits.rs
+++ b/kmip/src/store/traits.rs
@@ -314,6 +314,25 @@ pub struct ObjectRecord {
     /// KMIP *attribute* — the spec only exposes it as the Locate
     /// Storage Status Mask filter (K22).
     pub archived: bool,
+    /// Part F §F7.3 (rust-hsm-perf-bench-scenario-plan-07182026.md,
+    /// workspace root) — the KMIP identity's username that created this
+    /// object (`server::auth::Identity::username`, stored as a plain
+    /// `String` rather than the `Identity` type to keep `store`
+    /// decoupled from `server`). `None` for objects created by a
+    /// request with no authenticated identity (Single tenancy mode —
+    /// today's default — or every object that existed before this
+    /// field). `#[serde(default)]` keeps pre-existing sqlite/memory
+    /// records readable.
+    ///
+    /// Per the user's decision (2026-07-18): an ownerless object is
+    /// accessible ONLY to a requester who is ALSO unauthenticated —
+    /// enforcement (`ops::helpers::authorize_object`) does exact
+    /// `Option<String>` equality between this field and the requester's
+    /// identity, never a one-sided "no owner ⇒ public" rule. `None ==
+    /// None` covers "both anonymous"; `Some(a) == Some(a)` covers "same
+    /// tenant"; every other combination is a mismatch.
+    #[serde(default)]
+    pub owner: Option<String>,
 }
 
 impl ObjectRecord {
@@ -413,6 +432,7 @@ impl From<BaselineDefaults> for ObjectRecord {
             application_specific_information: None,
             protection_storage_mask: None,
             archived: false,
+            owner: None,
         }
     }
 }

--- a/kmip/tests/ecdh_recommended_curve_e2e.rs
+++ b/kmip/tests/ecdh_recommended_curve_e2e.rs
@@ -171,6 +171,7 @@ fn ecdh_curve25519_makes_x25519_and_reports_domain_params() {
     let ga = get_attributes(
         &d,
         GetAttributesRequest { uid: priv_uid.clone(), attribute_references: vec![] },
+        &pqctoday_kmip::server::auth::AuthContext::open(),
         "ga",
     )
     .expect("get_attributes");
@@ -186,6 +187,7 @@ fn ecdh_curve25519_makes_x25519_and_reports_domain_params() {
     let got = get(
         &d,
         GetRequest { uid: priv_uid, key_format_type: None, key_wrapping_specification: None },
+        &pqctoday_kmip::server::auth::AuthContext::open(),
         "get",
     );
     assert!(got.is_err(), "Get on the X25519 private key must be refused");

--- a/kmip/tests/ecdh_recommended_curve_e2e.rs
+++ b/kmip/tests/ecdh_recommended_curve_e2e.rs
@@ -81,6 +81,7 @@ fn create_ecdh(d: &Deps, curve: u32) -> String {
             seed: None,
         },
         "CreateKeyPair:KeyAgreement",
+        &pqctoday_kmip::server::auth::AuthContext::open(),
         "ckp",
     )
     .expect("ecdh keygen");
@@ -106,6 +107,7 @@ fn create_ecdh_pair(d: &Deps, curve: u32) -> (String, String) {
             seed: None,
         },
         "CreateKeyPair:KeyAgreement",
+        &pqctoday_kmip::server::auth::AuthContext::open(),
         "ckp",
     )
     .expect("ecdh keygen");

--- a/kmip/tests/ecdh_recommended_curve_e2e.rs
+++ b/kmip/tests/ecdh_recommended_curve_e2e.rs
@@ -143,6 +143,7 @@ fn derive_agree(d: &Deps, priv_uid: &str, peer_public: &[u8]) -> Vec<u8> {
             },
             template_attribute: vec![Attribute::CryptographicLength(256)], // 32 bytes
         },
+        &pqctoday_kmip::server::auth::AuthContext::open(),
         "derive",
     )
     .expect("derive_key ecdh agreement");

--- a/kmip/tests/frodokem_mceliece_e2e.rs
+++ b/kmip/tests/frodokem_mceliece_e2e.rs
@@ -22,6 +22,7 @@ use pqctoday_kmip::ops::get::get;
 use pqctoday_kmip::ops::activate::activate;
 use pqctoday_kmip::ops::{Deps, DepsConfig};
 use pqctoday_kmip::policy::Engine;
+use pqctoday_kmip::server::auth::AuthContext;
 use pqctoday_kmip::store::MemoryStore;
 
 // The softhsmrustv3 engine is global (lazy_static Mutex state); serialize the
@@ -66,6 +67,7 @@ fn round_trip(alg: KmipAlgorithm, ss_len: usize) {
             seed: None,
         },
         "CreateKeyPair:KeyAgreement",
+        &AuthContext::open(),
         "ckp",
     )
     .unwrap_or_else(|e| panic!("{alg:?}: keygen failed: {e:?}"));
@@ -81,6 +83,7 @@ fn round_trip(alg: KmipAlgorithm, ss_len: usize) {
             input_key_material: None,
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "encap",
     )
     .unwrap_or_else(|e| panic!("{alg:?}: encapsulate failed: {e:?}"));

--- a/kmip/tests/frodokem_mceliece_e2e.rs
+++ b/kmip/tests/frodokem_mceliece_e2e.rs
@@ -96,6 +96,7 @@ fn round_trip(alg: KmipAlgorithm, ss_len: usize) {
             data: enc.data.clone(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "decap",
     )
     .unwrap_or_else(|e| panic!("{alg:?}: decapsulate failed: {e:?}"));
@@ -117,6 +118,7 @@ fn round_trip(alg: KmipAlgorithm, ss_len: usize) {
             key_format_type: None,
             key_wrapping_specification: None,
         },
+        &AuthContext::open(),
         "get",
     );
     assert!(got.is_err(), "{alg:?}: Get on the private key must be refused (non-extractable)");

--- a/kmip/tests/hybrid_kem_e2e.rs
+++ b/kmip/tests/hybrid_kem_e2e.rs
@@ -19,6 +19,7 @@ use pqctoday_kmip::ops::get::get;
 use pqctoday_kmip::ops::activate::activate;
 use pqctoday_kmip::ops::{Deps, DepsConfig};
 use pqctoday_kmip::policy::Engine;
+use pqctoday_kmip::server::auth::AuthContext;
 use pqctoday_kmip::store::MemoryStore;
 
 // The softhsmrustv3 engine is global (lazy_static Mutex state); serialize the
@@ -59,6 +60,7 @@ fn round_trip(alg: KmipAlgorithm, ss_len: usize) {
             seed: None,
         },
         "CreateKeyPair:KeyAgreement",
+        &AuthContext::open(),
         "ckp",
     )
     .expect("hybrid keygen");
@@ -76,6 +78,7 @@ fn round_trip(alg: KmipAlgorithm, ss_len: usize) {
             input_key_material: None,
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "encap",
     )
     .expect("encapsulate");

--- a/kmip/tests/hybrid_kem_e2e.rs
+++ b/kmip/tests/hybrid_kem_e2e.rs
@@ -92,6 +92,7 @@ fn round_trip(alg: KmipAlgorithm, ss_len: usize) {
             data: enc.data.clone(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "decap",
     )
     .expect("decapsulate");
@@ -115,6 +116,7 @@ fn round_trip(alg: KmipAlgorithm, ss_len: usize) {
             key_format_type: None,
             key_wrapping_specification: None,
         },
+        &AuthContext::open(),
         "get",
     );
     assert!(

--- a/kmip/tests/migration_rekey_e2e.rs
+++ b/kmip/tests/migration_rekey_e2e.rs
@@ -23,6 +23,7 @@ use pqctoday_kmip::ops::rekey::{rekey, rekey_key_pair};
 use pqctoday_kmip::ops::sign::sign;
 use pqctoday_kmip::ops::{Deps, DepsConfig};
 use pqctoday_kmip::policy::{load_from_file, Engine};
+use pqctoday_kmip::server::auth::AuthContext;
 use pqctoday_kmip::store::MemoryStore;
 
 fn engine_test_lock() -> std::sync::MutexGuard<'static, ()> {
@@ -84,6 +85,7 @@ fn gen_pair(deps: &Deps, name: &str, usage: UsageMask) -> (String, String) {
         } else {
             "CreateKeyPair:Sign"
         },
+        &AuthContext::open(),
         "gen",
     )
     .unwrap();
@@ -115,6 +117,7 @@ fn firmware_signing_key_rekeys_rsa2048_to_mldsa44_on_first_sign() {
     let resp = sign(
         &deps,
         SignRequest { uid: priv_uid.clone(), data: b"release".to_vec(), cryptographic_parameters: None },
+        &AuthContext::open(),
         "sign",
     )
     .unwrap();
@@ -193,6 +196,7 @@ fn x448_kex_rekeys_to_mlkem1024_on_first_encapsulate() {
     let resp = encapsulate(
         &deps,
         EncapsulateRequest { uid: pub_uid.clone(), ..Default::default() },
+        &AuthContext::open(),
         "encap",
     )
     .unwrap();
@@ -252,6 +256,7 @@ fn sweep_rekeys_via_rekey_and_rekeykeypair() {
             private_key_attributes: vec![],
             public_key_attributes: vec![],
         },
+        &AuthContext::open(),
         "sweep",
     )
     .unwrap();

--- a/kmip/tests/migration_rekey_e2e.rs
+++ b/kmip/tests/migration_rekey_e2e.rs
@@ -170,6 +170,7 @@ fn payments_cipher_rekeys_aes128_to_aes256_on_first_encrypt() {
             final_indicator: None,
             correlation_value: None,
         },
+        &AuthContext::open(),
         "enc",
     )
     .unwrap();
@@ -313,6 +314,7 @@ fn legacy_signature_still_verifies_after_owner_key_rekeys() {
             final_indicator: None,
             correlation_value: None,
         },
+        &AuthContext::open(),
         "enc",
     )
     .unwrap();
@@ -335,6 +337,7 @@ fn legacy_signature_still_verifies_after_owner_key_rekeys() {
             cryptographic_parameters: None,
             aad: None,
         },
+        &AuthContext::open(),
         "dec",
     )
     .unwrap();

--- a/kmip/tests/migration_rekey_e2e.rs
+++ b/kmip/tests/migration_rekey_e2e.rs
@@ -149,6 +149,7 @@ fn payments_cipher_rekeys_aes128_to_aes256_on_first_encrypt() {
                 Attribute::Name("payments-db-cipher".into()),
             ],
         },
+        &AuthContext::open(),
         "create",
     )
     .unwrap();
@@ -225,6 +226,7 @@ fn sweep_rekeys_via_rekey_and_rekeykeypair() {
                 Attribute::Name("payments-db-cipher".into()),
             ],
         },
+        &AuthContext::open(),
         "create",
     )
     .unwrap();
@@ -240,6 +242,7 @@ fn sweep_rekeys_via_rekey_and_rekeykeypair() {
     let rk_sym = rekey(
         &deps,
         ReKeyRequest { uid: sym.uid.clone(), offset: None, template_attribute: vec![] },
+        &AuthContext::open(),
         "sweep",
     )
     .unwrap();
@@ -290,6 +293,7 @@ fn legacy_signature_still_verifies_after_owner_key_rekeys() {
                 Attribute::Name("payments-db-cipher".into()),
             ],
         },
+        &AuthContext::open(),
         "create",
     )
     .unwrap();

--- a/kmip/tests/native_bridge_e2e.rs
+++ b/kmip/tests/native_bridge_e2e.rs
@@ -725,6 +725,7 @@ fn k9_register_ml_kem_768_encap_decap_roundtrip() {
             final_indicator: None,
             correlation_value: None,
         },
+        &AuthContext::open(),
         "k9-encap",
     )
     .expect("Encrypt(encapsulate) with registered ML-KEM-768 public key");
@@ -741,6 +742,7 @@ fn k9_register_ml_kem_768_encap_decap_roundtrip() {
             cryptographic_parameters: None,
             aad: None,
         },
+        &AuthContext::open(),
         "k9-decap",
     )
     .expect("Decrypt(decapsulate) with registered ML-KEM-768 private key");
@@ -1772,6 +1774,7 @@ fn k21_rekeyed_aes_key_encrypts_against_real_engine() {
             final_indicator: None,
             correlation_value: None,
         },
+        &AuthContext::open(),
         "k21-encrypt",
     )
     .expect("re-keyed AES key must encrypt through the engine");
@@ -1790,6 +1793,7 @@ fn k21_rekeyed_aes_key_encrypts_against_real_engine() {
             cryptographic_parameters: None,
             aad: None,
         },
+        &AuthContext::open(),
         "k21-decrypt",
     )
     .expect("re-keyed AES key must decrypt its own ciphertext");

--- a/kmip/tests/native_bridge_e2e.rs
+++ b/kmip/tests/native_bridge_e2e.rs
@@ -601,6 +601,7 @@ fn register_pqc(
             protection_storage_masks: None,
             certificate_payload: None,
         },
+        &AuthContext::open(),
         "k9-register",
     )
     .map(|r| r.uid)
@@ -878,6 +879,7 @@ fn k9_register_pqc_length_mismatch_fails_invalid_attribute_value() {
             protection_storage_masks: None,
             certificate_payload: None,
         },
+        &AuthContext::open(),
         "k9-len-mismatch",
     )
     .expect_err("declared-length mismatch must fail Register");
@@ -1260,6 +1262,7 @@ fn k17_register_wrapped_hmac_key_then_mac_against_real_engine() {
                 protection_storage_masks: None,
                 certificate_payload: None,
             },
+            &AuthContext::open(),
             cid,
         )
         .unwrap()
@@ -1317,6 +1320,7 @@ fn k17_register_wrapped_hmac_key_then_mac_against_real_engine() {
             key_compression_type: None,
             key_wrapping_specification: Some(kws.clone()),
         },
+        &AuthContext::open(),
         "k17-export-wrapped",
     )
     .unwrap();
@@ -2191,6 +2195,7 @@ fn hss_register_sign_verify_against_real_engine() {
                 protection_storage_masks: None,
                 certificate_payload: None,
             },
+            &AuthContext::open(),
             cid,
         )
         .unwrap()
@@ -2531,6 +2536,7 @@ fn k3_register_rsa_public_key_accepts_both_pkcs1_and_pkcs8_der() {
                 protection_storage_masks: None,
                 certificate_payload: None,
             },
+            &AuthContext::open(),
             "k3-register",
         )
         .map(|r| r.uid)
@@ -2616,6 +2622,7 @@ fn k3_register_rsa_private_key_malformed_pkcs1_fails_register_not_silently() {
             protection_storage_masks: None,
             certificate_payload: None,
         },
+        &AuthContext::open(),
         "k3-register-malformed",
     )
     .unwrap_err();
@@ -2840,6 +2847,7 @@ fn k3_register_transparent_rsa_public_key_produces_usable_engine_object() {
                 protection_storage_masks: None,
                 certificate_payload: None,
             },
+            &AuthContext::open(),
             "k3-register-transparent",
         )
         .map(|r| r.uid)

--- a/kmip/tests/native_bridge_e2e.rs
+++ b/kmip/tests/native_bridge_e2e.rs
@@ -41,6 +41,7 @@ use pqctoday_kmip::ops::sign::sign;
 use pqctoday_kmip::ops::signature_verify::signature_verify;
 use pqctoday_kmip::ops::{Deps, DepsConfig};
 use pqctoday_kmip::policy::{load_from_str, Engine};
+use pqctoday_kmip::server::auth::AuthContext;
 use pqctoday_kmip::store::MemoryStore;
 
 /// Serialise all e2e tests that touch the engine. The engine's
@@ -116,7 +117,7 @@ fn ml_dsa_65_create_sign_verify_destroy_against_real_engine() {
     seed: None,
     };
     let kp_resp =
-        create_key_pair(&deps, create_req, "CreateKeyPair:Sign", "e2e-create").unwrap();
+        create_key_pair(&deps, create_req, "CreateKeyPair:Sign", &AuthContext::open(), "e2e-create").unwrap();
 
     // Both halves of the keypair share the same CKA_ID — verify via the store.
     let priv_rec = deps.store.get(&kp_resp.private_key_uid).unwrap().unwrap();
@@ -148,6 +149,7 @@ fn ml_dsa_65_create_sign_verify_destroy_against_real_engine() {
             data: message.to_vec(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "e2e-sign",
     )
     .unwrap();
@@ -240,7 +242,7 @@ fn ml_dsa_87_create_sign_verify_against_real_engine() {
     seed: None,
     };
     let kp_resp =
-        create_key_pair(&deps, create_req, "CreateKeyPair:Sign", "e2e87-create").unwrap();
+        create_key_pair(&deps, create_req, "CreateKeyPair:Sign", &AuthContext::open(), "e2e87-create").unwrap();
 
     let priv_rec = deps.store.get(&kp_resp.private_key_uid).unwrap().unwrap();
     let pub_rec = deps.store.get(&kp_resp.public_key_uid).unwrap().unwrap();
@@ -256,6 +258,7 @@ fn ml_dsa_87_create_sign_verify_against_real_engine() {
             data: b"hello".to_vec(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "s",
     )
     .unwrap();
@@ -305,7 +308,7 @@ fn k6_rsa_sha384_sha512_sign_verify_against_real_engine() {
         public_key_attributes: vec![Attribute::CryptographicUsageMask(UsageMask::VERIFY)],
     seed: None,
     };
-    let kp = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", "k6-create").unwrap();
+    let kp = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", &AuthContext::open(), "k6-create").unwrap();
     let priv_uid = kp.private_key_uid;
     let pub_uid = kp.public_key_uid;
     activate(&deps, ActivateRequest { uid: priv_uid.clone() }, "k6-a1").unwrap();
@@ -333,6 +336,7 @@ fn k6_rsa_sha384_sha512_sign_verify_against_real_engine() {
                 data: message.clone(),
                 cryptographic_parameters: Some(cp(hash, padding)),
             },
+            &AuthContext::open(),
             "k6-sign",
         )
         .unwrap_or_else(|e| panic!("sign {hash:?}/{padding:?} failed: {e:?}"));
@@ -398,6 +402,7 @@ fn k6_rsa_sha384_sha512_sign_verify_against_real_engine() {
             data: message,
             cryptographic_parameters: Some(cp(HashingAlgorithm::Sha1, Some(0x08))),
         },
+        &AuthContext::open(),
         "k6-sign-sha1",
     )
     .unwrap_err();
@@ -441,7 +446,7 @@ fn k18_rsa_pss_salt_length_threads_to_engine() {
         public_key_attributes: vec![Attribute::CryptographicUsageMask(UsageMask::VERIFY)],
     seed: None,
     };
-    let kp = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", "k18-create").unwrap();
+    let kp = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", &AuthContext::open(), "k18-create").unwrap();
     let priv_uid = kp.private_key_uid;
     let pub_uid = kp.public_key_uid;
     activate(&deps, ActivateRequest { uid: priv_uid.clone() }, "k18-a1").unwrap();
@@ -462,6 +467,7 @@ fn k18_rsa_pss_salt_length_threads_to_engine() {
                 data: message.clone(),
                 cryptographic_parameters: cp,
             },
+            &AuthContext::open(),
             "k18-sign",
         )
     };
@@ -648,6 +654,7 @@ fn k9_register_ml_dsa_65_sign_verify_roundtrip() {
             data: message.clone(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "k9-sign",
     )
     .expect("Sign with registered ML-DSA-65 private key");
@@ -783,6 +790,7 @@ fn k9_register_slh_dsa_shake_128f_sign_verify_roundtrip() {
             data: message.clone(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "k9-slh-sign",
     )
     .expect("Sign with registered SLH-DSA private key");
@@ -936,6 +944,7 @@ fn k11_digest_persisted_from_real_engine_material() {
         seed: None,
         },
         "CreateKeyPair:Sign",
+        &AuthContext::open(),
         "k11-kp",
     )
     .unwrap();
@@ -1072,6 +1081,7 @@ fn k15_audit_records_real_rv_and_native_entry_point() {
             data: b"k15".to_vec(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "k15-sign-fail",
     )
     .expect_err("CKM_ML_DSA over an AES secret key must fail in the engine");
@@ -1442,6 +1452,7 @@ fn wd19_encapsulate_decapsulate_byte_exact_against_real_engine() {
             input_key_material: Some(coins.clone()),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "wd19-encap-1",
     )
     .expect("Encapsulate with ML-KEM-768 public key");
@@ -1459,6 +1470,7 @@ fn wd19_encapsulate_decapsulate_byte_exact_against_real_engine() {
             input_key_material: Some(coins.clone()),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "wd19-encap-2",
     )
     .expect("second deterministic Encapsulate");
@@ -1495,6 +1507,7 @@ fn wd19_encapsulate_decapsulate_byte_exact_against_real_engine() {
             input_key_material: Some(vec![0xAB; 32]),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "wd19-encap-3",
     )
     .unwrap();
@@ -1625,6 +1638,7 @@ fn wd19_encapsulate_matches_oasis_transcript_vectors() {
             input_key_material: Some(coins),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "wd19-transcript-encap",
     )
     .expect("transcript Encapsulate");
@@ -1792,7 +1806,7 @@ fn rsa_create_respects_cryptographic_length_attribute() {
         public_key_attributes: vec![Attribute::CryptographicUsageMask(UsageMask::VERIFY)],
     seed: None,
     };
-    let kp = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", "rsa-len").unwrap();
+    let kp = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", &AuthContext::open(), "rsa-len").unwrap();
     let priv_rec = deps.store.get(&kp.private_key_uid).unwrap().unwrap();
     assert_eq!(priv_rec.cryptographic_length, 2048);
 
@@ -1816,7 +1830,7 @@ fn rsa_create_rejects_unsupported_length() {
         public_key_attributes: vec![Attribute::CryptographicUsageMask(UsageMask::VERIFY)],
     seed: None,
     };
-    let err = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", "rsa-bad")
+    let err = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", &AuthContext::open(), "rsa-bad")
         .expect_err("RSA-1024 must be rejected");
     assert_eq!(err.result_reason(), ResultReason::InvalidAttributeValue);
 
@@ -1841,7 +1855,7 @@ fn ecdsa_create_respects_cryptographic_length_attribute() {
         public_key_attributes: vec![Attribute::CryptographicUsageMask(UsageMask::VERIFY)],
     seed: None,
     };
-    let kp = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", "ec-384").unwrap();
+    let kp = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", &AuthContext::open(), "ec-384").unwrap();
     let priv_rec = deps.store.get(&kp.private_key_uid).unwrap().unwrap();
     assert_eq!(priv_rec.cryptographic_length, 384);
 
@@ -1874,7 +1888,7 @@ fn ecdh_create_key_pair_succeeds_for_all_three_nist_curves() {
             )],
             seed: None,
         };
-        let kp = create_key_pair(&deps, create_req, "CreateKeyPair:KeyAgreement", "ecdh-e2e")
+        let kp = create_key_pair(&deps, create_req, "CreateKeyPair:KeyAgreement", &AuthContext::open(), "ecdh-e2e")
             .unwrap_or_else(|e| panic!("ECDH-P{length} CreateKeyPair failed: {e:?}"));
         let priv_rec = deps.store.get(&kp.private_key_uid).unwrap().unwrap();
         assert_eq!(priv_rec.algorithm, KmipAlgorithm::Ecdh);
@@ -1904,7 +1918,7 @@ fn ed25519_create_sign_verify_round_trip() {
         )],
         seed: None,
     };
-    let kp_resp = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", "ed25519-e2e").unwrap();
+    let kp_resp = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", &AuthContext::open(), "ed25519-e2e").unwrap();
     let priv_rec = deps.store.get(&kp_resp.private_key_uid).unwrap().unwrap();
     let pub_rec = deps.store.get(&kp_resp.public_key_uid).unwrap().unwrap();
     assert_eq!(priv_rec.algorithm, KmipAlgorithm::Ed25519);
@@ -1922,6 +1936,7 @@ fn ed25519_create_sign_verify_round_trip() {
             data: message.to_vec(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "ed25519-sign",
     )
     .unwrap();
@@ -1980,7 +1995,7 @@ fn locate_drops_orphans_when_engine_handle_is_gone() {
         public_key_attributes: vec![Attribute::CryptographicUsageMask(UsageMask::VERIFY)],
     seed: None,
     };
-    let _ = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", "loc-create").unwrap();
+    let _ = create_key_pair(&deps, create_req, "CreateKeyPair:Sign", &AuthContext::open(), "loc-create").unwrap();
 
     // Sanity: locate finds both halves.
     let before = locate(
@@ -2176,6 +2191,7 @@ fn hss_register_sign_verify_against_real_engine() {
     let sig1 = sign(
         &deps,
         SignRequest { uid: priv_uid.clone(), data: b"message one".to_vec(), cryptographic_parameters: None },
+        &AuthContext::open(),
         "hss-e2e-sign-1",
     )
     .unwrap();
@@ -2196,6 +2212,7 @@ fn hss_register_sign_verify_against_real_engine() {
     let sig2 = sign(
         &deps,
         SignRequest { uid: priv_uid.clone(), data: b"message two".to_vec(), cryptographic_parameters: None },
+        &AuthContext::open(),
         "hss-e2e-sign-2",
     )
     .unwrap();
@@ -2508,6 +2525,7 @@ fn k3_register_rsa_public_key_accepts_both_pkcs1_and_pkcs8_der() {
     let sig = sign(
         &deps,
         SignRequest { uid: priv_uid, data: message.clone(), cryptographic_parameters: None },
+        &AuthContext::open(),
         "k3-sign",
     )
     .expect("Sign with PKCS#8-registered RSA private key");
@@ -2823,6 +2841,7 @@ fn k3_register_transparent_rsa_public_key_produces_usable_engine_object() {
     let sig = sign(
         &deps,
         SignRequest { uid: priv_uid, data: message.clone(), cryptographic_parameters: None },
+        &AuthContext::open(),
         "k3-sign-transparent",
     )
     .expect("Sign with PKCS#8-registered RSA private key");

--- a/kmip/tests/native_bridge_e2e.rs
+++ b/kmip/tests/native_bridge_e2e.rs
@@ -220,6 +220,7 @@ fn ml_dsa_65_create_sign_verify_destroy_against_real_engine() {
         DestroyRequest {
             uid: priv_rec.uid.clone(),
         },
+        &AuthContext::open(),
         "e2e-destroy",
     )
     .unwrap();
@@ -964,6 +965,7 @@ fn k11_digest_persisted_from_real_engine_material() {
             uid: kp.private_key_uid.clone(),
             attribute_references: vec!["Digest".into()],
         },
+        &AuthContext::open(),
         "k11-ga",
     )
     .unwrap();
@@ -983,6 +985,7 @@ fn k11_digest_persisted_from_real_engine_material() {
                 Attribute::CryptographicUsageMask(UsageMask::ENCRYPT | UsageMask::DECRYPT),
             ],
         },
+        &AuthContext::open(),
         "k11-create",
     )
     .unwrap();
@@ -1045,6 +1048,7 @@ fn k15_audit_records_real_rv_and_native_entry_point() {
                 Attribute::CryptographicUsageMask(UsageMask::ENCRYPT),
             ],
         },
+        &AuthContext::open(),
         "k15-create-ok",
     )
     .unwrap();
@@ -1126,6 +1130,7 @@ fn k15_hmac_mac_and_verify_route_through_engine() {
                 ),
             ],
         },
+        &AuthContext::open(),
         "k15-hmac-create",
     )
     .unwrap();
@@ -1420,6 +1425,7 @@ fn get_shared_secret(deps: &Deps, uid: &str) -> Vec<u8> {
     let r = get(
         deps,
         GetRequest { uid: uid.to_string(), key_format_type: None, key_wrapping_specification: None },
+        &AuthContext::open(),
         "kem-get-ss",
     )
     .expect("Get shared-secret object");
@@ -1489,6 +1495,7 @@ fn wd19_encapsulate_decapsulate_byte_exact_against_real_engine() {
             data: enc1.data.clone(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "wd19-decap",
     )
     .expect("Decapsulate with ML-KEM-768 private key");
@@ -1698,6 +1705,7 @@ fn k21_rekeyed_aes_key_encrypts_against_real_engine() {
                 Attribute::CryptographicUsageMask(UsageMask::ENCRYPT | UsageMask::DECRYPT),
             ],
         },
+        &AuthContext::open(),
         "k21-create",
     )
     .unwrap();
@@ -1707,6 +1715,7 @@ fn k21_rekeyed_aes_key_encrypts_against_real_engine() {
     let r = rekey(
         &deps,
         ReKeyRequest { uid: c.uid.clone(), offset: None, template_attribute: vec![] },
+        &AuthContext::open(),
         "k21-rekey",
     )
     .unwrap();
@@ -2005,6 +2014,7 @@ fn locate_drops_orphans_when_engine_handle_is_gone() {
             maximum_items: None,
             ..Default::default()
         },
+        &AuthContext::open(),
         "loc-before",
     )
     .unwrap();
@@ -2037,6 +2047,7 @@ fn locate_drops_orphans_when_engine_handle_is_gone() {
             maximum_items: None,
             ..Default::default()
         },
+        &AuthContext::open(),
         "loc-after",
     )
     .unwrap();
@@ -2076,6 +2087,7 @@ fn narrowing_usage_mask_via_set_attribute_shrinks_engine_whitelist() {
                 ),
             ],
         },
+        &AuthContext::open(),
         "narrow-create",
     )
     .unwrap();
@@ -2278,6 +2290,7 @@ fn create_split_key_then_join_threshold_subset_reconstructs_via_real_engine() {
         get(
             &deps,
             GetRequest { uid: uid.to_string(), key_format_type: None, key_wrapping_specification: None },
+            &AuthContext::open(),
             "split-key-e2e-get",
         )
         .unwrap()
@@ -2378,6 +2391,7 @@ fn create_split_key_then_join_covers_every_11_54_method_via_real_engine() {
         get(
             &deps,
             GetRequest { uid: uid.to_string(), key_format_type: None, key_wrapping_specification: None },
+            &AuthContext::open(),
             "split-key-methods-e2e-get",
         )
         .unwrap()

--- a/kmip/tests/native_bridge_e2e.rs
+++ b/kmip/tests/native_bridge_e2e.rs
@@ -169,6 +169,7 @@ fn ml_dsa_65_create_sign_verify_destroy_against_real_engine() {
             signature: sig_resp.signature.clone(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "e2e-verify-ok",
     )
     .unwrap();
@@ -190,6 +191,7 @@ fn ml_dsa_65_create_sign_verify_destroy_against_real_engine() {
             signature: tampered,
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "e2e-verify-bad",
     )
     .unwrap();
@@ -212,6 +214,7 @@ fn ml_dsa_65_create_sign_verify_destroy_against_real_engine() {
             uid: priv_rec.uid.clone(),
             reason: RevocationReason::CessationOfOperation,
         },
+        &AuthContext::open(),
         "e2e-revoke",
     )
     .unwrap();
@@ -277,6 +280,7 @@ fn ml_dsa_87_create_sign_verify_against_real_engine() {
             signature: sig.signature,
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "v",
     )
     .unwrap();
@@ -351,6 +355,7 @@ fn k6_rsa_sha384_sha512_sign_verify_against_real_engine() {
                 signature: sig.signature.clone(),
                 cryptographic_parameters: Some(cp(hash, padding)),
             },
+            &AuthContext::open(),
             "k6-verify",
         )
         .unwrap();
@@ -370,6 +375,7 @@ fn k6_rsa_sha384_sha512_sign_verify_against_real_engine() {
                 signature: sig.signature,
                 cryptographic_parameters: Some(cp(other, padding)),
             },
+            &AuthContext::open(),
             "k6-verify-cross",
         )
         .unwrap();
@@ -390,6 +396,7 @@ fn k6_rsa_sha384_sha512_sign_verify_against_real_engine() {
             signature: vec![0u8; 256],
             cryptographic_parameters: Some(cp(HashingAlgorithm::Sha1, Some(0x0a))),
         },
+        &AuthContext::open(),
         "k6-verify-sha1",
     )
     .unwrap();
@@ -481,6 +488,7 @@ fn k18_rsa_pss_salt_length_threads_to_engine() {
                 signature: sig,
                 cryptographic_parameters: cp,
             },
+            &AuthContext::open(),
             "k18-verify",
         )
         .unwrap()
@@ -670,6 +678,7 @@ fn k9_register_ml_dsa_65_sign_verify_roundtrip() {
             signature: sig.signature,
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "k9-verify",
     )
     .expect("SignatureVerify with registered ML-DSA-65 public key");
@@ -808,6 +817,7 @@ fn k9_register_slh_dsa_shake_128f_sign_verify_roundtrip() {
             signature: sig.signature,
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "k9-slh-verify",
     )
     .expect("SignatureVerify with registered SLH-DSA public key");
@@ -1151,6 +1161,7 @@ fn k15_hmac_mac_and_verify_route_through_engine() {
             cryptographic_parameters: None,
             data: data.clone(),
         },
+        &AuthContext::open(),
         "k15-hmac-mac",
     )
     .unwrap();
@@ -1191,6 +1202,7 @@ fn k15_hmac_mac_and_verify_route_through_engine() {
             data: data.clone(),
             mac_data: m.mac_data.clone(),
         },
+        &AuthContext::open(),
         "k15-hmac-verify",
     )
     .unwrap();
@@ -1213,6 +1225,7 @@ fn k15_hmac_mac_and_verify_route_through_engine() {
             data,
             mac_data: bad,
         },
+        &AuthContext::open(),
         "k15-hmac-verify-bad",
     )
     .unwrap();
@@ -1358,6 +1371,7 @@ fn k17_register_wrapped_hmac_key_then_mac_against_real_engine() {
             cryptographic_parameters: None,
             data: data.clone(),
         },
+        &AuthContext::open(),
         "k17-mac",
     )
     .unwrap();
@@ -1967,6 +1981,7 @@ fn ed25519_create_sign_verify_round_trip() {
             signature: sig_resp.signature.clone(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "ed25519-verify-ok",
     )
     .unwrap();
@@ -1983,6 +1998,7 @@ fn ed25519_create_sign_verify_round_trip() {
             signature: tampered,
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "ed25519-verify-bad",
     )
     .unwrap();
@@ -2129,6 +2145,7 @@ fn narrowing_usage_mask_via_set_attribute_shrinks_engine_whitelist() {
             uid: created.uid.clone(),
             new_attribute: Attribute::CryptographicUsageMask(UsageMask::ENCRYPT | UsageMask::DECRYPT),
         },
+        &AuthContext::open(),
         "narrow-set",
     )
     .unwrap();
@@ -2224,6 +2241,7 @@ fn hss_register_sign_verify_against_real_engine() {
             signature: sig1.signature.clone(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "hss-e2e-verify-1",
     )
     .unwrap();
@@ -2249,6 +2267,7 @@ fn hss_register_sign_verify_against_real_engine() {
             signature: sig2.signature,
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "hss-e2e-verify-2",
     )
     .unwrap();
@@ -2266,6 +2285,7 @@ fn hss_register_sign_verify_against_real_engine() {
             signature: tampered,
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "hss-e2e-verify-bad",
     )
     .unwrap();
@@ -2326,6 +2346,7 @@ fn create_split_key_then_join_threshold_subset_reconstructs_via_real_engine() {
             ],
             protection_storage_masks: None,
         },
+        &AuthContext::open(),
         "split-key-e2e-create",
     )
     .unwrap();
@@ -2350,6 +2371,7 @@ fn create_split_key_then_join_threshold_subset_reconstructs_via_real_engine() {
             attributes: vec![],
             protection_storage_masks: None,
         },
+        &AuthContext::open(),
         "split-key-e2e-join",
     )
     .unwrap();
@@ -2367,6 +2389,7 @@ fn create_split_key_then_join_threshold_subset_reconstructs_via_real_engine() {
             attributes: vec![],
             protection_storage_masks: None,
         },
+        &AuthContext::open(),
         "split-key-e2e-join-insufficient",
     )
     .unwrap_err();
@@ -2442,6 +2465,7 @@ fn create_split_key_then_join_covers_every_11_54_method_via_real_engine() {
                 attributes,
                 protection_storage_masks: None,
             },
+            &AuthContext::open(),
             "split-key-methods-e2e-create",
         )
         .unwrap_or_else(|e| panic!("method {method}: Create Split Key failed: {e}"));
@@ -2474,6 +2498,7 @@ fn create_split_key_then_join_covers_every_11_54_method_via_real_engine() {
                 attributes: vec![],
                 protection_storage_masks: None,
             },
+            &AuthContext::open(),
             "split-key-methods-e2e-join",
         )
         .unwrap_or_else(|e| panic!("method {method}: Join Split Key failed: {e}"));
@@ -2566,6 +2591,7 @@ fn k3_register_rsa_public_key_accepts_both_pkcs1_and_pkcs8_der() {
             signature: sig.signature.clone(),
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "k3-verify-pkcs8",
     )
     .expect("SignatureVerify against a PKCS#8-registered RSA public key");
@@ -2583,6 +2609,7 @@ fn k3_register_rsa_public_key_accepts_both_pkcs1_and_pkcs8_der() {
             signature: sig.signature,
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "k3-verify-pkcs1",
     )
     .expect("SignatureVerify against a PKCS#1-registered RSA public key");
@@ -2731,6 +2758,7 @@ fn k9_id_placeholder_resolves_after_join_split_key() {
             ],
             protection_storage_masks: None,
         },
+        &AuthContext::open(),
         "k9-precreate-parts",
     )
     .expect("Create Split Key");
@@ -2879,6 +2907,7 @@ fn k3_register_transparent_rsa_public_key_produces_usable_engine_object() {
             signature: sig.signature,
             cryptographic_parameters: None,
         },
+        &AuthContext::open(),
         "k3-verify-transparent",
     )
     .expect("SignatureVerify against a TransparentRSAPublicKey-registered public key");

--- a/kmip/tests/op_coverage_e2e.rs
+++ b/kmip/tests/op_coverage_e2e.rs
@@ -739,6 +739,7 @@ fn set_defaults_inherited_by_create_unless_client_overrides() {
                 attributes: vec![Attribute::Name("server-default-name".into())],
             }]),
         },
+        &AuthContext::open(),
         "sd-set",
     )
     .unwrap();

--- a/kmip/tests/op_coverage_e2e.rs
+++ b/kmip/tests/op_coverage_e2e.rs
@@ -128,6 +128,7 @@ fn create_aes(deps: &Deps, extra: Vec<Attribute>, cid: &str) -> String {
             object_type: ObjectType::SymmetricKey,
             template_attribute: aes_template(extra),
         },
+        &AuthContext::open(),
         cid,
     )
     .unwrap()
@@ -143,6 +144,7 @@ fn state_via_get_attributes(deps: &Deps, uid: &str) -> State {
             uid: uid.to_string(),
             attribute_references: vec!["State".into()],
         },
+        &AuthContext::open(),
         "ga-state",
     )
     .unwrap();
@@ -169,12 +171,12 @@ fn archive_then_get_fails_then_recover_restores() {
     let uid = import_aes_with_material(&deps, "ar-mat", vec![0x11; 32]);
 
     // Get works before Archive.
-    let before = get(&deps, GetRequest { uid: uid.clone(), key_format_type: None, key_wrapping_specification: None }, "ar-get1").unwrap();
+    let before = get(&deps, GetRequest { uid: uid.clone(), key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "ar-get1").unwrap();
     assert_eq!(before.key_block.key_value, vec![0x11; 32]);
 
     // Archive → record moves off-line.
     archive(&deps, ArchiveRequest { uid: uid.clone() }, "ar-archive").unwrap();
-    let err = get(&deps, GetRequest { uid: uid.clone(), key_format_type: None, key_wrapping_specification: None }, "ar-get2").unwrap_err();
+    let err = get(&deps, GetRequest { uid: uid.clone(), key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "ar-get2").unwrap_err();
     assert_eq!(
         err.result_reason(),
         ResultReason::ObjectArchived,
@@ -183,7 +185,7 @@ fn archive_then_get_fails_then_recover_restores() {
 
     // Recover → back on-line, Get returns the same bytes.
     recover(&deps, RecoverRequest { uid: uid.clone() }, "ar-recover").unwrap();
-    let after = get(&deps, GetRequest { uid, key_format_type: None, key_wrapping_specification: None }, "ar-get3").unwrap();
+    let after = get(&deps, GetRequest { uid, key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "ar-get3").unwrap();
     assert_eq!(after.key_block.key_value, vec![0x11; 32], "Recover restores the same material");
 
     let _ = softhsmrustv3::native::session::finalize();
@@ -268,7 +270,7 @@ fn import_material_round_trips_through_get_and_export() {
 
     // Import lands in PreActive; Get serves the material in any
     // non-Destroyed state, so no activation needed.
-    let g = get(&deps, GetRequest { uid: uid.clone(), key_format_type: None, key_wrapping_specification: None }, "ie-get").unwrap();
+    let g = get(&deps, GetRequest { uid: uid.clone(), key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "ie-get").unwrap();
     assert_eq!(g.key_block.key_value, material, "Get recovers the imported material verbatim");
     assert_eq!(g.key_block.cryptographic_algorithm, KmipAlgorithm::Aes);
 
@@ -322,6 +324,7 @@ fn object_group_create_into_group_then_locate_by_group_in_one_session() {
     let mut g1 = locate(
         &deps,
         LocateRequest { attributes: vec![Attribute::ObjectGroup("G1".into())], ..Default::default() },
+        &AuthContext::open(),
         "og-loc-g1",
     )
     .unwrap()
@@ -335,6 +338,7 @@ fn object_group_create_into_group_then_locate_by_group_in_one_session() {
     let g2 = locate(
         &deps,
         LocateRequest { attributes: vec![Attribute::ObjectGroup("G2".into())], ..Default::default() },
+        &AuthContext::open(),
         "og-loc-g2",
     )
     .unwrap()
@@ -345,6 +349,7 @@ fn object_group_create_into_group_then_locate_by_group_in_one_session() {
     let none = locate(
         &deps,
         LocateRequest { attributes: vec![Attribute::ObjectGroup("ghost".into())], ..Default::default() },
+        &AuthContext::open(),
         "og-loc-ghost",
     )
     .unwrap()
@@ -357,6 +362,7 @@ fn object_group_create_into_group_then_locate_by_group_in_one_session() {
     let ga = get_attributes(
         &deps,
         GetAttributesRequest { uid: a.clone(), attribute_references: vec!["GroupLink".into()] },
+        &AuthContext::open(),
         "og-ga",
     )
     .unwrap();
@@ -389,6 +395,7 @@ fn set_attribute_writes_value_and_rejects_read_only() {
     let r = get_attributes(
         &deps,
         GetAttributesRequest { uid: uid.clone(), attribute_references: vec!["Name".into()] },
+        &AuthContext::open(),
         "sa-ga",
     )
     .unwrap();
@@ -465,6 +472,7 @@ fn derive_key_produces_usable_derived_object_with_links() {
                 Attribute::ActivationDate(OffsetDateTime::now_utc().unix_timestamp() - 3600),
             ],
         },
+        &AuthContext::open(),
         "dk-base",
     )
     .unwrap()
@@ -500,6 +508,7 @@ fn derive_key_produces_usable_derived_object_with_links() {
     let derived_attrs = get_attributes(
         &deps,
         GetAttributesRequest { uid: resp.uid.clone(), attribute_references: vec![] },
+        &AuthContext::open(),
         "dk-ga-derived",
     )
     .unwrap();
@@ -510,6 +519,7 @@ fn derive_key_produces_usable_derived_object_with_links() {
     let base_attrs = get_attributes(
         &deps,
         GetAttributesRequest { uid: base_uid, attribute_references: vec![] },
+        &AuthContext::open(),
         "dk-ga-base",
     )
     .unwrap();
@@ -542,6 +552,7 @@ fn rekey_mints_replacement_with_links_and_retires_original() {
     let resp = rekey(
         &deps,
         ReKeyRequest { uid: orig.clone(), offset: None, template_attribute: vec![] },
+        &AuthContext::open(),
         "rk-rekey",
     )
     .unwrap();
@@ -1129,7 +1140,7 @@ fn certify_issues_certificate_get_able_with_links() {
     .unwrap();
 
     // ── The issued Certificate is Get-able with §11 attrs. ──
-    let g = get(&deps, GetRequest { uid: resp.uid.clone(), key_format_type: None, key_wrapping_specification: None }, "e2e-get").unwrap();
+    let g = get(&deps, GetRequest { uid: resp.uid.clone(), key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "e2e-get").unwrap();
     assert_eq!(g.object_type, ObjectType::Certificate);
     assert!(!g.key_block.key_value.is_empty(), "issued cert DER is returned by Get");
 
@@ -1347,6 +1358,6 @@ fn import_certificate_round_trips_der_no_algorithm_attribute_required() {
 
     // Get must return the exact same DER — proves the store-side fix,
     // independent of any engine session (none is wired in this test).
-    let got = get(&deps, GetRequest { uid: "cert-import".into(), key_format_type: None, key_wrapping_specification: None }, "get-cert").unwrap();
+    let got = get(&deps, GetRequest { uid: "cert-import".into(), key_format_type: None, key_wrapping_specification: None }, &AuthContext::open(), "get-cert").unwrap();
     assert_eq!(got.key_block.key_value, der);
 }

--- a/kmip/tests/op_coverage_e2e.rs
+++ b/kmip/tests/op_coverage_e2e.rs
@@ -391,6 +391,7 @@ fn set_attribute_writes_value_and_rejects_read_only() {
     set_attribute(
         &deps,
         SetAttributeRequest { uid: uid.clone(), new_attribute: Attribute::Name("rotated-key-7".into()) },
+        &AuthContext::open(),
         "sa-set",
     )
     .unwrap();
@@ -410,6 +411,7 @@ fn set_attribute_writes_value_and_rejects_read_only() {
     let err = set_attribute(
         &deps,
         SetAttributeRequest { uid, new_attribute: Attribute::State(State::Compromised) },
+        &AuthContext::open(),
         "sa-ro",
     )
     .unwrap_err();
@@ -438,6 +440,7 @@ fn adjust_attribute_increments_usage_mask_by_delta() {
             adjustment_type: AdjustmentType::Increment,
             adjustment_value: Some(UsageMask::SIGN.bits() as i64),
         },
+        &AuthContext::open(),
         "adj",
     )
     .unwrap();
@@ -497,6 +500,7 @@ fn derive_key_produces_usable_derived_object_with_links() {
                 Attribute::CryptographicUsageMask(UsageMask::ENCRYPT | UsageMask::DECRYPT),
             ],
         },
+        &AuthContext::open(),
         "dk-derive",
     )
     .unwrap();
@@ -1280,18 +1284,18 @@ fn pkcs11_get_info_returns_real_ck_info_bytes_against_real_engine() {
     // C_Initialize (0x01) — the KMIP-server-side virtual lifecycle
     // flag; the real engine is already initialized for the server's
     // whole lifetime, this just tracks THIS client's view of it.
-    assert_eq!(pkcs11(&deps, req(1), "pkcs11-e2e-init").unwrap().return_code, 0);
+    assert_eq!(pkcs11(&deps, req(1), &AuthContext::open(), "pkcs11-e2e-init").unwrap().return_code, 0);
 
     // C_GetInfo (0x03) against the REAL engine session — must return
     // actual, non-empty CK_INFO bytes, not the honest-`None` fallback.
-    let info_resp = pkcs11(&deps, req(3), "pkcs11-e2e-getinfo").unwrap();
+    let info_resp = pkcs11(&deps, req(3), &AuthContext::open(), "pkcs11-e2e-getinfo").unwrap();
     assert_eq!(info_resp.return_code, 0);
     let info_bytes = info_resp.output_parameters.expect("real engine must return real CK_INFO bytes");
     assert_eq!(info_bytes.len(), 72, "CK_INFO is 72 bytes per PKCS#11 v3.2 §5.4");
     assert!(info_bytes.iter().any(|&b| b != 0), "real CK_INFO is not all-zero filler");
 
     // C_Finalize (0x02) — clean teardown of the virtual lifecycle flag.
-    assert_eq!(pkcs11(&deps, req(2), "pkcs11-e2e-finalize").unwrap().return_code, 0);
+    assert_eq!(pkcs11(&deps, req(2), &AuthContext::open(), "pkcs11-e2e-finalize").unwrap().return_code, 0);
 
     let _ = softhsmrustv3::native::session::finalize();
 }

--- a/kmip/tests/op_coverage_e2e.rs
+++ b/kmip/tests/op_coverage_e2e.rs
@@ -251,6 +251,7 @@ fn import_aes_with_material(deps: &Deps, uid: &str, material: Vec<u8>) -> String
             }),
             certificate_payload: None,
         },
+        &AuthContext::open(),
         "import",
     )
     .unwrap();
@@ -283,6 +284,7 @@ fn import_material_round_trips_through_get_and_export() {
             key_compression_type: None,
             key_wrapping_specification: None,
         },
+        &AuthContext::open(),
         "ie-export",
     )
     .unwrap();
@@ -989,6 +991,7 @@ fn validate_stored_self_signed_cert_returns_valid_and_error_paths() {
     let r = validate(
         &deps,
         ValidateRequest { certificates: vec![], uids: vec!["cert-ca".into()], validity_date: None },
+        &AuthContext::open(),
         "v-valid",
     )
     .unwrap();
@@ -1003,6 +1006,7 @@ fn validate_stored_self_signed_cert_returns_valid_and_error_paths() {
             uids: vec![],
             validity_date: Some(OffsetDateTime::now_utc() + time::Duration::days(365 * 100)),
         },
+        &AuthContext::open(),
         "v-expired",
     )
     .unwrap();
@@ -1016,6 +1020,7 @@ fn validate_stored_self_signed_cert_returns_valid_and_error_paths() {
     let r = validate(
         &deps,
         ValidateRequest { certificates: vec![leaf.der().to_vec()], uids: vec![], validity_date: None },
+        &AuthContext::open(),
         "v-unknown",
     )
     .unwrap();
@@ -1029,6 +1034,7 @@ fn validate_stored_self_signed_cert_returns_valid_and_error_paths() {
             uids: vec![],
             validity_date: None,
         },
+        &AuthContext::open(),
         "v-chain",
     )
     .unwrap();
@@ -1038,6 +1044,7 @@ fn validate_stored_self_signed_cert_returns_valid_and_error_paths() {
     let err = validate(
         &deps,
         ValidateRequest { certificates: vec![], uids: vec!["ghost".into()], validity_date: None },
+        &AuthContext::open(),
         "v-nf",
     )
     .unwrap_err();
@@ -1057,6 +1064,7 @@ fn validate_stored_self_signed_cert_returns_valid_and_error_paths() {
     let err = validate(
         &deps,
         ValidateRequest { certificates: vec![], uids: vec!["sym".into()], validity_date: None },
+        &AuthContext::open(),
         "v-iot",
     )
     .unwrap_err();
@@ -1135,6 +1143,7 @@ fn certify_issues_certificate_get_able_with_links() {
             certificate_request: Some(csr.der().to_vec()),
             ..CertifyRequest::default()
         },
+        &AuthContext::open(),
         "e2e-certify",
     )
     .unwrap();
@@ -1347,6 +1356,7 @@ fn import_certificate_round_trips_der_no_algorithm_attribute_required() {
             managed_object: None,
             certificate_payload: Some((0 /* X.509 */, der.clone())),
         },
+        &AuthContext::open(),
         "import-cert",
     )
     .unwrap();

--- a/kmip/tests/op_coverage_e2e.rs
+++ b/kmip/tests/op_coverage_e2e.rs
@@ -581,6 +581,7 @@ fn rekey_key_pair_mints_both_halves_with_links_and_retires_originals() {
         seed: None,
         },
         "CreateKeyPair:Sign",
+        &AuthContext::open(),
         "rkkp-create",
     )
     .unwrap();
@@ -595,6 +596,7 @@ fn rekey_key_pair_mints_both_halves_with_links_and_retires_originals() {
             private_key_attributes: vec![],
             public_key_attributes: vec![],
         },
+        &AuthContext::open(),
         "rkkp-rekey",
     )
     .unwrap();
@@ -1093,6 +1095,7 @@ fn certify_issues_certificate_get_able_with_links() {
         seed: None,
         },
         "CreateKeyPair",
+        &AuthContext::open(),
         "e2e-ca-keygen",
     )
     .unwrap();

--- a/kmip/tests/openssl_cert_crosscheck.rs
+++ b/kmip/tests/openssl_cert_crosscheck.rs
@@ -47,6 +47,7 @@ use pqctoday_kmip::kmip30::{
 use pqctoday_kmip::ops::certify::{bootstrap_ca_certificate, certify};
 use pqctoday_kmip::ops::{Deps, DepsConfig};
 use pqctoday_kmip::policy::Engine;
+use pqctoday_kmip::server::auth::AuthContext;
 use pqctoday_kmip::store::{MemoryStore, ObjectRecord};
 
 use softhsmrustv3::constants as c;
@@ -230,6 +231,7 @@ fn issue_leaf(deps: &Deps) -> Vec<u8> {
             certificate_request: Some(csr.der().to_vec()),
             ..CertifyRequest::default()
         },
+        &AuthContext::open(),
         "crosscheck-issue",
     )
     .unwrap();

--- a/kmip/tests/openssl_kem_interop.rs
+++ b/kmip/tests/openssl_kem_interop.rs
@@ -237,6 +237,7 @@ fn mlkem768_openssl_encap_our_decap() {
     let dec = decapsulate(
         &d,
         DecapsulateRequest { uid: priv_uid, data: ct, cryptographic_parameters: None },
+        &AuthContext::open(),
         "decap",
     )
     .expect("KMIP decapsulate");
@@ -394,6 +395,7 @@ fn x25519mlkem768_openssl_component_encap_our_decap() {
     let dec = decapsulate(
         &d,
         DecapsulateRequest { uid: kp.private_key_uid, data: hybrid_ct, cryptographic_parameters: None },
+        &AuthContext::open(),
         "decap",
     )
     .expect("KMIP hybrid decapsulate");

--- a/kmip/tests/openssl_kem_interop.rs
+++ b/kmip/tests/openssl_kem_interop.rs
@@ -141,6 +141,7 @@ fn register_key(
             protection_storage_masks: None,
             certificate_payload: None,
         },
+        &AuthContext::open(),
         "interop-register",
     )
     .expect("register")

--- a/kmip/tests/openssl_kem_interop.rs
+++ b/kmip/tests/openssl_kem_interop.rs
@@ -31,6 +31,7 @@ use pqctoday_kmip::ops::encapsulate::encapsulate;
 use pqctoday_kmip::ops::register_import_export::register;
 use pqctoday_kmip::ops::{Deps, DepsConfig};
 use pqctoday_kmip::policy::Engine;
+use pqctoday_kmip::server::auth::AuthContext;
 use pqctoday_kmip::store::MemoryStore;
 
 const MLKEM768_EK: usize = 1184;
@@ -174,6 +175,7 @@ fn mlkem768_our_encap_openssl_decap() {
     let enc = encapsulate(
         &d,
         EncapsulateRequest { uid: pub_uid, input_key_material: None, cryptographic_parameters: None },
+        &AuthContext::open(),
         "encap",
     )
     .expect("KMIP encapsulate");
@@ -288,6 +290,7 @@ fn x25519mlkem768_our_encap_openssl_component_decap() {
     let enc = encapsulate(
         &d,
         EncapsulateRequest { uid: pub_uid, input_key_material: None, cryptographic_parameters: None },
+        &AuthContext::open(),
         "encap",
     )
     .expect("KMIP hybrid encapsulate");
@@ -349,6 +352,7 @@ fn x25519mlkem768_openssl_component_encap_our_decap() {
             seed: None,
         },
         "CreateKeyPair:KeyAgreement",
+        &AuthContext::open(),
         "ckp",
     )
     .expect("hybrid keygen");

--- a/kmip/tests/policy_op_layer.rs
+++ b/kmip/tests/policy_op_layer.rs
@@ -122,7 +122,7 @@ fn try_create_sym(
     for (k, v) in custom {
         t.push(Attribute::Custom { name: (*k).to_string(), value: pqctoday_kmip::kmip30::CustomAttributeValue::Text((*v).to_string()) });
     }
-    create(deps, CreateRequest { object_type: ObjectType::SymmetricKey, template_attribute: t }, "cr")
+    create(deps, CreateRequest { object_type: ObjectType::SymmetricKey, template_attribute: t }, &AuthContext::open(), "cr")
         .map(|_| ())
         .map_err(|e| format!("{:?}", e.result_reason()))
 }

--- a/kmip/tests/policy_op_layer.rs
+++ b/kmip/tests/policy_op_layer.rs
@@ -31,6 +31,7 @@ use pqctoday_kmip::ops::create::create;
 use pqctoday_kmip::ops::create_key_pair::create_key_pair;
 use pqctoday_kmip::ops::{Deps, DepsConfig};
 use pqctoday_kmip::policy::{load_from_str, Engine};
+use pqctoday_kmip::server::auth::AuthContext;
 use pqctoday_kmip::store::MemoryStore;
 
 const POLICIES_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/policies");
@@ -97,6 +98,7 @@ fn try_create_key_pair(
             seed: None,
         },
         canonical_op_for(intent),
+        &AuthContext::open(),
         "ckp",
     )
     .map(|_| ())

--- a/kmip/tests/store_backend_parity.rs
+++ b/kmip/tests/store_backend_parity.rs
@@ -12,6 +12,7 @@ use pqctoday_kmip::ops::activate::activate;
 use pqctoday_kmip::ops::create::create;
 use pqctoday_kmip::ops::{Deps, DepsConfig};
 use pqctoday_kmip::policy::{load_from_str, Engine};
+use pqctoday_kmip::server::auth::AuthContext;
 use pqctoday_kmip::store::{KeyStore, MemoryStore, SqliteStore};
 
 const POLICY: &str = r#"
@@ -57,6 +58,7 @@ fn create_then_activate_then_sign_works_on_both_backends() {
                 object_type: ObjectType::SymmetricKey,
                 template_attribute: vec![],
             },
+            &AuthContext::open(),
             &format!("c-{backend_name}-create"),
         )
         .unwrap();

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -67,6 +67,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +145,19 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bench-harness"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "libloading",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "softhsmrustv3",
+]
 
 [[package]]
 name = "bindgen"
@@ -275,6 +338,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "classic-mceliece-rust"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +413,12 @@ name = "cmov"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -901,6 +1010,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1233,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opaque-debug"
@@ -1751,6 +1872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,6 +1965,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,6 +4,22 @@ version = "0.15.0"
 edition = "2024"
 description = "A native Rust WebAssembly clone of SoftHSMv3"
 
+# hsm-perf-bench plan §A4.1/§P4 — makes this crate the workspace root, with
+# `bench-harness/` as a sibling member. Purely structural: does not change
+# this crate's own compiled output (cdylib/wasm/rlib) in any way, and
+# `cargo build`/`cargo test` invoked from `rust/` for THIS package alone
+# behave identically to before. What it DOES do: bench-harness now shares
+# this file's `[patch.crates-io]` section (below) and this directory's
+# Cargo.lock — patches only apply within a shared workspace, so a
+# standalone sibling crate depending on this one via a bare path dependency
+# would silently re-resolve the UNPATCHED upstream fips204/fips205 (same
+# version number, missing the added Ph variants / _internal_*_external_mu
+# functions this crate's own crypto/handlers.rs needs) — confirmed the
+# hard way: bench-harness's first build failed on exactly those symbols
+# before this workspace declaration was added.
+[workspace]
+members = ["bench-harness"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/rust/RUST_P11_V32_CONFORMANCE_REPORT.md
+++ b/rust/RUST_P11_V32_CONFORMANCE_REPORT.md
@@ -90,6 +90,34 @@ All constants verified against both the vendored `src/lib/pkcs11/pkcs11t.h`
 and a live fetch of `docs.oasis-open.org/pkcs11/pkcs11-spec/v3.2/os/include/
 pkcs11-v3.2/pkcs11t.h` — no value taken from memory.
 
+## 2026-07-18 — `native::*` token-scoping isolation gate (§2.4/§4.4)
+
+`ffi::C_*` (the wasm-bindgen ABI this report's harness exercises) has always
+enforced `state::can_access_object` — token-scoped handles, §2.4/§4.4 — at 8
+call sites. The typed `native::*` surface (no wasm32 pointer marshalling;
+what the KMIP server calls exclusively) did not: found and closed on
+`feat/hsm-perf-bench` (see `rust-hsm-perf-bench-scenario-plan-07182026.md`
+Part F in the workspace root for the full design/audit trail). Every
+by-handle `native::*` function (sign/verify, encrypt/decrypt,
+encapsulate/decapsulate, ECDH agree, get/set attribute, destroy, split/join,
+hybrid) now routes through the same predicate via new `state::`
+primitives (`resolve_session_access`, `with_object_checked[_mut]`,
+`take_object_checked`), so a handle from another token uniformly fails
+with `CKR_OBJECT_HANDLE_INVALID` on **both** surfaces — no PKCS#11-visible
+behavior change on `ffi::*`, `native::*` now conformant where it previously
+was not (native has no ABI/wasm harness of its own; verified by
+`tests/multitenant_concurrency.rs` and `native::object::tests::
+find_by_cka_id_is_token_scoped`, plus the unmodified `cargo test` suites of
+both this crate — 309/309 — and the KMIP crate — 655+ lib tests, all
+integration suites — confirming zero behavior change for existing
+single-tenant callers).
+
+Found and fixed in the same pass: a TOCTOU race in `ffi::C_Login` where the
+per-token login-exclusivity check (§5.6 — only one login wins) read a stale
+snapshot before the state write, letting concurrent logins on one token
+silently double-succeed. Regression test:
+`tests/multitenant_concurrency.rs::login_exclusivity_holds_under_concurrent_attempts`.
+
 ## Sections covered
 
 - R1.2 — initialization gate (§5.4/§5.6)

--- a/rust/bench-harness/Cargo.toml
+++ b/rust/bench-harness/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "bench-harness"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "bench-harness"
+path = "src/main.rs"
+
+[dependencies]
+# hsm-perf-bench plan §A4.1/§P4 — path dependency used ONLY for its
+# public CK_* type/const definitions (the Rust-native equivalent of
+# #include-ing pkcs11.h/pkcs11t.h/pkcs11f.h). This harness never calls
+# a softhsmrustv3 function directly: every PKCS#11 operation goes
+# through the dlopen'd .dylib/.so's own function-pointer table, so all
+# engine state lives in ONE loaded instance — the same one a real
+# PKCS#11 application would load. Depending on the crate for types only
+# is inert at runtime: lazy_static globals are never touched unless a
+# function that reads them is called, and this crate calls none.
+softhsmrustv3 = { path = "..", default-features = false }
+libloading = "0.8"
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+rand = "0.8"
+anyhow = "1"

--- a/rust/bench-harness/src/algos.rs
+++ b/rust/bench-harness/src/algos.rs
@@ -1,16 +1,23 @@
 //! Algorithm definitions: which mechanism generates the key pair, which
-//! mechanism signs/verifies with it, and (per the engine's own
-//! `C_GenerateKeyPair` dispatch — verified against `rust/src/ffi.rs`
-//! before writing this) whether any template attributes are actually
-//! required. Ed25519 needs none; every default the engine sets
-//! (CKA_SIGN/CKA_VERIFY, key type, etc.) is already correct for a plain
-//! signing key, so an empty template is a genuine, verified minimal case
-//! — not a shortcut.
+//! mechanism signs/verifies/derives/encapsulates with it, and (per the
+//! engine's own dispatch in `rust/src/ffi.rs` — verified against source
+//! before writing each of these, never guessed) which template
+//! attributes are actually required. Every mechanism value here is a
+//! real, OASIS-assigned PKCS#11 v3.2 codepoint (cross-checked against
+//! `rust/src/constants.rs`, which itself is checked against the spec's
+//! `pkcs11t.h` per this repo's CLAUDE.md) — no vendor extensions.
 
-use softhsmrustv3::constants::{CKM_EC_EDWARDS_KEY_PAIR_GEN, CKM_EDDSA};
+use softhsmrustv3::constants::{
+    CKA_PARAMETER_SET, CKM_EC_EDWARDS_KEY_PAIR_GEN, CKM_EC_MONTGOMERY_KEY_PAIR_GEN, CKM_EDDSA,
+    CKM_ML_KEM, CKM_ML_KEM_KEY_PAIR_GEN, CKP_ML_KEM_768,
+};
 
 /// One benchmarked signature algorithm: its keygen mechanism and its
-/// sign/verify mechanism (often, as here, not the same value).
+/// sign/verify mechanism (often, as here, not the same value). Ed25519
+/// needs no template attributes — every default the engine sets
+/// (CKA_SIGN/CKA_VERIFY, key type, etc.) is already correct for a plain
+/// signing key, so an empty template is a genuine, verified minimal
+/// case, not a shortcut.
 #[derive(Clone, Copy, Debug)]
 pub struct SignatureAlgo {
     pub name: &'static str,
@@ -23,3 +30,48 @@ pub const ED25519: SignatureAlgo = SignatureAlgo {
     keygen_mechanism: CKM_EC_EDWARDS_KEY_PAIR_GEN,
     sign_mechanism: CKM_EDDSA,
 };
+
+/// One benchmarked key-agreement algorithm. `CKM_EC_MONTGOMERY_KEY_PAIR_GEN`
+/// with an empty template defaults to X25519 (§6.7 — the OID in
+/// CKA_EC_PARAMS only selects X448; absent, X25519 is the default,
+/// verified against `ffi.rs`'s `is_x448` check). Deriving is always
+/// `CKM_ECDH1_DERIVE` (§6.7/§5.18.5) — the SAME generic derive mechanism
+/// used for Weierstrass-curve ECDH; the engine dispatches to the X25519
+/// math internally based on the base key's own stored algorithm family,
+/// so no separate "X25519 derive" mechanism exists or is needed. That
+/// mechanism is hardcoded inside `pkcs11::Engine::ecdh1_derive` rather
+/// than carried as a field here, since no other value is valid for it.
+#[derive(Clone, Copy, Debug)]
+pub struct KeyAgreementAlgo {
+    pub name: &'static str,
+    pub keygen_mechanism: u32,
+}
+
+pub const X25519: KeyAgreementAlgo = KeyAgreementAlgo {
+    name: "X25519",
+    keygen_mechanism: CKM_EC_MONTGOMERY_KEY_PAIR_GEN,
+};
+
+/// One benchmarked KEM. `CKA_PARAMETER_SET` (§6.68.2, value `0x61d`) is a
+/// REQUIRED public-key-template attribute for `CKM_ML_KEM_KEY_PAIR_GEN`
+/// (confirmed against `ffi.rs`: absent → `CKR_TEMPLATE_INCOMPLETE`) —
+/// unlike Ed25519/X25519 this category cannot use an empty template.
+#[derive(Clone, Copy, Debug)]
+pub struct KemAlgo {
+    pub name: &'static str,
+    pub keygen_mechanism: u32,
+    pub kem_mechanism: u32,
+    pub parameter_set: u32,
+}
+
+pub const ML_KEM_768: KemAlgo = KemAlgo {
+    name: "ML-KEM-768",
+    keygen_mechanism: CKM_ML_KEM_KEY_PAIR_GEN,
+    kem_mechanism: CKM_ML_KEM,
+    parameter_set: CKP_ML_KEM_768,
+};
+
+/// `CKA_PARAMETER_SET`'s attribute type constant, re-exported so `main.rs`
+/// can build the one-attribute keygen template without a second import
+/// path into `softhsmrustv3::constants`.
+pub const PARAMETER_SET_ATTR: u32 = CKA_PARAMETER_SET;

--- a/rust/bench-harness/src/algos.rs
+++ b/rust/bench-harness/src/algos.rs
@@ -1,0 +1,25 @@
+//! Algorithm definitions: which mechanism generates the key pair, which
+//! mechanism signs/verifies with it, and (per the engine's own
+//! `C_GenerateKeyPair` dispatch — verified against `rust/src/ffi.rs`
+//! before writing this) whether any template attributes are actually
+//! required. Ed25519 needs none; every default the engine sets
+//! (CKA_SIGN/CKA_VERIFY, key type, etc.) is already correct for a plain
+//! signing key, so an empty template is a genuine, verified minimal case
+//! — not a shortcut.
+
+use softhsmrustv3::constants::{CKM_EC_EDWARDS_KEY_PAIR_GEN, CKM_EDDSA};
+
+/// One benchmarked signature algorithm: its keygen mechanism and its
+/// sign/verify mechanism (often, as here, not the same value).
+#[derive(Clone, Copy, Debug)]
+pub struct SignatureAlgo {
+    pub name: &'static str,
+    pub keygen_mechanism: u32,
+    pub sign_mechanism: u32,
+}
+
+pub const ED25519: SignatureAlgo = SignatureAlgo {
+    name: "Ed25519",
+    keygen_mechanism: CKM_EC_EDWARDS_KEY_PAIR_GEN,
+    sign_mechanism: CKM_EDDSA,
+};

--- a/rust/bench-harness/src/algos.rs
+++ b/rust/bench-harness/src/algos.rs
@@ -23,9 +23,15 @@
 use softhsmrustv3::constants::{
     CKM_EC_EDWARDS_KEY_PAIR_GEN, CKM_EC_KEY_PAIR_GEN, CKM_EC_MONTGOMERY_KEY_PAIR_GEN,
     CKM_ECDSA_SHA256, CKM_ECDSA_SHA384, CKM_ECDSA_SHA512, CKM_EDDSA, CKM_ML_DSA,
-    CKM_ML_DSA_KEY_PAIR_GEN, CKM_ML_KEM, CKM_ML_KEM_KEY_PAIR_GEN, CKM_SLH_DSA,
+    CKM_ML_DSA_KEY_PAIR_GEN, CKM_ML_KEM, CKM_ML_KEM_KEY_PAIR_GEN,
+    CKM_RSA_PKCS_KEY_PAIR_GEN, CKM_RSA_PKCS_OAEP, CKM_SHA256_RSA_PKCS_PSS, CKM_SHA384_RSA_PKCS_PSS,
+    CKM_SHA512_RSA_PKCS_PSS, CKM_SLH_DSA,
     CKM_SLH_DSA_KEY_PAIR_GEN, CKP_ML_DSA_44, CKP_ML_DSA_65, CKP_ML_DSA_87, CKP_ML_KEM_1024,
-    CKP_ML_KEM_512, CKP_ML_KEM_768, CKP_SLH_DSA_SHA2_128S, CKP_SLH_DSA_SHA2_256S,
+    CKP_ML_KEM_512, CKP_ML_KEM_768,
+    CKP_SLH_DSA_SHA2_128F, CKP_SLH_DSA_SHA2_128S, CKP_SLH_DSA_SHA2_192F, CKP_SLH_DSA_SHA2_192S,
+    CKP_SLH_DSA_SHA2_256F, CKP_SLH_DSA_SHA2_256S,
+    CKP_SLH_DSA_SHAKE_128F, CKP_SLH_DSA_SHAKE_128S, CKP_SLH_DSA_SHAKE_192F, CKP_SLH_DSA_SHAKE_192S,
+    CKP_SLH_DSA_SHAKE_256F, CKP_SLH_DSA_SHAKE_256S,
 };
 
 /// How a keygen call's public-key template must be built for a given
@@ -43,6 +49,13 @@ pub enum KeygenParam {
     None,
     EcParamsOid(&'static [u8]),
     ParameterSet(u32),
+    /// `CKA_MODULUS_BITS` (RSA keygen only) — read via the SAME
+    /// `get_attr_ulong` convention as `ParameterSet` (confirmed against
+    /// `ffi.rs`'s `CKM_RSA_PKCS_KEY_PAIR_GEN` dispatch before adding this:
+    /// plain 4-byte `u32`, not native `CK_ULONG` width). No
+    /// `CKA_PUBLIC_EXPONENT` needed — the engine generates and stores that
+    /// itself.
+    RsaModulusBits(u32),
 }
 
 /// DER OID bytes for the three NIST Weierstrass curves this harness uses,
@@ -122,10 +135,99 @@ pub const SLH_DSA_256S: SignatureAlgo = SignatureAlgo {
     sign_mechanism: CKM_SLH_DSA, slow: true,
 };
 
+/// FIPS 205 completion: the other 10 of the standard's 12 parameter sets
+/// ({SHA2,SHAKE} x {128,192,256} x {s,f}) — all 12 have real, non-stub
+/// sign/verify/keygen dispatch in the engine (verified against
+/// crypto/handlers.rs before adding these, not assumed). "s" (small
+/// signature, slow sign) entries are marked `slow: true` to match the
+/// existing 128s/256s convention; "f" (fast sign, larger signature) is
+/// FIPS 205's own tradeoff specifically FOR faster signing, so those are
+/// marked `slow: false` here — confirmed empirically via a timed run
+/// (see hsm-perf-bench FIPS-gap plan Part A), not assumed from the name.
+pub const SLH_DSA_SHAKE_128S: SignatureAlgo = SignatureAlgo {
+    name: "SLH-DSA-SHAKE-128s", security_level: "L1",
+    keygen_mechanism: CKM_SLH_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_SLH_DSA_SHAKE_128S),
+    sign_mechanism: CKM_SLH_DSA, slow: true,
+};
+pub const SLH_DSA_SHA2_128F: SignatureAlgo = SignatureAlgo {
+    name: "SLH-DSA-SHA2-128f", security_level: "L1",
+    keygen_mechanism: CKM_SLH_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_SLH_DSA_SHA2_128F),
+    sign_mechanism: CKM_SLH_DSA, slow: false,
+};
+pub const SLH_DSA_SHAKE_128F: SignatureAlgo = SignatureAlgo {
+    name: "SLH-DSA-SHAKE-128f", security_level: "L1",
+    keygen_mechanism: CKM_SLH_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_SLH_DSA_SHAKE_128F),
+    sign_mechanism: CKM_SLH_DSA, slow: false,
+};
+pub const SLH_DSA_SHA2_192S: SignatureAlgo = SignatureAlgo {
+    name: "SLH-DSA-SHA2-192s", security_level: "L3",
+    keygen_mechanism: CKM_SLH_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_SLH_DSA_SHA2_192S),
+    sign_mechanism: CKM_SLH_DSA, slow: true,
+};
+pub const SLH_DSA_SHAKE_192S: SignatureAlgo = SignatureAlgo {
+    name: "SLH-DSA-SHAKE-192s", security_level: "L3",
+    keygen_mechanism: CKM_SLH_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_SLH_DSA_SHAKE_192S),
+    sign_mechanism: CKM_SLH_DSA, slow: true,
+};
+pub const SLH_DSA_SHA2_192F: SignatureAlgo = SignatureAlgo {
+    name: "SLH-DSA-SHA2-192f", security_level: "L3",
+    keygen_mechanism: CKM_SLH_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_SLH_DSA_SHA2_192F),
+    sign_mechanism: CKM_SLH_DSA, slow: false,
+};
+pub const SLH_DSA_SHAKE_192F: SignatureAlgo = SignatureAlgo {
+    name: "SLH-DSA-SHAKE-192f", security_level: "L3",
+    keygen_mechanism: CKM_SLH_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_SLH_DSA_SHAKE_192F),
+    sign_mechanism: CKM_SLH_DSA, slow: false,
+};
+pub const SLH_DSA_SHAKE_256S: SignatureAlgo = SignatureAlgo {
+    name: "SLH-DSA-SHAKE-256s", security_level: "L5",
+    keygen_mechanism: CKM_SLH_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_SLH_DSA_SHAKE_256S),
+    sign_mechanism: CKM_SLH_DSA, slow: true,
+};
+pub const SLH_DSA_SHA2_256F: SignatureAlgo = SignatureAlgo {
+    name: "SLH-DSA-SHA2-256f", security_level: "L5",
+    keygen_mechanism: CKM_SLH_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_SLH_DSA_SHA2_256F),
+    sign_mechanism: CKM_SLH_DSA, slow: false,
+};
+pub const SLH_DSA_SHAKE_256F: SignatureAlgo = SignatureAlgo {
+    name: "SLH-DSA-SHAKE-256f", security_level: "L5",
+    keygen_mechanism: CKM_SLH_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_SLH_DSA_SHAKE_256F),
+    sign_mechanism: CKM_SLH_DSA, slow: false,
+};
+
+/// RSA-PSS signing — added per the hub's Transition Guide (RSA is the
+/// classical algorithm referenced most, absent from this harness until
+/// now). PSS needs no `CK_RSA_PKCS_PSS_PARAMS` at sign/verify time:
+/// confirmed against `ffi.rs`'s dispatch that absent params fall back to
+/// sane legacy defaults ("Absent params keep legacy defaults") — the
+/// existing `sign_init`/`sign`/`verify_init`/`verify` wrappers (which
+/// always pass null mechanism parameters) work unchanged, no new
+/// params-struct plumbing needed. Key sizes/levels match the hub guide's
+/// own RSA-PSS rows (2048->L1, 3072->L3, 4096->L5).
+pub const RSA_PSS_2048: SignatureAlgo = SignatureAlgo {
+    name: "RSA-PSS-2048", security_level: "L1",
+    keygen_mechanism: CKM_RSA_PKCS_KEY_PAIR_GEN, keygen_param: KeygenParam::RsaModulusBits(2048),
+    sign_mechanism: CKM_SHA256_RSA_PKCS_PSS, slow: false,
+};
+pub const RSA_PSS_3072: SignatureAlgo = SignatureAlgo {
+    name: "RSA-PSS-3072", security_level: "L3",
+    keygen_mechanism: CKM_RSA_PKCS_KEY_PAIR_GEN, keygen_param: KeygenParam::RsaModulusBits(3072),
+    sign_mechanism: CKM_SHA384_RSA_PKCS_PSS, slow: false,
+};
+pub const RSA_PSS_4096: SignatureAlgo = SignatureAlgo {
+    name: "RSA-PSS-4096", security_level: "L5",
+    keygen_mechanism: CKM_RSA_PKCS_KEY_PAIR_GEN, keygen_param: KeygenParam::RsaModulusBits(4096),
+    sign_mechanism: CKM_SHA512_RSA_PKCS_PSS, slow: false,
+};
+
 pub const SIGNATURE_ALGOS: &[SignatureAlgo] = &[
     ED25519, ECDSA_P256, ECDSA_P384, ECDSA_P521,
     ML_DSA_44, ML_DSA_65, ML_DSA_87,
     SLH_DSA_128S, SLH_DSA_256S,
+    SLH_DSA_SHAKE_128S, SLH_DSA_SHA2_128F, SLH_DSA_SHAKE_128F,
+    SLH_DSA_SHA2_192S, SLH_DSA_SHAKE_192S, SLH_DSA_SHA2_192F, SLH_DSA_SHAKE_192F,
+    SLH_DSA_SHAKE_256S, SLH_DSA_SHA2_256F, SLH_DSA_SHAKE_256F,
+    RSA_PSS_2048, RSA_PSS_3072, RSA_PSS_4096,
 ];
 
 /// One benchmarked key-agreement (ECDH-family) algorithm. Deriving is
@@ -190,3 +292,49 @@ pub const ML_KEM_1024: KemAlgo = KemAlgo {
 };
 
 pub const KEM_ALGOS: &[KemAlgo] = &[ML_KEM_512, ML_KEM_768, ML_KEM_1024];
+
+/// One benchmarked key-transport (RSA-OAEP) algorithm — `C_Encrypt`/
+/// `C_Decrypt`, not a KEM's `C_EncapsulateKey`/`C_DecapsulateKey`, but
+/// reported under the SAME `"key_establishment"` category as
+/// `KeyAgreementAlgo`/`KemAlgo` above (main.rs already puts two
+/// structurally different measurement patterns — derive vs encapsulate/
+/// decapsulate — under that one label, differentiated only by `op`; this
+/// is a third instance of that same pattern, not a new category).
+///
+/// `keygen_mechanism`/`keygen_param` here are a FALLBACK only:
+/// `provision_tenant` reuses the matching `SignatureAlgo` entry named
+/// `sig_algo_name`'s ALREADY-provisioned keypair when that algorithm was
+/// also selected for this run (confirmed the engine's default RSA keygen
+/// template already sets dual CKA_SIGN+CKA_DECRYPT on one keypair — no
+/// redundant, and for RSA genuinely expensive, second keygen in the
+/// common case). These fields only get used if a run selects an
+/// `EncAlgo` WITHOUT its matching `SignatureAlgo` (e.g. `--algorithms
+/// RSA-OAEP-2048` alone) — provisioning then falls back to an
+/// independent keypair for just that case.
+#[derive(Clone, Copy, Debug)]
+pub struct EncAlgo {
+    pub name: &'static str,
+    pub security_level: &'static str,
+    pub sig_algo_name: &'static str,
+    pub keygen_mechanism: u32,
+    pub keygen_param: KeygenParam,
+    pub encrypt_mechanism: u32,
+}
+
+pub const RSA_OAEP_2048: EncAlgo = EncAlgo {
+    name: "RSA-OAEP-2048", security_level: "L1", sig_algo_name: "RSA-PSS-2048",
+    keygen_mechanism: CKM_RSA_PKCS_KEY_PAIR_GEN, keygen_param: KeygenParam::RsaModulusBits(2048),
+    encrypt_mechanism: CKM_RSA_PKCS_OAEP,
+};
+pub const RSA_OAEP_3072: EncAlgo = EncAlgo {
+    name: "RSA-OAEP-3072", security_level: "L3", sig_algo_name: "RSA-PSS-3072",
+    keygen_mechanism: CKM_RSA_PKCS_KEY_PAIR_GEN, keygen_param: KeygenParam::RsaModulusBits(3072),
+    encrypt_mechanism: CKM_RSA_PKCS_OAEP,
+};
+pub const RSA_OAEP_4096: EncAlgo = EncAlgo {
+    name: "RSA-OAEP-4096", security_level: "L5", sig_algo_name: "RSA-PSS-4096",
+    keygen_mechanism: CKM_RSA_PKCS_KEY_PAIR_GEN, keygen_param: KeygenParam::RsaModulusBits(4096),
+    encrypt_mechanism: CKM_RSA_PKCS_OAEP,
+};
+
+pub const ENC_ALGOS: &[EncAlgo] = &[RSA_OAEP_2048, RSA_OAEP_3072, RSA_OAEP_4096];

--- a/rust/bench-harness/src/algos.rs
+++ b/rust/bench-harness/src/algos.rs
@@ -6,72 +6,187 @@
 //! real, OASIS-assigned PKCS#11 v3.2 codepoint (cross-checked against
 //! `rust/src/constants.rs`, which itself is checked against the spec's
 //! `pkcs11t.h` per this repo's CLAUDE.md) — no vendor extensions.
+//!
+//! Two categories from plan §A5 are deliberately NOT here, both verified
+//! against source before excluding (not assumed):
+//! - **Composite/hybrid signatures** (e.g. ECDSA P-256 + ML-DSA-44): no
+//!   single PKCS#11 mechanism exists for these in this engine — a caller
+//!   genuinely issues two separate real sign operations. §A5 itself calls
+//!   these "modeled, not native"; a harness-level composite measurement is
+//!   a distinct, separately-scoped increment, not added here.
+//! - **Hybrid/native KEMs** (X25519MLKEM768 etc.): `rust/src/native/hybrid.rs`
+//!   confirms these exist ONLY through the KMIP server's own tenant/handle
+//!   bookkeeping (`kmip/src/hybrid_kem.rs` and friends) — no
+//!   `C_GenerateKeyPair`/`C_EncapsulateKey` dispatch arm reaches them.
+//!   Unreachable from a pkcs11-direct harness; deferred to kmip mode (§P2).
 
 use softhsmrustv3::constants::{
-    CKA_PARAMETER_SET, CKM_EC_EDWARDS_KEY_PAIR_GEN, CKM_EC_MONTGOMERY_KEY_PAIR_GEN, CKM_EDDSA,
-    CKM_ML_KEM, CKM_ML_KEM_KEY_PAIR_GEN, CKP_ML_KEM_768,
+    CKM_EC_EDWARDS_KEY_PAIR_GEN, CKM_EC_KEY_PAIR_GEN, CKM_EC_MONTGOMERY_KEY_PAIR_GEN,
+    CKM_ECDSA_SHA256, CKM_ECDSA_SHA384, CKM_ECDSA_SHA512, CKM_EDDSA, CKM_ML_DSA,
+    CKM_ML_DSA_KEY_PAIR_GEN, CKM_ML_KEM, CKM_ML_KEM_KEY_PAIR_GEN, CKM_SLH_DSA,
+    CKM_SLH_DSA_KEY_PAIR_GEN, CKP_ML_DSA_44, CKP_ML_DSA_65, CKP_ML_DSA_87, CKP_ML_KEM_1024,
+    CKP_ML_KEM_512, CKP_ML_KEM_768, CKP_SLH_DSA_SHA2_128S, CKP_SLH_DSA_SHA2_256S,
 };
 
-/// One benchmarked signature algorithm: its keygen mechanism and its
-/// sign/verify mechanism (often, as here, not the same value). Ed25519
-/// needs no template attributes — every default the engine sets
-/// (CKA_SIGN/CKA_VERIFY, key type, etc.) is already correct for a plain
-/// signing key, so an empty template is a genuine, verified minimal
-/// case, not a shortcut.
+/// How a keygen call's public-key template must be built for a given
+/// algorithm. `None` — no attribute needed, the engine's own defaults are
+/// already correct (Ed25519, X25519). `EcParamsOid` — CKA_EC_PARAMS must
+/// carry this exact DER OID (Weierstrass curves; absent defaults to
+/// P-256, verified against `ffi.rs`'s curve-selection branch). `ParameterSet`
+/// — CKA_PARAMETER_SET is REQUIRED (ML-DSA/ML-KEM/SLH-DSA; absent →
+/// CKR_TEMPLATE_INCOMPLETE), and per `get_attr_ulong`'s implementation
+/// (`crypto/handlers.rs`) the value must be readable as a plain 4-byte
+/// `u32` regardless of this platform's 8-byte native `CK_ULONG` width —
+/// `pkcs11::Engine::generate_key_pair_with_param` builds exactly that.
+#[derive(Clone, Copy, Debug)]
+pub enum KeygenParam {
+    None,
+    EcParamsOid(&'static [u8]),
+    ParameterSet(u32),
+}
+
+/// DER OID bytes for the three NIST Weierstrass curves this harness uses,
+/// byte-for-byte identical to what the engine's own SPKI builders emit
+/// (`crypto/handlers.rs` — cited per-curve below), so `CKA_EC_PARAMS`
+/// round-trips through exactly the bytes the engine already recognizes.
+pub const P256_OID: &[u8] = &[0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07];
+pub const P384_OID: &[u8] = &[0x06, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x22];
+pub const P521_OID: &[u8] = &[0x06, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x23];
+
+/// One benchmarked signature algorithm.
 #[derive(Clone, Copy, Debug)]
 pub struct SignatureAlgo {
     pub name: &'static str,
+    pub security_level: &'static str,
     pub keygen_mechanism: u32,
+    pub keygen_param: KeygenParam,
     pub sign_mechanism: u32,
+    /// Excluded unless `--include-slow` is passed (plan §A6 toggle).
+    pub slow: bool,
 }
 
 pub const ED25519: SignatureAlgo = SignatureAlgo {
-    name: "Ed25519",
-    keygen_mechanism: CKM_EC_EDWARDS_KEY_PAIR_GEN,
-    sign_mechanism: CKM_EDDSA,
+    name: "Ed25519", security_level: "L1",
+    keygen_mechanism: CKM_EC_EDWARDS_KEY_PAIR_GEN, keygen_param: KeygenParam::None,
+    sign_mechanism: CKM_EDDSA, slow: false,
 };
 
-/// One benchmarked key-agreement algorithm. `CKM_EC_MONTGOMERY_KEY_PAIR_GEN`
-/// with an empty template defaults to X25519 (§6.7 — the OID in
-/// CKA_EC_PARAMS only selects X448; absent, X25519 is the default,
-/// verified against `ffi.rs`'s `is_x448` check). Deriving is always
-/// `CKM_ECDH1_DERIVE` (§6.7/§5.18.5) — the SAME generic derive mechanism
-/// used for Weierstrass-curve ECDH; the engine dispatches to the X25519
-/// math internally based on the base key's own stored algorithm family,
-/// so no separate "X25519 derive" mechanism exists or is needed. That
-/// mechanism is hardcoded inside `pkcs11::Engine::ecdh1_derive` rather
-/// than carried as a field here, since no other value is valid for it.
+/// ECDSA hash-then-sign, paired with each curve's natural digest (§6.3.12
+/// hash-composite mechanisms — genuinely implemented, confirmed against
+/// `ffi.rs`'s `handlers.rs` dispatch, not the raw pre-hashed `CKM_ECDSA`):
+/// real sign-a-message semantics, matching every other algorithm here,
+/// rather than "sign this already-hashed digest."
+pub const ECDSA_P256: SignatureAlgo = SignatureAlgo {
+    name: "ECDSA-P256", security_level: "L1",
+    keygen_mechanism: CKM_EC_KEY_PAIR_GEN, keygen_param: KeygenParam::EcParamsOid(P256_OID),
+    sign_mechanism: CKM_ECDSA_SHA256, slow: false,
+};
+pub const ECDSA_P384: SignatureAlgo = SignatureAlgo {
+    name: "ECDSA-P384", security_level: "L3",
+    keygen_mechanism: CKM_EC_KEY_PAIR_GEN, keygen_param: KeygenParam::EcParamsOid(P384_OID),
+    sign_mechanism: CKM_ECDSA_SHA384, slow: false,
+};
+pub const ECDSA_P521: SignatureAlgo = SignatureAlgo {
+    name: "ECDSA-P521", security_level: "L5",
+    keygen_mechanism: CKM_EC_KEY_PAIR_GEN, keygen_param: KeygenParam::EcParamsOid(P521_OID),
+    sign_mechanism: CKM_ECDSA_SHA512, slow: false,
+};
+
+pub const ML_DSA_44: SignatureAlgo = SignatureAlgo {
+    name: "ML-DSA-44", security_level: "L1",
+    keygen_mechanism: CKM_ML_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_ML_DSA_44),
+    sign_mechanism: CKM_ML_DSA, slow: false,
+};
+pub const ML_DSA_65: SignatureAlgo = SignatureAlgo {
+    name: "ML-DSA-65", security_level: "L3",
+    keygen_mechanism: CKM_ML_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_ML_DSA_65),
+    sign_mechanism: CKM_ML_DSA, slow: false,
+};
+pub const ML_DSA_87: SignatureAlgo = SignatureAlgo {
+    name: "ML-DSA-87", security_level: "L5",
+    keygen_mechanism: CKM_ML_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_ML_DSA_87),
+    sign_mechanism: CKM_ML_DSA, slow: false,
+};
+
+/// Slow (§A6 toggle) — SLH-DSA sign is orders of magnitude more expensive
+/// than every other signature algorithm here (a full hypertree + FORS
+/// computation per signature, vs. a handful of field/lattice ops).
+pub const SLH_DSA_128S: SignatureAlgo = SignatureAlgo {
+    name: "SLH-DSA-SHA2-128s", security_level: "L1",
+    keygen_mechanism: CKM_SLH_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_SLH_DSA_SHA2_128S),
+    sign_mechanism: CKM_SLH_DSA, slow: true,
+};
+pub const SLH_DSA_256S: SignatureAlgo = SignatureAlgo {
+    name: "SLH-DSA-SHA2-256s", security_level: "L5",
+    keygen_mechanism: CKM_SLH_DSA_KEY_PAIR_GEN, keygen_param: KeygenParam::ParameterSet(CKP_SLH_DSA_SHA2_256S),
+    sign_mechanism: CKM_SLH_DSA, slow: true,
+};
+
+pub const SIGNATURE_ALGOS: &[SignatureAlgo] = &[
+    ED25519, ECDSA_P256, ECDSA_P384, ECDSA_P521,
+    ML_DSA_44, ML_DSA_65, ML_DSA_87,
+    SLH_DSA_128S, SLH_DSA_256S,
+];
+
+/// One benchmarked key-agreement (ECDH-family) algorithm. Deriving is
+/// always `CKM_ECDH1_DERIVE` (§6.7/§5.18.5) for every entry here — the
+/// SAME generic derive mechanism for both Montgomery (X25519) and
+/// Weierstrass (P-256/384/521) curves; the engine dispatches to the right
+/// math internally from the base key's own stored algorithm family
+/// (confirmed against `ffi.rs`'s single shared `C_DeriveKey` ECDH branch).
+/// That mechanism is hardcoded inside `pkcs11::Engine::ecdh1_derive`
+/// rather than carried as a field here, since no other value is valid.
 #[derive(Clone, Copy, Debug)]
 pub struct KeyAgreementAlgo {
     pub name: &'static str,
+    pub security_level: &'static str,
     pub keygen_mechanism: u32,
+    pub keygen_param: KeygenParam,
 }
 
 pub const X25519: KeyAgreementAlgo = KeyAgreementAlgo {
-    name: "X25519",
-    keygen_mechanism: CKM_EC_MONTGOMERY_KEY_PAIR_GEN,
+    name: "X25519", security_level: "L1",
+    keygen_mechanism: CKM_EC_MONTGOMERY_KEY_PAIR_GEN, keygen_param: KeygenParam::None,
+};
+pub const ECDH_P256: KeyAgreementAlgo = KeyAgreementAlgo {
+    name: "ECDH-P256", security_level: "L1",
+    keygen_mechanism: CKM_EC_KEY_PAIR_GEN, keygen_param: KeygenParam::EcParamsOid(P256_OID),
+};
+pub const ECDH_P384: KeyAgreementAlgo = KeyAgreementAlgo {
+    name: "ECDH-P384", security_level: "L3",
+    keygen_mechanism: CKM_EC_KEY_PAIR_GEN, keygen_param: KeygenParam::EcParamsOid(P384_OID),
+};
+pub const ECDH_P521: KeyAgreementAlgo = KeyAgreementAlgo {
+    name: "ECDH-P521", security_level: "L5",
+    keygen_mechanism: CKM_EC_KEY_PAIR_GEN, keygen_param: KeygenParam::EcParamsOid(P521_OID),
 };
 
-/// One benchmarked KEM. `CKA_PARAMETER_SET` (§6.68.2, value `0x61d`) is a
-/// REQUIRED public-key-template attribute for `CKM_ML_KEM_KEY_PAIR_GEN`
-/// (confirmed against `ffi.rs`: absent → `CKR_TEMPLATE_INCOMPLETE`) —
-/// unlike Ed25519/X25519 this category cannot use an empty template.
+pub const KEY_AGREEMENT_ALGOS: &[KeyAgreementAlgo] = &[X25519, ECDH_P256, ECDH_P384, ECDH_P521];
+
+/// One benchmarked KEM. `CKA_PARAMETER_SET` is a REQUIRED public-key-
+/// template attribute for `CKM_ML_KEM_KEY_PAIR_GEN` (confirmed against
+/// `ffi.rs`: absent → `CKR_TEMPLATE_INCOMPLETE`) — unlike Ed25519/X25519
+/// this category never uses an empty template.
 #[derive(Clone, Copy, Debug)]
 pub struct KemAlgo {
     pub name: &'static str,
+    pub security_level: &'static str,
     pub keygen_mechanism: u32,
     pub kem_mechanism: u32,
     pub parameter_set: u32,
 }
 
+pub const ML_KEM_512: KemAlgo = KemAlgo {
+    name: "ML-KEM-512", security_level: "L1",
+    keygen_mechanism: CKM_ML_KEM_KEY_PAIR_GEN, kem_mechanism: CKM_ML_KEM, parameter_set: CKP_ML_KEM_512,
+};
 pub const ML_KEM_768: KemAlgo = KemAlgo {
-    name: "ML-KEM-768",
-    keygen_mechanism: CKM_ML_KEM_KEY_PAIR_GEN,
-    kem_mechanism: CKM_ML_KEM,
-    parameter_set: CKP_ML_KEM_768,
+    name: "ML-KEM-768", security_level: "L3",
+    keygen_mechanism: CKM_ML_KEM_KEY_PAIR_GEN, kem_mechanism: CKM_ML_KEM, parameter_set: CKP_ML_KEM_768,
+};
+pub const ML_KEM_1024: KemAlgo = KemAlgo {
+    name: "ML-KEM-1024", security_level: "L5",
+    keygen_mechanism: CKM_ML_KEM_KEY_PAIR_GEN, kem_mechanism: CKM_ML_KEM, parameter_set: CKP_ML_KEM_1024,
 };
 
-/// `CKA_PARAMETER_SET`'s attribute type constant, re-exported so `main.rs`
-/// can build the one-attribute keygen template without a second import
-/// path into `softhsmrustv3::constants`.
-pub const PARAMETER_SET_ATTR: u32 = CKA_PARAMETER_SET;
+pub const KEM_ALGOS: &[KemAlgo] = &[ML_KEM_512, ML_KEM_768, ML_KEM_1024];

--- a/rust/bench-harness/src/main.rs
+++ b/rust/bench-harness/src/main.rs
@@ -1,20 +1,27 @@
 //! hsm-perf-bench harness — pkcs11-direct mode (plan §A4.1/§P4).
 //!
 //! Proves the harness mechanism end to end against the REAL engine,
-//! through the REAL dlopen'd C ABI, before any threading/JSONL/algorithm-
-//! matrix complexity is added: load the library, bootstrap two SEPARATE
-//! tenant tokens via nothing but standard PKCS#11 v3.2 operations
-//! (`C_GetSlotList`/`C_InitToken`/`C_OpenSession`/`C_Login`/`C_InitPIN`/
-//! `C_Logout`/`C_CloseSession` — no vendor extensions), generate a real
-//! Ed25519 key pair per tenant, sign, verify, and prove cross-tenant
-//! isolation with a real spec-defined error code, not an assumption.
-//! Proves one representative op from the other two axis categories —
-//! X25519 ECDH key agreement and ML-KEM-768 encapsulate/decapsulate —
-//! each with its own genuine cryptographic correctness self-check, not
-//! just a bare `CKR_OK`. Then, per §A7 ("fixed-duration points... not
-//! fixed-op-count"), runs a real fixed-duration multi-threaded
-//! measurement point per op and emits one JSONL row per point (§A4.1's
-//! output contract) to stdout.
+//! through the REAL dlopen'd C ABI: load the library, bootstrap two
+//! SEPARATE tenant tokens via nothing but standard PKCS#11 v3.2
+//! operations (`C_GetSlotList`/`C_InitToken`/`C_OpenSession`/`C_Login`/
+//! `C_InitPIN`/`C_Logout`/`C_CloseSession` — no vendor extensions),
+//! generate real key material per tenant, sign/verify/derive/encapsulate/
+//! decapsulate, and prove cross-tenant isolation with a real spec-defined
+//! error code, not an assumption. Then, per §A7 ("fixed-duration
+//! points... not fixed-op-count"), runs a real fixed-duration
+//! multi-threaded measurement point per (algorithm, op) and emits one
+//! JSONL row per point (§A4.1's output contract) to stdout.
+//!
+//! Algorithm coverage (§A5, `algos.rs`): 9 signature algorithms (Ed25519,
+//! ECDSA P-256/384/521, ML-DSA-44/65/87, SLH-DSA-SHA2-128s/256s behind
+//! `--include-slow`), 4 key-agreement algorithms (X25519, ECDH
+//! P-256/384/521), 3 KEMs (ML-KEM-512/768/1024) — 16 algorithms, every
+//! mechanism/attribute verified against `rust/src/ffi.rs`'s real dispatch
+//! before use (see `algos.rs`'s own doc comment for the two categories
+//! deliberately NOT here: composite/hybrid signatures have no native
+//! mechanism in this engine, "modeled not native" per §A5 itself; hybrid/
+//! native KEMs like X25519MLKEM768 exist ONLY behind the KMIP server's
+//! own tenant bookkeeping, unreachable from a pkcs11-direct harness).
 //!
 //! Topology B (§A4.1/§A4.2, "independent-N-instances"): `--instances N`
 //! (N>1) turns this invocation into a PARENT that spawns N SEPARATE OS
@@ -37,9 +44,8 @@
 //! without that hazard.
 //!
 //! Scope note (this increment): 2 fixed tenants per instance,
-//! pkcs11-direct access path only, 5 of the ~18-algorithm matrix (§A5).
-//! The full algorithm matrix and kmip mode (§P2) are later, separately-
-//! verified increments — not built here.
+//! pkcs11-direct access path only. kmip mode (§P2) is a later,
+//! separately-verified increment — not built here.
 
 mod algos;
 mod measure;
@@ -48,11 +54,9 @@ mod pkcs11;
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use pkcs11::Engine;
-use softhsmrustv3::ck_abi::{
-    CK_ATTRIBUTE, CK_ATTRIBUTE_TYPE, CK_OBJECT_HANDLE, CK_SESSION_HANDLE, CK_SLOT_ID, CK_ULONG,
-    CK_VOID_PTR,
-};
+use softhsmrustv3::ck_abi::{CK_OBJECT_HANDLE, CK_SESSION_HANDLE, CK_SLOT_ID};
 use softhsmrustv3::constants::{CKA_EC_POINT, CKA_VALUE, CKR_KEY_HANDLE_INVALID, CKR_OBJECT_HANDLE_INVALID};
+use std::collections::HashMap;
 use std::io::Read;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -82,6 +86,11 @@ struct Cli {
     /// behavior. `>1` makes this invocation the parent orchestrator.
     #[arg(long, default_value_t = 1)]
     instances: u32,
+    /// §A6 "Include-slow-algorithms toggle" — includes SLH-DSA-SHA2-128s/
+    /// 256s (orders of magnitude slower to sign than everything else in
+    /// the matrix).
+    #[arg(long, default_value_t = false)]
+    include_slow: bool,
     /// INTERNAL — set by the parent orchestrator on every child it spawns
     /// so the child stamps its JSONL rows as one of an N-instance
     /// Topology-B run even though it always executes as a plain,
@@ -91,33 +100,64 @@ struct Cli {
     topology_instances: Option<u32>,
 }
 
+struct SigMaterial {
+    pub_handle: CK_OBJECT_HANDLE,
+    priv_handle: CK_OBJECT_HANDLE,
+}
+
+struct KexMaterial {
+    priv_handle: CK_OBJECT_HANDLE,
+    own_point: Vec<u8>,
+    peer_point: Vec<u8>,
+}
+
+struct KemMaterial {
+    pub_handle: CK_OBJECT_HANDLE,
+    priv_handle: CK_OBJECT_HANDLE,
+    ciphertext: Vec<u8>,
+}
+
 /// One tenant's bootstrapped token + real, sanity-checked key material for
-/// every op category this increment measures. Ed25519 keys sign/verify
-/// their own sanity check inline; ML-KEM keys encapsulate/decapsulate
-/// their own sanity check inline (`kem_ciphertext`/`kem_ss` are the
-/// resulting pair, reused by the measured decapsulate loop so it doesn't
-/// need a fresh encapsulate call per iteration). X25519 needs a REAL
-/// peer, so its cross-tenant derive proof happens in `main` once both
-/// tenants exist; `peer_kex_point` is filled in there too.
+/// every algorithm in the configured matrix, keyed by algorithm name.
+/// Signature keys sign/verify their own sanity check inline; KEM keys
+/// encapsulate/decapsulate their own sanity check inline (the resulting
+/// ciphertext is kept, reused by the measured decapsulate loop so it
+/// doesn't need a fresh encapsulate call per iteration — decapsulate is
+/// deterministic given (sk, ct), so this still exercises the real math
+/// each call). Key-agreement keys need a REAL peer, so their cross-tenant
+/// derive proof happens in `run_instance` once both tenants exist;
+/// `peer_point` is filled in there too.
 struct Tenant {
     slot: CK_SLOT_ID,
     session: CK_SESSION_HANDLE,
-    pub_handle: CK_OBJECT_HANDLE,
-    priv_handle: CK_OBJECT_HANDLE,
-    kex_priv: CK_OBJECT_HANDLE,
-    kex_pub_point: Vec<u8>,
-    peer_kex_point: Vec<u8>,
-    kem_pub: CK_OBJECT_HANDLE,
-    kem_priv: CK_OBJECT_HANDLE,
-    kem_ciphertext: Vec<u8>,
+    sig: HashMap<&'static str, SigMaterial>,
+    kex: HashMap<&'static str, KexMaterial>,
+    kem: HashMap<&'static str, KemMaterial>,
 }
 
 /// Claim the next free slot (standard §5.4 `C_GetSlotList` auto-replenish
 /// — see `pkcs11.rs::get_slot_list`'s doc comment) and bring up a real
-/// token with sanity-checked Ed25519, X25519, and ML-KEM-768 key material
-/// on it, per-tenant PINs so each tenant's token stays independently
-/// openable (matching the KMIP server's own per-tenant-PIN tenancy model).
-fn provision_tenant(engine: &Engine, name: &str) -> Result<Tenant> {
+/// token with sanity-checked key material for every algorithm in
+/// `sig_algos`/`kex_algos`/`kem_algos`, per-tenant PINs so each tenant's
+/// token stays independently openable (matching the KMIP server's own
+/// per-tenant-PIN tenancy model).
+///
+/// Also returns this tenant's own real `C_GenerateKeyPair` wall-clock
+/// time per algorithm (keyed by algo name — unique across sig/kex/kem,
+/// so one map covers all three). This is ONLY used to report a `keygen`
+/// JSONL row later; every timed sign/verify/derive/encapsulate/
+/// decapsulate closure built from this tenant's material still excludes
+/// keygen entirely (plan §A7: "Keys pre-generated per tenant before
+/// timing — keygen excluded from the measured loop") — these are the
+/// SAME keygen calls provisioning already had to make, timed in place,
+/// not extra calls made just to produce a number.
+fn provision_tenant(
+    engine: &Engine,
+    name: &str,
+    sig_algos: &[algos::SignatureAlgo],
+    kex_algos: &[algos::KeyAgreementAlgo],
+    kem_algos: &[algos::KemAlgo],
+) -> Result<(Tenant, HashMap<&'static str, f64>)> {
     let slots_before = engine.get_slot_list().context("C_GetSlotList")?;
     let slot = *slots_before
         .last()
@@ -127,62 +167,63 @@ fn provision_tenant(engine: &Engine, name: &str) -> Result<Tenant> {
         .bootstrap_token(slot, &format!("so-pin-{name}"), &format!("user-pin-{name}"), &format!("bench-{name}"))
         .with_context(|| format!("bootstrap_token(slot={slot}, tenant={name})"))?;
 
-    // ── Ed25519 — self-contained sanity check (both keys are this
-    // tenant's own). ────────────────────────────────────────────────────
-    let sig_algo = algos::ED25519;
-    let (pub_handle, priv_handle) = engine
-        .generate_key_pair(session, sig_algo.keygen_mechanism, &mut [], &mut [])
-        .with_context(|| format!("C_GenerateKeyPair({}, tenant={name})", sig_algo.name))?;
-    let message = format!("hsm-perf-bench harness proof — tenant {name}").into_bytes();
-    engine.sign_init(session, sig_algo.sign_mechanism, priv_handle).context("C_SignInit")?;
-    let signature = engine.sign(session, &message).context("C_Sign")?;
-    engine.verify_init(session, sig_algo.sign_mechanism, pub_handle).context("C_VerifyInit")?;
-    let valid = engine.verify(session, &message, &signature).context("C_Verify")?;
-    assert!(valid, "tenant {name}'s own {} signature must verify", sig_algo.name);
+    let mut keygen_ms: HashMap<&'static str, f64> = HashMap::new();
 
-    // ── X25519 — keygen only here; the derive proof needs a real peer,
-    // done in `main` once both tenants exist. ──────────────────────────
-    let kex_algo = algos::X25519;
-    let (kex_pub, kex_priv) = engine
-        .generate_key_pair(session, kex_algo.keygen_mechanism, &mut [], &mut [])
-        .with_context(|| format!("C_GenerateKeyPair({}, tenant={name})", kex_algo.name))?;
-    let kex_pub_point = engine
-        .get_attribute_value(session, kex_pub, CKA_EC_POINT)
-        .with_context(|| format!("C_GetAttributeValue({} CKA_EC_POINT, tenant={name})", kex_algo.name))?;
+    let mut sig = HashMap::new();
+    for algo in sig_algos {
+        let keygen_start = std::time::Instant::now();
+        let (pub_handle, priv_handle) = engine
+            .generate_key_pair_with_param(session, algo.keygen_mechanism, algo.keygen_param)
+            .with_context(|| format!("C_GenerateKeyPair({}, tenant={name})", algo.name))?;
+        keygen_ms.insert(algo.name, keygen_start.elapsed().as_secs_f64() * 1000.0);
+        // Self-contained sanity: this tenant's own key round-trips.
+        let message = format!("hsm-perf-bench harness proof — {} — tenant {name}", algo.name).into_bytes();
+        engine.sign_init(session, algo.sign_mechanism, priv_handle).with_context(|| format!("C_SignInit({})", algo.name))?;
+        let signature = engine.sign(session, &message).with_context(|| format!("C_Sign({})", algo.name))?;
+        engine.verify_init(session, algo.sign_mechanism, pub_handle).with_context(|| format!("C_VerifyInit({})", algo.name))?;
+        let valid = engine.verify(session, &message, &signature).with_context(|| format!("C_Verify({})", algo.name))?;
+        assert!(valid, "tenant {name}'s own {} signature must verify", algo.name);
+        sig.insert(algo.name, SigMaterial { pub_handle, priv_handle });
+    }
 
-    // ── ML-KEM-768 — self-contained sanity check (encapsulate against
-    // this tenant's own public key, decapsulate with its own private
-    // key). The resulting (ciphertext, shared secret) pair is kept:
-    // the measured decapsulate loop reuses the SAME ciphertext every
-    // iteration (ML-KEM decapsulate is deterministic given (sk, ct), so
-    // this still exercises the real math each call — it just avoids
-    // needing a fresh encapsulate call per measured iteration). ────────
-    let kem_algo = algos::ML_KEM_768;
-    let mut param_set_value: u32 = kem_algo.parameter_set;
-    let mut kem_pub_template = [CK_ATTRIBUTE {
-        attrType: algos::PARAMETER_SET_ATTR as CK_ATTRIBUTE_TYPE,
-        pValue: &mut param_set_value as *mut u32 as CK_VOID_PTR,
-        ulValueLen: std::mem::size_of::<u32>() as CK_ULONG,
-    }];
-    let (kem_pub, kem_priv) = engine
-        .generate_key_pair(session, kem_algo.keygen_mechanism, &mut kem_pub_template, &mut [])
-        .with_context(|| format!("C_GenerateKeyPair({}, tenant={name})", kem_algo.name))?;
-    let (kem_ciphertext, encap_ss_handle) = engine
-        .encapsulate_key(session, kem_algo.kem_mechanism, kem_pub, &mut [])
-        .with_context(|| format!("C_EncapsulateKey(tenant={name})"))?;
-    let decap_ss_handle = engine
-        .decapsulate_key(session, kem_algo.kem_mechanism, kem_priv, &kem_ciphertext, &mut [])
-        .with_context(|| format!("C_DecapsulateKey(tenant={name})"))?;
-    let encap_ss = engine.get_attribute_value(session, encap_ss_handle, CKA_VALUE).context("C_GetAttributeValue(encap CKA_VALUE)")?;
-    let decap_ss = engine.get_attribute_value(session, decap_ss_handle, CKA_VALUE).context("C_GetAttributeValue(decap CKA_VALUE)")?;
-    assert_eq!(encap_ss, decap_ss, "tenant {name}'s {} decapsulate must recover the SAME shared secret encapsulate produced", kem_algo.name);
-    assert_eq!(encap_ss.len(), 32, "{} shared secret must be 32 bytes (FIPS 203)", kem_algo.name);
+    let mut kex = HashMap::new();
+    for algo in kex_algos {
+        // Keygen only here; the derive proof needs a real peer, done in
+        // `run_instance` once both tenants exist.
+        let keygen_start = std::time::Instant::now();
+        let (pub_handle, priv_handle) = engine
+            .generate_key_pair_with_param(session, algo.keygen_mechanism, algo.keygen_param)
+            .with_context(|| format!("C_GenerateKeyPair({}, tenant={name})", algo.name))?;
+        keygen_ms.insert(algo.name, keygen_start.elapsed().as_secs_f64() * 1000.0);
+        let own_point = engine
+            .get_attribute_value(session, pub_handle, CKA_EC_POINT)
+            .with_context(|| format!("C_GetAttributeValue({} CKA_EC_POINT, tenant={name})", algo.name))?;
+        kex.insert(algo.name, KexMaterial { priv_handle, own_point, peer_point: Vec::new() });
+    }
 
-    Ok(Tenant {
-        slot, session, pub_handle, priv_handle,
-        kex_priv, kex_pub_point, peer_kex_point: Vec::new(),
-        kem_pub, kem_priv, kem_ciphertext,
-    })
+    let mut kem = HashMap::new();
+    for algo in kem_algos {
+        let keygen_start = std::time::Instant::now();
+        let (pub_handle, priv_handle) = engine
+            .generate_key_pair_with_param(session, algo.keygen_mechanism, algos::KeygenParam::ParameterSet(algo.parameter_set))
+            .with_context(|| format!("C_GenerateKeyPair({}, tenant={name})", algo.name))?;
+        keygen_ms.insert(algo.name, keygen_start.elapsed().as_secs_f64() * 1000.0);
+        // Self-contained sanity: encapsulate against this tenant's own
+        // public key, decapsulate with its own private key.
+        let (ciphertext, encap_ss_handle) = engine
+            .encapsulate_key(session, algo.kem_mechanism, pub_handle, &mut [])
+            .with_context(|| format!("C_EncapsulateKey({}, tenant={name})", algo.name))?;
+        let decap_ss_handle = engine
+            .decapsulate_key(session, algo.kem_mechanism, priv_handle, &ciphertext, &mut [])
+            .with_context(|| format!("C_DecapsulateKey({}, tenant={name})", algo.name))?;
+        let encap_ss = engine.get_attribute_value(session, encap_ss_handle, CKA_VALUE).with_context(|| format!("C_GetAttributeValue(encap CKA_VALUE, {})", algo.name))?;
+        let decap_ss = engine.get_attribute_value(session, decap_ss_handle, CKA_VALUE).with_context(|| format!("C_GetAttributeValue(decap CKA_VALUE, {})", algo.name))?;
+        assert_eq!(encap_ss, decap_ss, "tenant {name}'s {} decapsulate must recover the SAME shared secret encapsulate produced", algo.name);
+        assert_eq!(encap_ss.len(), 32, "{} shared secret must be 32 bytes (FIPS 203)", algo.name);
+        kem.insert(algo.name, KemMaterial { pub_handle, priv_handle, ciphertext });
+    }
+
+    Ok((Tenant { slot, session, sig, kex, kem }, keygen_ms))
 }
 
 fn main() -> Result<()> {
@@ -198,12 +239,11 @@ fn main() -> Result<()> {
 /// same single-instance code path as Topology A) but stamped with
 /// `--topology-instances N` so its JSONL rows self-report as one instance
 /// of an N-instance independent topology. Each child's whole stdout is a
-/// few short JSON lines (5 rows for this increment's algorithm set) —
-/// well under any OS pipe buffer, so reading each child fully before
-/// moving to the next cannot deadlock on a full pipe; this stays true as
-/// long as no future increment makes a single instance's JSONL output
-/// pipe-buffer-sized (megabytes) — if that changes, switch to draining
-/// each child's stdout on its own thread instead of sequentially.
+/// bounded number of short JSON lines — well under any OS pipe buffer, so
+/// reading each child fully before moving to the next cannot deadlock on
+/// a full pipe; if a future increment makes a single instance's JSONL
+/// output pipe-buffer-sized (megabytes), switch to draining each child's
+/// stdout on its own thread instead of sequentially.
 fn run_parent(cli: &Cli) -> Result<()> {
     let self_exe = std::env::current_exe().context("resolving current_exe for child re-exec")?;
     eprintln!(
@@ -213,13 +253,17 @@ fn run_parent(cli: &Cli) -> Result<()> {
 
     let mut children = Vec::new();
     for instance_id in 0..cli.instances {
-        let child = std::process::Command::new(&self_exe)
-            .arg("--library").arg(&cli.library)
+        let mut cmd = std::process::Command::new(&self_exe);
+        cmd.arg("--library").arg(&cli.library)
             .arg("--threads").arg(cli.threads.to_string())
             .arg("--duration-secs").arg(cli.duration_secs.to_string())
             .arg("--warmup-secs").arg(cli.warmup_secs.to_string())
             .arg("--instances").arg("1")
-            .arg("--topology-instances").arg(cli.instances.to_string())
+            .arg("--topology-instances").arg(cli.instances.to_string());
+        if cli.include_slow {
+            cmd.arg("--include-slow");
+        }
+        let child = cmd
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .spawn()
@@ -246,41 +290,46 @@ fn run_instance(cli: &Cli) -> Result<()> {
         None => ("shared-1-instance", 1),
     };
 
+    let sig_algos: Vec<algos::SignatureAlgo> = algos::SIGNATURE_ALGOS.iter().copied().filter(|a| cli.include_slow || !a.slow).collect();
+    let kex_algos: Vec<algos::KeyAgreementAlgo> = algos::KEY_AGREEMENT_ALGOS.to_vec();
+    let kem_algos: Vec<algos::KemAlgo> = algos::KEM_ALGOS.to_vec();
+
     let engine = Engine::load(&cli.library).with_context(|| format!("loading engine library at {:?}", cli.library))?;
     engine.initialize().context("C_Initialize")?;
     eprintln!("[ok] engine initialized: {}", cli.library);
+    eprintln!(
+        "[ok] algorithm matrix: {} signature, {} key-agreement, {} KEM ({})",
+        sig_algos.len(), kex_algos.len(), kem_algos.len(),
+        if cli.include_slow { "including slow algorithms" } else { "slow algorithms excluded, pass --include-slow to add them" }
+    );
 
-    // ── Two tenants, two real tokens, real Ed25519 keys, standard PKCS#11
-    // v3.2 calls only. ──────────────────────────────────────────────────
-    let mut alice = provision_tenant(&engine, "alice")?;
-    eprintln!(
-        "[ok] alice bootstrapped on slot {}: session={} pub={} priv={}",
-        alice.slot, alice.session, alice.pub_handle, alice.priv_handle
-    );
-    let mut bob = provision_tenant(&engine, "bob")?;
-    eprintln!(
-        "[ok] bob bootstrapped on slot {}: session={} pub={} priv={}",
-        bob.slot, bob.session, bob.pub_handle, bob.priv_handle
-    );
+    // ── Two tenants, two real tokens, standard PKCS#11 v3.2 calls only. ─
+    let (mut alice, alice_keygen_ms) = provision_tenant(&engine, "alice", &sig_algos, &kex_algos, &kem_algos)?;
+    eprintln!("[ok] alice bootstrapped on slot {}: session={}", alice.slot, alice.session);
+    let (mut bob, bob_keygen_ms) = provision_tenant(&engine, "bob", &sig_algos, &kex_algos, &kem_algos)?;
+    eprintln!("[ok] bob bootstrapped on slot {}: session={}", bob.slot, bob.session);
     assert_ne!(alice.slot, bob.slot, "each tenant must land on its own slot");
-    eprintln!("[ok] alice and bob each have their own token, own key pair, own signature round-trip");
+    eprintln!("[ok] alice and bob each have their own token and full key material, every algorithm's own sign/verify or encap/decap round-trip verified");
 
     // ── Cross-tenant isolation, proven with a real PKCS#11 v3.2 error
     // code — not asserted, not assumed. Bob's session attempting to sign
-    // with ALICE's private-key handle must fail: her handle is not
+    // with ALICE's private-key handle (Ed25519, guaranteed present in
+    // every matrix configuration) must fail: her handle is not
     // visible/usable from his session's token scope. §6.3.2/§6.3.3
     // (SignInit/Sign) list CKR_KEY_HANDLE_INVALID for exactly this case;
     // this engine's own object-handle validation (`can_access_object`,
     // hardened across this whole tenancy effort) may also surface the
     // more general CKR_OBJECT_HANDLE_INVALID — both are spec-defined,
     // and either is an honest "no", so both are accepted here. ─────────
-    let cross_tenant_result = engine.sign_init(bob.session, algos::ED25519.sign_mechanism, alice.priv_handle);
+    let alice_ed25519_priv = alice.sig[algos::ED25519.name].priv_handle;
+    let bob_ed25519 = &bob.sig[algos::ED25519.name];
+    let cross_tenant_result = engine.sign_init(bob.session, algos::ED25519.sign_mechanism, alice_ed25519_priv);
     match cross_tenant_result {
         Ok(()) => {
             panic!(
                 "SECURITY REGRESSION: Bob's session (slot {}) could SignInit with \
-                 Alice's private key handle {} (her slot {}) — cross-tenant isolation failed",
-                bob.slot, alice.priv_handle, alice.slot
+                 Alice's private key handle {alice_ed25519_priv} (her slot {}) — cross-tenant isolation failed",
+                bob.slot, alice.slot
             );
         }
         Err(e) => {
@@ -300,50 +349,55 @@ fn run_instance(cli: &Cli) -> Result<()> {
     // proves the isolation check is a real gate, not a session-poisoning
     // side effect.
     let message = b"bob signs after the rejected cross-tenant attempt";
-    engine.sign_init(bob.session, algos::ED25519.sign_mechanism, bob.priv_handle).context("C_SignInit (bob, post-check)")?;
+    engine.sign_init(bob.session, algos::ED25519.sign_mechanism, bob_ed25519.priv_handle).context("C_SignInit (bob, post-check)")?;
     let sig = engine.sign(bob.session, message).context("C_Sign (bob, post-check)")?;
-    engine.verify_init(bob.session, algos::ED25519.sign_mechanism, bob.pub_handle).context("C_VerifyInit (bob, post-check)")?;
+    engine.verify_init(bob.session, algos::ED25519.sign_mechanism, bob_ed25519.pub_handle).context("C_VerifyInit (bob, post-check)")?;
     let valid = engine.verify(bob.session, message, &sig).context("C_Verify (bob, post-check)")?;
     assert!(valid, "bob's own key must still work after the rejected cross-tenant attempt");
     eprintln!("[ok] bob's own key still works after the rejected cross-tenant attempt — real gate, not a blanket deny");
 
-    // ── ECDH-derive category (X25519, PKCS#11 v3.2 §6.7) — genuine
+    // ── ECDH-derive category, every key-agreement algorithm — genuine
     // two-party key agreement across alice's and bob's SEPARATE tokens,
-    // each already holding her/his own X25519 keypair from
-    // `provision_tenant`. The only real correctness check a DH exchange
-    // offers: both sides must independently derive the IDENTICAL shared
-    // secret. ────────────────────────────────────────────────────────
-    let mut bob_point_for_alice = bob.kex_pub_point.clone();
-    let mut alice_point_for_bob = alice.kex_pub_point.clone();
-    let alice_shared_handle = engine.ecdh1_derive(alice.session, alice.kex_priv, &mut bob_point_for_alice).context("C_DeriveKey(ECDH1, alice)")?;
-    let bob_shared_handle = engine.ecdh1_derive(bob.session, bob.kex_priv, &mut alice_point_for_bob).context("C_DeriveKey(ECDH1, bob)")?;
-    let alice_shared = engine.get_attribute_value(alice.session, alice_shared_handle, CKA_VALUE).context("C_GetAttributeValue(alice shared CKA_VALUE)")?;
-    let bob_shared = engine.get_attribute_value(bob.session, bob_shared_handle, CKA_VALUE).context("C_GetAttributeValue(bob shared CKA_VALUE)")?;
-    assert_eq!(alice_shared, bob_shared, "X25519 ECDH must produce the SAME shared secret on both sides");
-    assert_eq!(alice_shared.len(), 32, "X25519 shared secret must be 32 bytes (RFC 7748)");
-    eprintln!(
-        "[ok] {} key agreement verified: alice and bob independently derived the SAME {}-byte shared secret",
-        algos::X25519.name, alice_shared.len()
-    );
-    alice.peer_kex_point = bob.kex_pub_point.clone();
-    bob.peer_kex_point = alice.kex_pub_point.clone();
+    // each already holding her/his own keypair from `provision_tenant`.
+    // The only real correctness check a DH exchange offers: both sides
+    // must independently derive the IDENTICAL shared secret. ──────────
+    for algo in &kex_algos {
+        let alice_own = alice.kex[algo.name].own_point.clone();
+        let bob_own = bob.kex[algo.name].own_point.clone();
+        let alice_priv = alice.kex[algo.name].priv_handle;
+        let bob_priv = bob.kex[algo.name].priv_handle;
 
-    eprintln!(
-        "[ok] {} KEM round-trip verified for both tenants during provisioning: {}-byte ciphertexts, matching encap/decap shared secrets",
-        algos::ML_KEM_768.name, alice.kem_ciphertext.len()
-    );
+        let mut bob_point_for_alice = bob_own.clone();
+        let mut alice_point_for_bob = alice_own.clone();
+        let alice_shared_handle = engine.ecdh1_derive(alice.session, alice_priv, &mut bob_point_for_alice).with_context(|| format!("C_DeriveKey(ECDH1, {}, alice)", algo.name))?;
+        let bob_shared_handle = engine.ecdh1_derive(bob.session, bob_priv, &mut alice_point_for_bob).with_context(|| format!("C_DeriveKey(ECDH1, {}, bob)", algo.name))?;
+        let alice_shared = engine.get_attribute_value(alice.session, alice_shared_handle, CKA_VALUE).with_context(|| format!("C_GetAttributeValue(alice shared CKA_VALUE, {})", algo.name))?;
+        let bob_shared = engine.get_attribute_value(bob.session, bob_shared_handle, CKA_VALUE).with_context(|| format!("C_GetAttributeValue(bob shared CKA_VALUE, {})", algo.name))?;
+        assert_eq!(alice_shared, bob_shared, "{} ECDH must produce the SAME shared secret on both sides", algo.name);
+        eprintln!("[ok] {} key agreement verified: alice and bob independently derived the SAME {}-byte shared secret", algo.name, alice_shared.len());
+
+        alice.kex.get_mut(algo.name).unwrap().peer_point = bob_own;
+        bob.kex.get_mut(algo.name).unwrap().peer_point = alice_own;
+    }
+
+    for algo in &kem_algos {
+        eprintln!(
+            "[ok] {} KEM round-trip verified for both tenants during provisioning: {}-byte ciphertexts, matching encap/decap shared secrets",
+            algo.name, alice.kem[algo.name].ciphertext.len()
+        );
+    }
 
     // ── Fixed-duration, multi-threaded measurement (§A7): one point per
-    // op, `cli.threads` workers round-robin across the 2 tenants, each
-    // worker on its OWN session (an operation's state — SignInit/Sign,
-    // etc. — lives on the session, so concurrent workers sharing one
-    // session would race each other's operation context). Login state
-    // is per-TOKEN not per-session (verified against `ffi.rs::C_Login`
-    // — `token.login_state` lives in `TOKEN_STORE` keyed by slot), so a
-    // worker session on an already-logged-in tenant slot needs no
-    // separate login; and `can_access_object` gates by slot, not by
-    // creating session, so every worker can use its tenant's key
-    // material without regenerating it. ─────────────────────────────────
+    // (algorithm, op), `cli.threads` workers round-robin across the 2
+    // tenants, each worker on its OWN session (an operation's state —
+    // SignInit/Sign, etc. — lives on the session, so concurrent workers
+    // sharing one session would race each other's operation context).
+    // Login state is per-TOKEN not per-session (verified against
+    // `ffi.rs::C_Login` — `token.login_state` lives in `TOKEN_STORE`
+    // keyed by slot), so a worker session on an already-logged-in tenant
+    // slot needs no separate login; and `can_access_object` gates by
+    // slot, not by creating session, so every worker can use its
+    // tenant's key material without regenerating it. ────────────────────
     let tenants = [&alice, &bob];
     let mut worker_sessions: Vec<(CK_SESSION_HANDLE, usize)> = Vec::new();
     for w in 0..cli.threads {
@@ -370,100 +424,121 @@ fn run_instance(cli: &Cli) -> Result<()> {
         }
     };
     let stdout = std::io::stdout();
+    let emit = |op: &'static str, category: &'static str, algorithm: &'static str, security_level: &'static str, total_ops: u64, latencies_ms: Vec<f64>, duration_s: f64| -> Result<()> {
+        let row = common(op, category, algorithm, security_level, total_ops, latencies_ms, duration_s);
+        eprintln!("[ok] measured {}/{}: {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.ops_per_sec, row.duration_s, row.total_ops);
+        serde_json::to_writer(&stdout, &row)?;
+        println!();
+        Ok(())
+    };
 
-    // sign (Ed25519, L1)
-    {
-        let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
-            let engine = Arc::clone(&engine);
-            let priv_handle = tenants[idx].priv_handle;
-            let mechanism = algos::ED25519.sign_mechanism;
-            let message = format!("hsm-perf-bench measured sign — tenant {idx}").into_bytes();
-            move || -> Result<()> {
+    // keygen — one real sample per tenant (2 total), NOT a hot loop:
+    // these are the SAME `C_GenerateKeyPair` calls `provision_tenant`
+    // already had to make, timed in place — no extra calls made just to
+    // produce this row, and every sign/verify/derive/encapsulate/
+    // decapsulate closure below still excludes keygen entirely (§A7).
+    // `duration_s` here is the sum of the 2 real samples' wall-clock
+    // time, not a fixed measurement window like the other rows.
+    let emit_keygen = |category: &'static str, name: &'static str, security_level: &'static str| -> Result<()> {
+        let latencies_ms = vec![alice_keygen_ms[name], bob_keygen_ms[name]];
+        let duration_s = (latencies_ms.iter().sum::<f64>() / 1000.0).max(1e-9);
+        emit("keygen", category, name, security_level, latencies_ms.len() as u64, latencies_ms, duration_s)
+    };
+    for algo in &sig_algos {
+        emit_keygen("signature", algo.name, algo.security_level)?;
+    }
+    for algo in &kex_algos {
+        emit_keygen("key_establishment", algo.name, algo.security_level)?;
+    }
+    for algo in &kem_algos {
+        emit_keygen("key_establishment", algo.name, algo.security_level)?;
+    }
+
+    // sign + verify, every signature algorithm
+    for algo in &sig_algos {
+        {
+            let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
+                let engine = Arc::clone(&engine);
+                let priv_handle = tenants[idx].sig[algo.name].priv_handle;
+                let mechanism = algo.sign_mechanism;
+                let message = format!("hsm-perf-bench measured sign {} — tenant {idx}", algo.name).into_bytes();
+                move || -> Result<()> {
+                    engine.sign_init(session, mechanism, priv_handle)?;
+                    engine.sign(session, &message)?;
+                    Ok(())
+                }
+            }).collect();
+            let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+            emit("sign", "signature", algo.name, algo.security_level, total_ops, latencies_ms, duration_s)?;
+        }
+        // verify — each worker signs ONE message once (setup, unmeasured)
+        // then the timed loop repeatedly verifies that same signature,
+        // exercising the real C_VerifyInit/C_Verify path only.
+        {
+            let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
+                let engine = Arc::clone(&engine);
+                let material = &tenants[idx].sig[algo.name];
+                let (priv_handle, pub_handle) = (material.priv_handle, material.pub_handle);
+                let mechanism = algo.sign_mechanism;
+                let message = format!("hsm-perf-bench measured verify {} — tenant {idx}", algo.name).into_bytes();
                 engine.sign_init(session, mechanism, priv_handle)?;
-                engine.sign(session, &message)?;
-                Ok(())
-            }
-        }).collect();
-        let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
-        let row = common("sign", "signature", algos::ED25519.name, "L1", total_ops, latencies_ms, duration_s);
-        eprintln!("[ok] measured {}/{}: {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.ops_per_sec, row.duration_s, row.total_ops);
-        serde_json::to_writer(&stdout, &row)?;
-        println!();
+                let signature = engine.sign(session, &message)?;
+                Ok::<_, anyhow::Error>(move || -> Result<()> {
+                    engine.verify_init(session, mechanism, pub_handle)?;
+                    engine.verify(session, &message, &signature)?;
+                    Ok(())
+                })
+            }).collect::<Result<Vec<_>>>()?;
+            let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+            emit("verify", "signature", algo.name, algo.security_level, total_ops, latencies_ms, duration_s)?;
+        }
     }
 
-    // verify (Ed25519, L1) — each worker signs ONE message once (setup,
-    // unmeasured) then the timed loop repeatedly verifies that same
-    // signature, exercising the real C_VerifyInit/C_Verify path only.
-    {
+    // derive, every key-agreement algorithm
+    for algo in &kex_algos {
         let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
             let engine = Arc::clone(&engine);
-            let (priv_handle, pub_handle) = (tenants[idx].priv_handle, tenants[idx].pub_handle);
-            let mechanism = algos::ED25519.sign_mechanism;
-            let message = format!("hsm-perf-bench measured verify — tenant {idx}").into_bytes();
-            engine.sign_init(session, mechanism, priv_handle)?;
-            let signature = engine.sign(session, &message)?;
-            Ok::<_, anyhow::Error>(move || -> Result<()> {
-                engine.verify_init(session, mechanism, pub_handle)?;
-                engine.verify(session, &message, &signature)?;
-                Ok(())
-            })
-        }).collect::<Result<Vec<_>>>()?;
-        let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
-        let row = common("verify", "signature", algos::ED25519.name, "L1", total_ops, latencies_ms, duration_s);
-        eprintln!("[ok] measured {}/{}: {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.ops_per_sec, row.duration_s, row.total_ops);
-        serde_json::to_writer(&stdout, &row)?;
-        println!();
-    }
-
-    // derive (X25519, L1)
-    {
-        let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
-            let engine = Arc::clone(&engine);
-            let priv_handle = tenants[idx].kex_priv;
-            let mut peer_point = tenants[idx].peer_kex_point.clone();
+            let priv_handle = tenants[idx].kex[algo.name].priv_handle;
+            let mut peer_point = tenants[idx].kex[algo.name].peer_point.clone();
             move || -> Result<()> {
                 engine.ecdh1_derive(session, priv_handle, &mut peer_point)?;
                 Ok(())
             }
         }).collect();
         let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
-        let row = common("derive", "key_establishment", algos::X25519.name, "L1", total_ops, latencies_ms, duration_s);
-        eprintln!("[ok] measured {}/{}: {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.ops_per_sec, row.duration_s, row.total_ops);
-        serde_json::to_writer(&stdout, &row)?;
-        println!();
+        emit("derive", "key_establishment", algo.name, algo.security_level, total_ops, latencies_ms, duration_s)?;
     }
 
-    // encapsulate / decapsulate (ML-KEM-768, L3)
-    {
-        let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
-            let engine = Arc::clone(&engine);
-            let kem_pub = tenants[idx].kem_pub;
-            move || -> Result<()> {
-                engine.encapsulate_key(session, algos::ML_KEM_768.kem_mechanism, kem_pub, &mut [])?;
-                Ok(())
-            }
-        }).collect();
-        let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
-        let row = common("encapsulate", "key_establishment", algos::ML_KEM_768.name, "L3", total_ops, latencies_ms, duration_s);
-        eprintln!("[ok] measured {}/{}: {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.ops_per_sec, row.duration_s, row.total_ops);
-        serde_json::to_writer(&stdout, &row)?;
-        println!();
-    }
-    {
-        let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
-            let engine = Arc::clone(&engine);
-            let kem_priv = tenants[idx].kem_priv;
-            let ciphertext = tenants[idx].kem_ciphertext.clone();
-            move || -> Result<()> {
-                engine.decapsulate_key(session, algos::ML_KEM_768.kem_mechanism, kem_priv, &ciphertext, &mut [])?;
-                Ok(())
-            }
-        }).collect();
-        let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
-        let row = common("decapsulate", "key_establishment", algos::ML_KEM_768.name, "L3", total_ops, latencies_ms, duration_s);
-        eprintln!("[ok] measured {}/{}: {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.ops_per_sec, row.duration_s, row.total_ops);
-        serde_json::to_writer(&stdout, &row)?;
-        println!();
+    // encapsulate + decapsulate, every KEM
+    for algo in &kem_algos {
+        {
+            let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
+                let engine = Arc::clone(&engine);
+                let kem_pub = tenants[idx].kem[algo.name].pub_handle;
+                let mechanism = algo.kem_mechanism;
+                move || -> Result<()> {
+                    engine.encapsulate_key(session, mechanism, kem_pub, &mut [])?;
+                    Ok(())
+                }
+            }).collect();
+            let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+            emit("encapsulate", "key_establishment", algo.name, algo.security_level, total_ops, latencies_ms, duration_s)?;
+        }
+        {
+            let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
+                let engine = Arc::clone(&engine);
+                let material = &tenants[idx].kem[algo.name];
+                let kem_priv = material.priv_handle;
+                let ciphertext = material.ciphertext.clone();
+                let mechanism = algo.kem_mechanism;
+                move || -> Result<()> {
+                    engine.decapsulate_key(session, mechanism, kem_priv, &ciphertext, &mut [])?;
+                    Ok(())
+                }
+            }).collect();
+            let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+            emit("decapsulate", "key_establishment", algo.name, algo.security_level, total_ops, latencies_ms, duration_s)?;
+        }
     }
 
     for (session, _) in worker_sessions {

--- a/rust/bench-harness/src/main.rs
+++ b/rust/bench-harness/src/main.rs
@@ -8,20 +8,32 @@
 //! `C_Logout`/`C_CloseSession` — no vendor extensions), generate a real
 //! Ed25519 key pair per tenant, sign, verify, and prove cross-tenant
 //! isolation with a real spec-defined error code, not an assumption.
-//! Then, per plan §P4 ("one real op per category"), proves one
-//! representative op from the other two axis categories — X25519 ECDH
-//! key agreement and ML-KEM-768 encapsulate/decapsulate — each with its
-//! own genuine cryptographic correctness self-check, not just a bare
-//! `CKR_OK`.
+//! Proves one representative op from the other two axis categories —
+//! X25519 ECDH key agreement and ML-KEM-768 encapsulate/decapsulate —
+//! each with its own genuine cryptographic correctness self-check, not
+//! just a bare `CKR_OK`. Then, per §A7 ("fixed-duration points... not
+//! fixed-op-count"), runs a real fixed-duration multi-threaded
+//! measurement point per op and emits one JSONL row per point (§A4.1's
+//! output contract) to stdout.
+//!
+//! Scope note (this increment): 2 fixed tenants, shared-1-instance
+//! topology, pkcs11-direct access path only. Topology B (independent
+//! N instances), the full ~18-algorithm matrix (§A5), and kmip mode
+//! (§P2) are later, separately-verified increments — not built here.
 
 mod algos;
+mod measure;
 mod pkcs11;
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use pkcs11::Engine;
-use softhsmrustv3::ck_abi::{CK_ATTRIBUTE, CK_ATTRIBUTE_TYPE, CK_OBJECT_HANDLE, CK_SLOT_ID, CK_ULONG, CK_VOID_PTR};
+use softhsmrustv3::ck_abi::{
+    CK_ATTRIBUTE, CK_ATTRIBUTE_TYPE, CK_OBJECT_HANDLE, CK_SESSION_HANDLE, CK_SLOT_ID, CK_ULONG,
+    CK_VOID_PTR,
+};
 use softhsmrustv3::constants::{CKA_EC_POINT, CKA_VALUE, CKR_KEY_HANDLE_INVALID, CKR_OBJECT_HANDLE_INVALID};
+use std::sync::Arc;
 
 #[derive(Parser, Debug)]
 #[command(name = "bench-harness", about = "hsm-perf-bench PKCS#11-direct measurement harness")]
@@ -29,22 +41,46 @@ struct Cli {
     /// Path to the compiled softhsmrustv3 shared library.
     #[arg(long, default_value = "../target/release/libsofthsmrustv3.dylib")]
     library: String,
+    /// Worker threads for the measured loop (§A4.2 axis — round-robin
+    /// across the 2 tenants, each on its OWN session so concurrent ops
+    /// don't race on one session's operation state, §6.5.1).
+    #[arg(long, default_value_t = 4)]
+    threads: u32,
+    /// Measured window per point, seconds (§A6 "seconds-per-point", §A7
+    /// "fixed-duration points").
+    #[arg(long, default_value_t = 2.0)]
+    duration_secs: f64,
+    /// Unmeasured warm-up per point, seconds (§A7).
+    #[arg(long, default_value_t = 0.5)]
+    warmup_secs: f64,
 }
 
-/// One tenant's bootstrapped token + a real Ed25519 key pair on it,
-/// signed and verified once as a per-tenant sanity check.
+/// One tenant's bootstrapped token + real, sanity-checked key material for
+/// every op category this increment measures. Ed25519 keys sign/verify
+/// their own sanity check inline; ML-KEM keys encapsulate/decapsulate
+/// their own sanity check inline (`kem_ciphertext`/`kem_ss` are the
+/// resulting pair, reused by the measured decapsulate loop so it doesn't
+/// need a fresh encapsulate call per iteration). X25519 needs a REAL
+/// peer, so its cross-tenant derive proof happens in `main` once both
+/// tenants exist; `peer_kex_point` is filled in there too.
 struct Tenant {
     slot: CK_SLOT_ID,
-    session: softhsmrustv3::ck_abi::CK_SESSION_HANDLE,
+    session: CK_SESSION_HANDLE,
     pub_handle: CK_OBJECT_HANDLE,
     priv_handle: CK_OBJECT_HANDLE,
+    kex_priv: CK_OBJECT_HANDLE,
+    kex_pub_point: Vec<u8>,
+    peer_kex_point: Vec<u8>,
+    kem_pub: CK_OBJECT_HANDLE,
+    kem_priv: CK_OBJECT_HANDLE,
+    kem_ciphertext: Vec<u8>,
 }
 
 /// Claim the next free slot (standard §5.4 `C_GetSlotList` auto-replenish
 /// — see `pkcs11.rs::get_slot_list`'s doc comment) and bring up a real
-/// token + Ed25519 key pair on it, per-tenant PINs so each tenant's token
-/// stays independently openable (matching the KMIP server's own
-/// per-tenant-PIN tenancy model).
+/// token with sanity-checked Ed25519, X25519, and ML-KEM-768 key material
+/// on it, per-tenant PINs so each tenant's token stays independently
+/// openable (matching the KMIP server's own per-tenant-PIN tenancy model).
 fn provision_tenant(engine: &Engine, name: &str) -> Result<Tenant> {
     let slots_before = engine.get_slot_list().context("C_GetSlotList")?;
     let slot = *slots_before
@@ -55,20 +91,62 @@ fn provision_tenant(engine: &Engine, name: &str) -> Result<Tenant> {
         .bootstrap_token(slot, &format!("so-pin-{name}"), &format!("user-pin-{name}"), &format!("bench-{name}"))
         .with_context(|| format!("bootstrap_token(slot={slot}, tenant={name})"))?;
 
-    let algo = algos::ED25519;
+    // ── Ed25519 — self-contained sanity check (both keys are this
+    // tenant's own). ────────────────────────────────────────────────────
+    let sig_algo = algos::ED25519;
     let (pub_handle, priv_handle) = engine
-        .generate_key_pair(session, algo.keygen_mechanism, &mut [], &mut [])
-        .with_context(|| format!("C_GenerateKeyPair({}, tenant={name})", algo.name))?;
-
-    // Per-tenant sanity: this tenant's own key round-trips correctly.
+        .generate_key_pair(session, sig_algo.keygen_mechanism, &mut [], &mut [])
+        .with_context(|| format!("C_GenerateKeyPair({}, tenant={name})", sig_algo.name))?;
     let message = format!("hsm-perf-bench harness proof — tenant {name}").into_bytes();
-    engine.sign_init(session, algo.sign_mechanism, priv_handle).context("C_SignInit")?;
+    engine.sign_init(session, sig_algo.sign_mechanism, priv_handle).context("C_SignInit")?;
     let signature = engine.sign(session, &message).context("C_Sign")?;
-    engine.verify_init(session, algo.sign_mechanism, pub_handle).context("C_VerifyInit")?;
+    engine.verify_init(session, sig_algo.sign_mechanism, pub_handle).context("C_VerifyInit")?;
     let valid = engine.verify(session, &message, &signature).context("C_Verify")?;
-    assert!(valid, "tenant {name}'s own {} signature must verify", algo.name);
+    assert!(valid, "tenant {name}'s own {} signature must verify", sig_algo.name);
 
-    Ok(Tenant { slot, session, pub_handle, priv_handle })
+    // ── X25519 — keygen only here; the derive proof needs a real peer,
+    // done in `main` once both tenants exist. ──────────────────────────
+    let kex_algo = algos::X25519;
+    let (kex_pub, kex_priv) = engine
+        .generate_key_pair(session, kex_algo.keygen_mechanism, &mut [], &mut [])
+        .with_context(|| format!("C_GenerateKeyPair({}, tenant={name})", kex_algo.name))?;
+    let kex_pub_point = engine
+        .get_attribute_value(session, kex_pub, CKA_EC_POINT)
+        .with_context(|| format!("C_GetAttributeValue({} CKA_EC_POINT, tenant={name})", kex_algo.name))?;
+
+    // ── ML-KEM-768 — self-contained sanity check (encapsulate against
+    // this tenant's own public key, decapsulate with its own private
+    // key). The resulting (ciphertext, shared secret) pair is kept:
+    // the measured decapsulate loop reuses the SAME ciphertext every
+    // iteration (ML-KEM decapsulate is deterministic given (sk, ct), so
+    // this still exercises the real math each call — it just avoids
+    // needing a fresh encapsulate call per measured iteration). ────────
+    let kem_algo = algos::ML_KEM_768;
+    let mut param_set_value: u32 = kem_algo.parameter_set;
+    let mut kem_pub_template = [CK_ATTRIBUTE {
+        attrType: algos::PARAMETER_SET_ATTR as CK_ATTRIBUTE_TYPE,
+        pValue: &mut param_set_value as *mut u32 as CK_VOID_PTR,
+        ulValueLen: std::mem::size_of::<u32>() as CK_ULONG,
+    }];
+    let (kem_pub, kem_priv) = engine
+        .generate_key_pair(session, kem_algo.keygen_mechanism, &mut kem_pub_template, &mut [])
+        .with_context(|| format!("C_GenerateKeyPair({}, tenant={name})", kem_algo.name))?;
+    let (kem_ciphertext, encap_ss_handle) = engine
+        .encapsulate_key(session, kem_algo.kem_mechanism, kem_pub, &mut [])
+        .with_context(|| format!("C_EncapsulateKey(tenant={name})"))?;
+    let decap_ss_handle = engine
+        .decapsulate_key(session, kem_algo.kem_mechanism, kem_priv, &kem_ciphertext, &mut [])
+        .with_context(|| format!("C_DecapsulateKey(tenant={name})"))?;
+    let encap_ss = engine.get_attribute_value(session, encap_ss_handle, CKA_VALUE).context("C_GetAttributeValue(encap CKA_VALUE)")?;
+    let decap_ss = engine.get_attribute_value(session, decap_ss_handle, CKA_VALUE).context("C_GetAttributeValue(decap CKA_VALUE)")?;
+    assert_eq!(encap_ss, decap_ss, "tenant {name}'s {} decapsulate must recover the SAME shared secret encapsulate produced", kem_algo.name);
+    assert_eq!(encap_ss.len(), 32, "{} shared secret must be 32 bytes (FIPS 203)", kem_algo.name);
+
+    Ok(Tenant {
+        slot, session, pub_handle, priv_handle,
+        kex_priv, kex_pub_point, peer_kex_point: Vec::new(),
+        kem_pub, kem_priv, kem_ciphertext,
+    })
 }
 
 fn main() -> Result<()> {
@@ -80,12 +158,12 @@ fn main() -> Result<()> {
 
     // ── Two tenants, two real tokens, real Ed25519 keys, standard PKCS#11
     // v3.2 calls only. ──────────────────────────────────────────────────
-    let alice = provision_tenant(&engine, "alice")?;
+    let mut alice = provision_tenant(&engine, "alice")?;
     eprintln!(
         "[ok] alice bootstrapped on slot {}: session={} pub={} priv={}",
         alice.slot, alice.session, alice.pub_handle, alice.priv_handle
     );
-    let bob = provision_tenant(&engine, "bob")?;
+    let mut bob = provision_tenant(&engine, "bob")?;
     eprintln!(
         "[ok] bob bootstrapped on slot {}: session={} pub={} priv={}",
         bob.slot, bob.session, bob.pub_handle, bob.priv_handle
@@ -136,75 +214,171 @@ fn main() -> Result<()> {
     eprintln!("[ok] bob's own key still works after the rejected cross-tenant attempt — real gate, not a blanket deny");
 
     // ── ECDH-derive category (X25519, PKCS#11 v3.2 §6.7) — genuine
-    // two-party key agreement across alice's and bob's SEPARATE tokens.
-    // The only real correctness check a DH exchange offers: both sides
-    // must independently derive the IDENTICAL shared secret. ──────────
-    let kex = algos::X25519;
-    let (alice_kex_pub, alice_kex_priv) = engine
-        .generate_key_pair(alice.session, kex.keygen_mechanism, &mut [], &mut [])
-        .context("C_GenerateKeyPair(X25519, alice)")?;
-    let (bob_kex_pub, bob_kex_priv) = engine
-        .generate_key_pair(bob.session, kex.keygen_mechanism, &mut [], &mut [])
-        .context("C_GenerateKeyPair(X25519, bob)")?;
-    eprintln!(
-        "[ok] {} key pairs generated: alice pub={alice_kex_pub} priv={alice_kex_priv}, bob pub={bob_kex_pub} priv={bob_kex_priv}",
-        kex.name
-    );
-
-    let mut alice_point = engine.get_attribute_value(alice.session, alice_kex_pub, CKA_EC_POINT).context("C_GetAttributeValue(alice CKA_EC_POINT)")?;
-    let mut bob_point = engine.get_attribute_value(bob.session, bob_kex_pub, CKA_EC_POINT).context("C_GetAttributeValue(bob CKA_EC_POINT)")?;
-
-    let alice_shared_handle = engine.ecdh1_derive(alice.session, alice_kex_priv, &mut bob_point).context("C_DeriveKey(ECDH1, alice)")?;
-    let bob_shared_handle = engine.ecdh1_derive(bob.session, bob_kex_priv, &mut alice_point).context("C_DeriveKey(ECDH1, bob)")?;
-
+    // two-party key agreement across alice's and bob's SEPARATE tokens,
+    // each already holding her/his own X25519 keypair from
+    // `provision_tenant`. The only real correctness check a DH exchange
+    // offers: both sides must independently derive the IDENTICAL shared
+    // secret. ────────────────────────────────────────────────────────
+    let mut bob_point_for_alice = bob.kex_pub_point.clone();
+    let mut alice_point_for_bob = alice.kex_pub_point.clone();
+    let alice_shared_handle = engine.ecdh1_derive(alice.session, alice.kex_priv, &mut bob_point_for_alice).context("C_DeriveKey(ECDH1, alice)")?;
+    let bob_shared_handle = engine.ecdh1_derive(bob.session, bob.kex_priv, &mut alice_point_for_bob).context("C_DeriveKey(ECDH1, bob)")?;
     let alice_shared = engine.get_attribute_value(alice.session, alice_shared_handle, CKA_VALUE).context("C_GetAttributeValue(alice shared CKA_VALUE)")?;
     let bob_shared = engine.get_attribute_value(bob.session, bob_shared_handle, CKA_VALUE).context("C_GetAttributeValue(bob shared CKA_VALUE)")?;
-
     assert_eq!(alice_shared, bob_shared, "X25519 ECDH must produce the SAME shared secret on both sides");
     assert_eq!(alice_shared.len(), 32, "X25519 shared secret must be 32 bytes (RFC 7748)");
     eprintln!(
         "[ok] {} key agreement verified: alice and bob independently derived the SAME {}-byte shared secret",
-        kex.name, alice_shared.len()
+        algos::X25519.name, alice_shared.len()
     );
+    alice.peer_kex_point = bob.kex_pub_point.clone();
+    bob.peer_kex_point = alice.kex_pub_point.clone();
 
-    // ── KEM category (ML-KEM-768, PKCS#11 v3.2 §6.68) — a real
-    // encapsulate/decapsulate round trip on alice's own token. A KEM has
-    // no "verify"; the correctness check is that C_DecapsulateKey
-    // recovers the SAME shared secret C_EncapsulateKey produced from the
-    // ciphertext alone. ─────────────────────────────────────────────────
-    let kem = algos::ML_KEM_768;
-    let mut param_set_value: u32 = kem.parameter_set;
-    let mut kem_pub_template = [CK_ATTRIBUTE {
-        attrType: algos::PARAMETER_SET_ATTR as CK_ATTRIBUTE_TYPE,
-        pValue: &mut param_set_value as *mut u32 as CK_VOID_PTR,
-        ulValueLen: std::mem::size_of::<u32>() as CK_ULONG,
-    }];
-    let (kem_pub, kem_priv) = engine
-        .generate_key_pair(alice.session, kem.keygen_mechanism, &mut kem_pub_template, &mut [])
-        .context("C_GenerateKeyPair(ML-KEM-768)")?;
-    eprintln!("[ok] {} key pair generated: pub={kem_pub} priv={kem_priv}", kem.name);
-
-    let (ciphertext, encap_ss_handle) = engine
-        .encapsulate_key(alice.session, kem.kem_mechanism, kem_pub, &mut [])
-        .context("C_EncapsulateKey")?;
-    let decap_ss_handle = engine
-        .decapsulate_key(alice.session, kem.kem_mechanism, kem_priv, &ciphertext, &mut [])
-        .context("C_DecapsulateKey")?;
-
-    let encap_ss = engine.get_attribute_value(alice.session, encap_ss_handle, CKA_VALUE).context("C_GetAttributeValue(encap CKA_VALUE)")?;
-    let decap_ss = engine.get_attribute_value(alice.session, decap_ss_handle, CKA_VALUE).context("C_GetAttributeValue(decap CKA_VALUE)")?;
-
-    assert_eq!(encap_ss, decap_ss, "ML-KEM-768 decapsulate must recover the SAME shared secret encapsulate produced");
-    assert_eq!(encap_ss.len(), 32, "ML-KEM shared secret must be 32 bytes (FIPS 203)");
     eprintln!(
-        "[ok] {} KEM round-trip verified: encapsulate/decapsulate agree on the SAME {}-byte shared secret (ciphertext {} bytes)",
-        kem.name, encap_ss.len(), ciphertext.len()
+        "[ok] {} KEM round-trip verified for both tenants during provisioning: {}-byte ciphertexts, matching encap/decap shared secrets",
+        algos::ML_KEM_768.name, alice.kem_ciphertext.len()
     );
 
+    // ── Fixed-duration, multi-threaded measurement (§A7): one point per
+    // op, `cli.threads` workers round-robin across the 2 tenants, each
+    // worker on its OWN session (an operation's state — SignInit/Sign,
+    // etc. — lives on the session, so concurrent workers sharing one
+    // session would race each other's operation context). Login state
+    // is per-TOKEN not per-session (verified against `ffi.rs::C_Login`
+    // — `token.login_state` lives in `TOKEN_STORE` keyed by slot), so a
+    // worker session on an already-logged-in tenant slot needs no
+    // separate login; and `can_access_object` gates by slot, not by
+    // creating session, so every worker can use its tenant's key
+    // material without regenerating it. ─────────────────────────────────
+    let tenants = [&alice, &bob];
+    let mut worker_sessions: Vec<(CK_SESSION_HANDLE, usize)> = Vec::new();
+    for w in 0..cli.threads {
+        let tenant_idx = (w as usize) % tenants.len();
+        let session = engine.open_session(tenants[tenant_idx].slot).with_context(|| format!("C_OpenSession (worker {w})"))?;
+        worker_sessions.push((session, tenant_idx));
+    }
+    eprintln!("[ok] {} worker sessions opened across {} tenants", worker_sessions.len(), tenants.len());
+
+    let engine = Arc::new(engine);
+    let engine_version = engine.library_version().context("C_GetInfo")?;
+    let common = |op: &'static str, category: &'static str, algorithm: &'static str, security_level: &'static str, total_ops: u64, latencies_ms: Vec<f64>, duration_s: f64| {
+        let (p50_ms, p99_ms) = measure::percentiles_ms(latencies_ms);
+        measure::ResultRow {
+            access_path: "pkcs11-direct",
+            topology: "shared-1-instance",
+            instances: 1,
+            tenants: tenants.len() as u32,
+            threads: cli.threads,
+            category, algorithm, security_level, op,
+            ops_per_sec: total_ops as f64 / duration_s,
+            p50_ms, p99_ms, duration_s, total_ops,
+            engine_version: engine_version.clone(),
+        }
+    };
+    let stdout = std::io::stdout();
+
+    // sign (Ed25519, L1)
+    {
+        let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
+            let engine = Arc::clone(&engine);
+            let priv_handle = tenants[idx].priv_handle;
+            let mechanism = algos::ED25519.sign_mechanism;
+            let message = format!("hsm-perf-bench measured sign — tenant {idx}").into_bytes();
+            move || -> Result<()> {
+                engine.sign_init(session, mechanism, priv_handle)?;
+                engine.sign(session, &message)?;
+                Ok(())
+            }
+        }).collect();
+        let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+        let row = common("sign", "signature", algos::ED25519.name, "L1", total_ops, latencies_ms, duration_s);
+        eprintln!("[ok] measured {}/{}: {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.ops_per_sec, row.duration_s, row.total_ops);
+        serde_json::to_writer(&stdout, &row)?;
+        println!();
+    }
+
+    // verify (Ed25519, L1) — each worker signs ONE message once (setup,
+    // unmeasured) then the timed loop repeatedly verifies that same
+    // signature, exercising the real C_VerifyInit/C_Verify path only.
+    {
+        let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
+            let engine = Arc::clone(&engine);
+            let (priv_handle, pub_handle) = (tenants[idx].priv_handle, tenants[idx].pub_handle);
+            let mechanism = algos::ED25519.sign_mechanism;
+            let message = format!("hsm-perf-bench measured verify — tenant {idx}").into_bytes();
+            engine.sign_init(session, mechanism, priv_handle)?;
+            let signature = engine.sign(session, &message)?;
+            Ok::<_, anyhow::Error>(move || -> Result<()> {
+                engine.verify_init(session, mechanism, pub_handle)?;
+                engine.verify(session, &message, &signature)?;
+                Ok(())
+            })
+        }).collect::<Result<Vec<_>>>()?;
+        let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+        let row = common("verify", "signature", algos::ED25519.name, "L1", total_ops, latencies_ms, duration_s);
+        eprintln!("[ok] measured {}/{}: {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.ops_per_sec, row.duration_s, row.total_ops);
+        serde_json::to_writer(&stdout, &row)?;
+        println!();
+    }
+
+    // derive (X25519, L1)
+    {
+        let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
+            let engine = Arc::clone(&engine);
+            let priv_handle = tenants[idx].kex_priv;
+            let mut peer_point = tenants[idx].peer_kex_point.clone();
+            move || -> Result<()> {
+                engine.ecdh1_derive(session, priv_handle, &mut peer_point)?;
+                Ok(())
+            }
+        }).collect();
+        let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+        let row = common("derive", "key_establishment", algos::X25519.name, "L1", total_ops, latencies_ms, duration_s);
+        eprintln!("[ok] measured {}/{}: {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.ops_per_sec, row.duration_s, row.total_ops);
+        serde_json::to_writer(&stdout, &row)?;
+        println!();
+    }
+
+    // encapsulate / decapsulate (ML-KEM-768, L3)
+    {
+        let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
+            let engine = Arc::clone(&engine);
+            let kem_pub = tenants[idx].kem_pub;
+            move || -> Result<()> {
+                engine.encapsulate_key(session, algos::ML_KEM_768.kem_mechanism, kem_pub, &mut [])?;
+                Ok(())
+            }
+        }).collect();
+        let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+        let row = common("encapsulate", "key_establishment", algos::ML_KEM_768.name, "L3", total_ops, latencies_ms, duration_s);
+        eprintln!("[ok] measured {}/{}: {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.ops_per_sec, row.duration_s, row.total_ops);
+        serde_json::to_writer(&stdout, &row)?;
+        println!();
+    }
+    {
+        let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
+            let engine = Arc::clone(&engine);
+            let kem_priv = tenants[idx].kem_priv;
+            let ciphertext = tenants[idx].kem_ciphertext.clone();
+            move || -> Result<()> {
+                engine.decapsulate_key(session, algos::ML_KEM_768.kem_mechanism, kem_priv, &ciphertext, &mut [])?;
+                Ok(())
+            }
+        }).collect();
+        let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+        let row = common("decapsulate", "key_establishment", algos::ML_KEM_768.name, "L3", total_ops, latencies_ms, duration_s);
+        eprintln!("[ok] measured {}/{}: {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.ops_per_sec, row.duration_s, row.total_ops);
+        serde_json::to_writer(&stdout, &row)?;
+        println!();
+    }
+
+    for (session, _) in worker_sessions {
+        engine.close_session(session).context("C_CloseSession (worker)")?;
+    }
     engine.close_session(alice.session).context("C_CloseSession (alice)")?;
     engine.close_session(bob.session).context("C_CloseSession (bob)")?;
     engine.finalize().context("C_Finalize")?;
-    eprintln!("[ok] mechanism + isolation proof complete — engine finalized cleanly");
+    eprintln!("[ok] mechanism + isolation proof + measurement complete — engine finalized cleanly");
 
     Ok(())
 }

--- a/rust/bench-harness/src/main.rs
+++ b/rust/bench-harness/src/main.rs
@@ -91,6 +91,15 @@ struct Cli {
     /// the matrix).
     #[arg(long, default_value_t = false)]
     include_slow: bool,
+    /// Print the configured (algorithm, op) matrix as JSON and exit —
+    /// NO engine load, NO dlopen, NO C_Initialize. Lets a caller (e.g.
+    /// the sandbox UI's job backend, hsm-perf-bench-ui-implementation-
+    /// plan-07192026.md §2.4) learn the exact expected row count/labels
+    /// up front from the harness's own real algorithm list, instead of
+    /// duplicating it as a separately-maintained constant that could
+    /// drift from `algos.rs`.
+    #[arg(long, default_value_t = false)]
+    list_algorithms: bool,
     /// INTERNAL — set by the parent orchestrator on every child it spawns
     /// so the child stamps its JSONL rows as one of an N-instance
     /// Topology-B run even though it always executes as a plain,
@@ -228,10 +237,50 @@ fn provision_tenant(
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    if cli.list_algorithms {
+        return list_algorithms(&cli);
+    }
     if cli.instances > 1 {
         return run_parent(&cli);
     }
     run_instance(&cli)
+}
+
+#[derive(serde::Serialize)]
+struct AlgoCell {
+    category: &'static str,
+    algorithm: &'static str,
+    security_level: &'static str,
+    op: &'static str,
+}
+
+/// `--list-algorithms`: the configured matrix's exact (category,
+/// algorithm, security_level, op) cells, in the same vocabulary
+/// `measure::ResultRow` uses for those fields — so a caller can match
+/// this list's entries directly against streamed JSONL rows with no
+/// translation. Touches nothing but `algos.rs`'s own const data; no
+/// `Engine::load` anywhere in this path.
+fn list_algorithms(cli: &Cli) -> Result<()> {
+    let sig_algos: Vec<algos::SignatureAlgo> = algos::SIGNATURE_ALGOS.iter().copied().filter(|a| cli.include_slow || !a.slow).collect();
+
+    let mut cells = Vec::new();
+    for algo in &sig_algos {
+        for op in ["keygen", "sign", "verify"] {
+            cells.push(AlgoCell { category: "signature", algorithm: algo.name, security_level: algo.security_level, op });
+        }
+    }
+    for algo in algos::KEY_AGREEMENT_ALGOS {
+        for op in ["keygen", "derive"] {
+            cells.push(AlgoCell { category: "key_establishment", algorithm: algo.name, security_level: algo.security_level, op });
+        }
+    }
+    for algo in algos::KEM_ALGOS {
+        for op in ["keygen", "encapsulate", "decapsulate"] {
+            cells.push(AlgoCell { category: "key_establishment", algorithm: algo.name, security_level: algo.security_level, op });
+        }
+    }
+    println!("{}", serde_json::to_string(&cells)?);
+    Ok(())
 }
 
 /// Topology B orchestrator: spawn `cli.instances` fresh child processes of

--- a/rust/bench-harness/src/main.rs
+++ b/rust/bench-harness/src/main.rs
@@ -8,6 +8,11 @@
 //! `C_Logout`/`C_CloseSession` — no vendor extensions), generate a real
 //! Ed25519 key pair per tenant, sign, verify, and prove cross-tenant
 //! isolation with a real spec-defined error code, not an assumption.
+//! Then, per plan §P4 ("one real op per category"), proves one
+//! representative op from the other two axis categories — X25519 ECDH
+//! key agreement and ML-KEM-768 encapsulate/decapsulate — each with its
+//! own genuine cryptographic correctness self-check, not just a bare
+//! `CKR_OK`.
 
 mod algos;
 mod pkcs11;
@@ -15,8 +20,8 @@ mod pkcs11;
 use anyhow::{Context, Result};
 use clap::Parser;
 use pkcs11::Engine;
-use softhsmrustv3::ck_abi::{CK_OBJECT_HANDLE, CK_SLOT_ID};
-use softhsmrustv3::constants::{CKR_KEY_HANDLE_INVALID, CKR_OBJECT_HANDLE_INVALID};
+use softhsmrustv3::ck_abi::{CK_ATTRIBUTE, CK_ATTRIBUTE_TYPE, CK_OBJECT_HANDLE, CK_SLOT_ID, CK_ULONG, CK_VOID_PTR};
+use softhsmrustv3::constants::{CKA_EC_POINT, CKA_VALUE, CKR_KEY_HANDLE_INVALID, CKR_OBJECT_HANDLE_INVALID};
 
 #[derive(Parser, Debug)]
 #[command(name = "bench-harness", about = "hsm-perf-bench PKCS#11-direct measurement harness")]
@@ -53,7 +58,7 @@ fn provision_tenant(engine: &Engine, name: &str) -> Result<Tenant> {
     let algo = algos::ED25519;
     let (pub_handle, priv_handle) = engine
         .generate_key_pair(session, algo.keygen_mechanism, &mut [], &mut [])
-        .with_context(|| format!("C_GenerateKeyPair(tenant={name})"))?;
+        .with_context(|| format!("C_GenerateKeyPair({}, tenant={name})", algo.name))?;
 
     // Per-tenant sanity: this tenant's own key round-trips correctly.
     let message = format!("hsm-perf-bench harness proof — tenant {name}").into_bytes();
@@ -61,7 +66,7 @@ fn provision_tenant(engine: &Engine, name: &str) -> Result<Tenant> {
     let signature = engine.sign(session, &message).context("C_Sign")?;
     engine.verify_init(session, algo.sign_mechanism, pub_handle).context("C_VerifyInit")?;
     let valid = engine.verify(session, &message, &signature).context("C_Verify")?;
-    assert!(valid, "tenant {name}'s own signature must verify");
+    assert!(valid, "tenant {name}'s own {} signature must verify", algo.name);
 
     Ok(Tenant { slot, session, pub_handle, priv_handle })
 }
@@ -129,6 +134,72 @@ fn main() -> Result<()> {
     let valid = engine.verify(bob.session, message, &sig).context("C_Verify (bob, post-check)")?;
     assert!(valid, "bob's own key must still work after the rejected cross-tenant attempt");
     eprintln!("[ok] bob's own key still works after the rejected cross-tenant attempt — real gate, not a blanket deny");
+
+    // ── ECDH-derive category (X25519, PKCS#11 v3.2 §6.7) — genuine
+    // two-party key agreement across alice's and bob's SEPARATE tokens.
+    // The only real correctness check a DH exchange offers: both sides
+    // must independently derive the IDENTICAL shared secret. ──────────
+    let kex = algos::X25519;
+    let (alice_kex_pub, alice_kex_priv) = engine
+        .generate_key_pair(alice.session, kex.keygen_mechanism, &mut [], &mut [])
+        .context("C_GenerateKeyPair(X25519, alice)")?;
+    let (bob_kex_pub, bob_kex_priv) = engine
+        .generate_key_pair(bob.session, kex.keygen_mechanism, &mut [], &mut [])
+        .context("C_GenerateKeyPair(X25519, bob)")?;
+    eprintln!(
+        "[ok] {} key pairs generated: alice pub={alice_kex_pub} priv={alice_kex_priv}, bob pub={bob_kex_pub} priv={bob_kex_priv}",
+        kex.name
+    );
+
+    let mut alice_point = engine.get_attribute_value(alice.session, alice_kex_pub, CKA_EC_POINT).context("C_GetAttributeValue(alice CKA_EC_POINT)")?;
+    let mut bob_point = engine.get_attribute_value(bob.session, bob_kex_pub, CKA_EC_POINT).context("C_GetAttributeValue(bob CKA_EC_POINT)")?;
+
+    let alice_shared_handle = engine.ecdh1_derive(alice.session, alice_kex_priv, &mut bob_point).context("C_DeriveKey(ECDH1, alice)")?;
+    let bob_shared_handle = engine.ecdh1_derive(bob.session, bob_kex_priv, &mut alice_point).context("C_DeriveKey(ECDH1, bob)")?;
+
+    let alice_shared = engine.get_attribute_value(alice.session, alice_shared_handle, CKA_VALUE).context("C_GetAttributeValue(alice shared CKA_VALUE)")?;
+    let bob_shared = engine.get_attribute_value(bob.session, bob_shared_handle, CKA_VALUE).context("C_GetAttributeValue(bob shared CKA_VALUE)")?;
+
+    assert_eq!(alice_shared, bob_shared, "X25519 ECDH must produce the SAME shared secret on both sides");
+    assert_eq!(alice_shared.len(), 32, "X25519 shared secret must be 32 bytes (RFC 7748)");
+    eprintln!(
+        "[ok] {} key agreement verified: alice and bob independently derived the SAME {}-byte shared secret",
+        kex.name, alice_shared.len()
+    );
+
+    // ── KEM category (ML-KEM-768, PKCS#11 v3.2 §6.68) — a real
+    // encapsulate/decapsulate round trip on alice's own token. A KEM has
+    // no "verify"; the correctness check is that C_DecapsulateKey
+    // recovers the SAME shared secret C_EncapsulateKey produced from the
+    // ciphertext alone. ─────────────────────────────────────────────────
+    let kem = algos::ML_KEM_768;
+    let mut param_set_value: u32 = kem.parameter_set;
+    let mut kem_pub_template = [CK_ATTRIBUTE {
+        attrType: algos::PARAMETER_SET_ATTR as CK_ATTRIBUTE_TYPE,
+        pValue: &mut param_set_value as *mut u32 as CK_VOID_PTR,
+        ulValueLen: std::mem::size_of::<u32>() as CK_ULONG,
+    }];
+    let (kem_pub, kem_priv) = engine
+        .generate_key_pair(alice.session, kem.keygen_mechanism, &mut kem_pub_template, &mut [])
+        .context("C_GenerateKeyPair(ML-KEM-768)")?;
+    eprintln!("[ok] {} key pair generated: pub={kem_pub} priv={kem_priv}", kem.name);
+
+    let (ciphertext, encap_ss_handle) = engine
+        .encapsulate_key(alice.session, kem.kem_mechanism, kem_pub, &mut [])
+        .context("C_EncapsulateKey")?;
+    let decap_ss_handle = engine
+        .decapsulate_key(alice.session, kem.kem_mechanism, kem_priv, &ciphertext, &mut [])
+        .context("C_DecapsulateKey")?;
+
+    let encap_ss = engine.get_attribute_value(alice.session, encap_ss_handle, CKA_VALUE).context("C_GetAttributeValue(encap CKA_VALUE)")?;
+    let decap_ss = engine.get_attribute_value(alice.session, decap_ss_handle, CKA_VALUE).context("C_GetAttributeValue(decap CKA_VALUE)")?;
+
+    assert_eq!(encap_ss, decap_ss, "ML-KEM-768 decapsulate must recover the SAME shared secret encapsulate produced");
+    assert_eq!(encap_ss.len(), 32, "ML-KEM shared secret must be 32 bytes (FIPS 203)");
+    eprintln!(
+        "[ok] {} KEM round-trip verified: encapsulate/decapsulate agree on the SAME {}-byte shared secret (ciphertext {} bytes)",
+        kem.name, encap_ss.len(), ciphertext.len()
+    );
 
     engine.close_session(alice.session).context("C_CloseSession (alice)")?;
     engine.close_session(bob.session).context("C_CloseSession (bob)")?;

--- a/rust/bench-harness/src/main.rs
+++ b/rust/bench-harness/src/main.rs
@@ -56,7 +56,7 @@ use clap::Parser;
 use pkcs11::Engine;
 use softhsmrustv3::ck_abi::{CK_OBJECT_HANDLE, CK_SESSION_HANDLE, CK_SLOT_ID};
 use softhsmrustv3::constants::{CKA_EC_POINT, CKA_VALUE, CKR_KEY_HANDLE_INVALID, CKR_OBJECT_HANDLE_INVALID};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::process::Stdio;
 use std::sync::Arc;
 
@@ -90,6 +90,13 @@ struct Cli {
     /// the matrix).
     #[arg(long, default_value_t = false)]
     include_slow: bool,
+    /// Comma-separated exact algorithm names (algos.rs `.name` values, e.g.
+    /// "Ed25519,ML-DSA-65") to restrict the matrix to. Absent = full matrix
+    /// (unchanged default behavior, same pattern as --include-slow). Lets a
+    /// caller (the sandbox UI's algorithm picker) scope a run down instead
+    /// of always executing all 16 algorithms.
+    #[arg(long)]
+    algorithms: Option<String>,
     /// Print the configured (algorithm, op) matrix as JSON and exit —
     /// NO engine load, NO dlopen, NO C_Initialize. Lets a caller (e.g.
     /// the sandbox UI's job backend, hsm-perf-bench-ui-implementation-
@@ -114,6 +121,20 @@ struct Cli {
     /// hand.
     #[arg(long, hide = true)]
     instance_id: Option<u32>,
+}
+
+/// Parses `--algorithms` into a name set once per invocation. `None` means
+/// "no filter" (the flag was absent) — distinct from `Some(empty set)`,
+/// which can't actually happen since `_build_argv` on the Flask side never
+/// sends an empty `--algorithms` value.
+fn selected_algo_names(cli: &Cli) -> Option<HashSet<String>> {
+    cli.algorithms.as_ref().map(|s| {
+        s.split(',').map(|x| x.trim().to_string()).filter(|x| !x.is_empty()).collect()
+    })
+}
+
+fn algo_allowed(name: &str, selected: &Option<HashSet<String>>) -> bool {
+    selected.as_ref().is_none_or(|s| s.contains(name))
 }
 
 struct SigMaterial {
@@ -268,7 +289,20 @@ struct AlgoCell {
 /// translation. Touches nothing but `algos.rs`'s own const data; no
 /// `Engine::load` anywhere in this path.
 fn list_algorithms(cli: &Cli) -> Result<()> {
-    let sig_algos: Vec<algos::SignatureAlgo> = algos::SIGNATURE_ALGOS.iter().copied().filter(|a| cli.include_slow || !a.slow).collect();
+    let selected = selected_algo_names(cli);
+    let sig_algos: Vec<algos::SignatureAlgo> = algos::SIGNATURE_ALGOS.iter().copied()
+        .filter(|a| cli.include_slow || !a.slow)
+        .filter(|a| algo_allowed(a.name, &selected))
+        .collect();
+    let kex_algos: Vec<algos::KeyAgreementAlgo> = algos::KEY_AGREEMENT_ALGOS.iter().copied()
+        .filter(|a| algo_allowed(a.name, &selected))
+        .collect();
+    let kem_algos: Vec<algos::KemAlgo> = algos::KEM_ALGOS.iter().copied()
+        .filter(|a| algo_allowed(a.name, &selected))
+        .collect();
+    if sig_algos.is_empty() && kex_algos.is_empty() && kem_algos.is_empty() {
+        bail!("--algorithms matched no known algorithm: {:?}", cli.algorithms);
+    }
 
     let mut cells = Vec::new();
     for algo in &sig_algos {
@@ -276,12 +310,12 @@ fn list_algorithms(cli: &Cli) -> Result<()> {
             cells.push(AlgoCell { category: "signature", algorithm: algo.name, security_level: algo.security_level, op });
         }
     }
-    for algo in algos::KEY_AGREEMENT_ALGOS {
+    for algo in &kex_algos {
         for op in ["keygen", "derive"] {
             cells.push(AlgoCell { category: "key_establishment", algorithm: algo.name, security_level: algo.security_level, op });
         }
     }
-    for algo in algos::KEM_ALGOS {
+    for algo in &kem_algos {
         for op in ["keygen", "encapsulate", "decapsulate"] {
             cells.push(AlgoCell { category: "key_establishment", algorithm: algo.name, security_level: algo.security_level, op });
         }
@@ -334,6 +368,9 @@ fn run_parent(cli: &Cli) -> Result<()> {
             .arg("--instance-id").arg(instance_id.to_string());
         if cli.include_slow {
             cmd.arg("--include-slow");
+        }
+        if let Some(algorithms) = &cli.algorithms {
+            cmd.arg("--algorithms").arg(algorithms);
         }
         let mut child = cmd
             .stdout(Stdio::piped())
@@ -391,9 +428,20 @@ fn run_instance(cli: &Cli) -> Result<()> {
     // (there's only ever one instance to be).
     let this_instance_id = cli.instance_id.unwrap_or(0);
 
-    let sig_algos: Vec<algos::SignatureAlgo> = algos::SIGNATURE_ALGOS.iter().copied().filter(|a| cli.include_slow || !a.slow).collect();
-    let kex_algos: Vec<algos::KeyAgreementAlgo> = algos::KEY_AGREEMENT_ALGOS.to_vec();
-    let kem_algos: Vec<algos::KemAlgo> = algos::KEM_ALGOS.to_vec();
+    let selected = selected_algo_names(cli);
+    let sig_algos: Vec<algos::SignatureAlgo> = algos::SIGNATURE_ALGOS.iter().copied()
+        .filter(|a| cli.include_slow || !a.slow)
+        .filter(|a| algo_allowed(a.name, &selected))
+        .collect();
+    let kex_algos: Vec<algos::KeyAgreementAlgo> = algos::KEY_AGREEMENT_ALGOS.iter().copied()
+        .filter(|a| algo_allowed(a.name, &selected))
+        .collect();
+    let kem_algos: Vec<algos::KemAlgo> = algos::KEM_ALGOS.iter().copied()
+        .filter(|a| algo_allowed(a.name, &selected))
+        .collect();
+    if sig_algos.is_empty() && kex_algos.is_empty() && kem_algos.is_empty() {
+        bail!("--algorithms matched no known algorithm: {:?}", cli.algorithms);
+    }
 
     let engine = Engine::load(&cli.library).with_context(|| format!("loading engine library at {:?}", cli.library))?;
     engine.initialize().context("C_Initialize")?;

--- a/rust/bench-harness/src/main.rs
+++ b/rust/bench-harness/src/main.rs
@@ -16,16 +16,36 @@
 //! measurement point per op and emits one JSONL row per point (§A4.1's
 //! output contract) to stdout.
 //!
-//! Scope note (this increment): 2 fixed tenants, shared-1-instance
-//! topology, pkcs11-direct access path only. Topology B (independent
-//! N instances), the full ~18-algorithm matrix (§A5), and kmip mode
-//! (§P2) are later, separately-verified increments — not built here.
+//! Topology B (§A4.1/§A4.2, "independent-N-instances"): `--instances N`
+//! (N>1) turns this invocation into a PARENT that spawns N SEPARATE OS
+//! PROCESSES of this same binary, each running the identical single-
+//! instance measurement in complete isolation, and relays their JSONL
+//! rows to its own stdout. Real process separation, not simulated —
+//! `rust/src/state.rs`'s `TOKEN_STORE`/`OBJECTS`/`SESSIONS` are
+//! `lazy_static!` (process-global, Mutex-guarded), confirmed by reading
+//! that file before designing this: multiple OS THREADS in one process
+//! genuinely share and contend on that state (exactly what
+//! shared-1-instance measures), while multiple OS PROCESSES each get
+//! their own independent copy purely from address-space separation — no
+//! IPC or explicit reset needed for the isolation to be real. Children
+//! are spawned via `Command::new(current_exe)` (a fresh process image),
+//! not a raw POSIX `fork()`: forking a multi-threaded process is a
+//! well-known hazard (only the forking thread survives in the child;
+//! mutexes held by other threads at fork time stay locked forever) —
+//! spawning a new process achieves the identical "separate process,
+//! separate dlopen'd engine copy" independence this topology needs,
+//! without that hazard.
+//!
+//! Scope note (this increment): 2 fixed tenants per instance,
+//! pkcs11-direct access path only, 5 of the ~18-algorithm matrix (§A5).
+//! The full algorithm matrix and kmip mode (§P2) are later, separately-
+//! verified increments — not built here.
 
 mod algos;
 mod measure;
 mod pkcs11;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::Parser;
 use pkcs11::Engine;
 use softhsmrustv3::ck_abi::{
@@ -33,6 +53,8 @@ use softhsmrustv3::ck_abi::{
     CK_VOID_PTR,
 };
 use softhsmrustv3::constants::{CKA_EC_POINT, CKA_VALUE, CKR_KEY_HANDLE_INVALID, CKR_OBJECT_HANDLE_INVALID};
+use std::io::Read;
+use std::process::Stdio;
 use std::sync::Arc;
 
 #[derive(Parser, Debug)]
@@ -43,7 +65,9 @@ struct Cli {
     library: String,
     /// Worker threads for the measured loop (§A4.2 axis — round-robin
     /// across the 2 tenants, each on its OWN session so concurrent ops
-    /// don't race on one session's operation state, §6.5.1).
+    /// don't race on one session's operation state, §6.5.1). Per §A4.2,
+    /// this is PER INSTANCE: total concurrency under Topology B is
+    /// `threads * instances`.
     #[arg(long, default_value_t = 4)]
     threads: u32,
     /// Measured window per point, seconds (§A6 "seconds-per-point", §A7
@@ -53,6 +77,18 @@ struct Cli {
     /// Unmeasured warm-up per point, seconds (§A7).
     #[arg(long, default_value_t = 0.5)]
     warmup_secs: f64,
+    /// Topology B (§A4.2): number of independent instances, 1-4. `1`
+    /// (default) is Topology A (shared-1-instance) — unchanged in-process
+    /// behavior. `>1` makes this invocation the parent orchestrator.
+    #[arg(long, default_value_t = 1)]
+    instances: u32,
+    /// INTERNAL — set by the parent orchestrator on every child it spawns
+    /// so the child stamps its JSONL rows as one of an N-instance
+    /// Topology-B run even though it always executes as a plain,
+    /// single-instance measurement itself (`instances` is forced to `1`
+    /// on the child's own invocation). Not meant to be set by hand.
+    #[arg(long, hide = true)]
+    topology_instances: Option<u32>,
 }
 
 /// One tenant's bootstrapped token + real, sanity-checked key material for
@@ -151,6 +187,64 @@ fn provision_tenant(engine: &Engine, name: &str) -> Result<Tenant> {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    if cli.instances > 1 {
+        return run_parent(&cli);
+    }
+    run_instance(&cli)
+}
+
+/// Topology B orchestrator: spawn `cli.instances` fresh child processes of
+/// this same binary, each forced to `--instances 1` (so it runs the exact
+/// same single-instance code path as Topology A) but stamped with
+/// `--topology-instances N` so its JSONL rows self-report as one instance
+/// of an N-instance independent topology. Each child's whole stdout is a
+/// few short JSON lines (5 rows for this increment's algorithm set) —
+/// well under any OS pipe buffer, so reading each child fully before
+/// moving to the next cannot deadlock on a full pipe; this stays true as
+/// long as no future increment makes a single instance's JSONL output
+/// pipe-buffer-sized (megabytes) — if that changes, switch to draining
+/// each child's stdout on its own thread instead of sequentially.
+fn run_parent(cli: &Cli) -> Result<()> {
+    let self_exe = std::env::current_exe().context("resolving current_exe for child re-exec")?;
+    eprintln!(
+        "[[parent]] topology B: spawning {} independent instances (separate processes, separate dlopen'd engine copies)",
+        cli.instances
+    );
+
+    let mut children = Vec::new();
+    for instance_id in 0..cli.instances {
+        let child = std::process::Command::new(&self_exe)
+            .arg("--library").arg(&cli.library)
+            .arg("--threads").arg(cli.threads.to_string())
+            .arg("--duration-secs").arg(cli.duration_secs.to_string())
+            .arg("--warmup-secs").arg(cli.warmup_secs.to_string())
+            .arg("--instances").arg("1")
+            .arg("--topology-instances").arg(cli.instances.to_string())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .with_context(|| format!("spawning instance {instance_id}"))?;
+        children.push(child);
+    }
+
+    for (instance_id, mut child) in children.into_iter().enumerate() {
+        let mut jsonl = String::new();
+        child.stdout.take().expect("piped stdout").read_to_string(&mut jsonl).context("reading child stdout")?;
+        print!("{jsonl}");
+        let status = child.wait().with_context(|| format!("waiting on instance {instance_id}"))?;
+        if !status.success() {
+            bail!("instance {instance_id} exited with {status}");
+        }
+    }
+    eprintln!("[[parent]] all {} instances completed successfully", cli.instances);
+    Ok(())
+}
+
+fn run_instance(cli: &Cli) -> Result<()> {
+    let (topology, topology_instances): (&'static str, u32) = match cli.topology_instances {
+        Some(n) => ("independent-n-instances", n),
+        None => ("shared-1-instance", 1),
+    };
 
     let engine = Engine::load(&cli.library).with_context(|| format!("loading engine library at {:?}", cli.library))?;
     engine.initialize().context("C_Initialize")?;
@@ -265,8 +359,8 @@ fn main() -> Result<()> {
         let (p50_ms, p99_ms) = measure::percentiles_ms(latencies_ms);
         measure::ResultRow {
             access_path: "pkcs11-direct",
-            topology: "shared-1-instance",
-            instances: 1,
+            topology,
+            instances: topology_instances,
             tenants: tenants.len() as u32,
             threads: cli.threads,
             category, algorithm, security_level, op,

--- a/rust/bench-harness/src/main.rs
+++ b/rust/bench-harness/src/main.rs
@@ -57,7 +57,6 @@ use pkcs11::Engine;
 use softhsmrustv3::ck_abi::{CK_OBJECT_HANDLE, CK_SESSION_HANDLE, CK_SLOT_ID};
 use softhsmrustv3::constants::{CKA_EC_POINT, CKA_VALUE, CKR_KEY_HANDLE_INVALID, CKR_OBJECT_HANDLE_INVALID};
 use std::collections::HashMap;
-use std::io::Read;
 use std::process::Stdio;
 use std::sync::Arc;
 
@@ -294,13 +293,26 @@ fn list_algorithms(cli: &Cli) -> Result<()> {
 /// Topology B orchestrator: spawn `cli.instances` fresh child processes of
 /// this same binary, each forced to `--instances 1` (so it runs the exact
 /// same single-instance code path as Topology A) but stamped with
-/// `--topology-instances N` so its JSONL rows self-report as one instance
-/// of an N-instance independent topology. Each child's whole stdout is a
-/// bounded number of short JSON lines — well under any OS pipe buffer, so
-/// reading each child fully before moving to the next cannot deadlock on
-/// a full pipe; if a future increment makes a single instance's JSONL
-/// output pipe-buffer-sized (megabytes), switch to draining each child's
-/// stdout on its own thread instead of sequentially.
+/// `--topology-instances N` + a distinct `--instance-id` so its JSONL
+/// rows self-report as one specific instance of an N-instance independent
+/// topology.
+///
+/// Each child's stdout is read on its OWN thread, one line at a time, and
+/// forwarded to the parent's own stdout AS EACH LINE ARRIVES (via an
+/// mpsc channel drained by the main thread) — not read to completion
+/// child-by-child. An earlier version of this function read one child's
+/// ENTIRE stdout via a blocking `read_to_string()` before even starting
+/// the next child; that is correct for the data itself (nothing was ever
+/// lost or corrupted) but defeats LIVE progress for any caller streaming
+/// the parent's stdout (the sandbox job runner, `hsm_perf_bench_job.py`):
+/// confirmed live — a real 2-instance run showed 0/152 completed cells
+/// for the entire ~15s runtime, then jumped straight to 152/152 the
+/// instant the last child exited, with no intermediate value ever
+/// observed. Rust's `Stdout` is a `LineWriter` regardless of whether it's
+/// attached to a tty or a pipe (unlike C's stdio, which block-buffers
+/// non-tty output), so each child already flushes every JSONL row to its
+/// pipe as soon as that row is written — the blocking was entirely on
+/// this function's READING side, not the children's writing side.
 fn run_parent(cli: &Cli) -> Result<()> {
     let self_exe = std::env::current_exe().context("resolving current_exe for child re-exec")?;
     eprintln!(
@@ -308,7 +320,9 @@ fn run_parent(cli: &Cli) -> Result<()> {
         cli.instances
     );
 
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
     let mut children = Vec::new();
+    let mut readers = Vec::new();
     for instance_id in 0..cli.instances {
         let mut cmd = std::process::Command::new(&self_exe);
         cmd.arg("--library").arg(&cli.library)
@@ -321,18 +335,42 @@ fn run_parent(cli: &Cli) -> Result<()> {
         if cli.include_slow {
             cmd.arg("--include-slow");
         }
-        let child = cmd
+        let mut child = cmd
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .spawn()
             .with_context(|| format!("spawning instance {instance_id}"))?;
+        let stdout = child.stdout.take().expect("piped stdout");
+        let tx = tx.clone();
+        readers.push(std::thread::spawn(move || -> Result<()> {
+            for line in std::io::BufRead::lines(std::io::BufReader::new(stdout)) {
+                let line = line.with_context(|| format!("reading instance {instance_id} stdout"))?;
+                // `.lines()` strips the trailing newline `println!` wrote on
+                // the child side; put it back so what reaches the parent's
+                // own stdout is byte-identical to shared-1-instance mode's
+                // output shape (one JSON object per line).
+                if tx.send(format!("{line}\n")).is_err() {
+                    break; // receiver already gone — main thread is exiting
+                }
+            }
+            Ok(())
+        }));
         children.push(child);
     }
+    drop(tx); // only the per-child clones keep the channel open now
 
+    // Print each line the instant it arrives, interleaved across
+    // instances in real arrival order — this loop ends once every
+    // sender (one per reader thread) has been dropped, i.e. once every
+    // child's stdout has hit EOF.
+    for line in rx {
+        print!("{line}");
+    }
+
+    for reader in readers {
+        reader.join().expect("reader thread panicked")?;
+    }
     for (instance_id, mut child) in children.into_iter().enumerate() {
-        let mut jsonl = String::new();
-        child.stdout.take().expect("piped stdout").read_to_string(&mut jsonl).context("reading child stdout")?;
-        print!("{jsonl}");
         let status = child.wait().with_context(|| format!("waiting on instance {instance_id}"))?;
         if !status.success() {
             bail!("instance {instance_id} exited with {status}");
@@ -451,28 +489,42 @@ fn run_instance(cli: &Cli) -> Result<()> {
     }
 
     // ── Fixed-duration, multi-threaded measurement (§A7): one point per
-    // (algorithm, op), `cli.threads` workers round-robin across the 2
-    // tenants, each worker on its OWN session (an operation's state —
-    // SignInit/Sign, etc. — lives on the session, so concurrent workers
-    // sharing one session would race each other's operation context).
-    // Login state is per-TOKEN not per-session (verified against
-    // `ffi.rs::C_Login` — `token.login_state` lives in `TOKEN_STORE`
-    // keyed by slot), so a worker session on an already-logged-in tenant
-    // slot needs no separate login; and `can_access_object` gates by
-    // slot, not by creating session, so every worker can use its
-    // tenant's key material without regenerating it. ────────────────────
+    // (tenant, algorithm, op) — `cli.threads` workers round-robin across
+    // the 2 tenants, each worker on its OWN session (an operation's
+    // state — SignInit/Sign, etc. — lives on the session, so concurrent
+    // workers sharing one session would race each other's operation
+    // context). Login state is per-TOKEN not per-session (verified
+    // against `ffi.rs::C_Login` — `token.login_state` lives in
+    // `TOKEN_STORE` keyed by slot), so a worker session on an already-
+    // logged-in tenant slot needs no separate login; and
+    // `can_access_object` gates by slot, not by creating session, so
+    // every worker can use its tenant's key material without
+    // regenerating it.
+    //
+    // Grouped by tenant (not pooled across all threads into one row per
+    // op, as this used to be) so each tenant's own throughput is its own
+    // real, separate measurement — telemetry plan §2.2: pooling silently
+    // averaged away exactly the per-tenant fairness/contention question
+    // a shared-vs-independent-topology benchmark exists to answer. An
+    // odd `--threads` value gives one tenant one more worker than the
+    // other (`⌈N/2⌉` vs `⌊N/2⌋`) — a real property of the run, now
+    // visible as different `total_ops` between the two tenants' rows at
+    // the same `threads` value, not hidden inside a pooled average. ────
     let tenants = [&alice, &bob];
-    let mut worker_sessions: Vec<(CK_SESSION_HANDLE, usize)> = Vec::new();
+    let mut worker_sessions_by_tenant: Vec<Vec<CK_SESSION_HANDLE>> = vec![Vec::new(); tenants.len()];
     for w in 0..cli.threads {
         let tenant_idx = (w as usize) % tenants.len();
         let session = engine.open_session(tenants[tenant_idx].slot).with_context(|| format!("C_OpenSession (worker {w})"))?;
-        worker_sessions.push((session, tenant_idx));
+        worker_sessions_by_tenant[tenant_idx].push(session);
     }
-    eprintln!("[ok] {} worker sessions opened across {} tenants", worker_sessions.len(), tenants.len());
+    eprintln!(
+        "[ok] {} worker sessions opened across {} tenants ({} / {} split)",
+        cli.threads, tenants.len(), worker_sessions_by_tenant[0].len(), worker_sessions_by_tenant[1].len()
+    );
 
     let engine = Arc::new(engine);
     let engine_version = engine.library_version().context("C_GetInfo")?;
-    let common = |op: &'static str, category: &'static str, algorithm: &'static str, security_level: &'static str, total_ops: u64, latencies_ms: Vec<f64>, duration_s: f64| {
+    let common = |op: &'static str, category: &'static str, algorithm: &'static str, security_level: &'static str, tenant_index: u32, slot: u64, total_ops: u64, latencies_ms: Vec<f64>, duration_s: f64| {
         let (p50_ms, p99_ms) = measure::percentiles_ms(latencies_ms);
         measure::ResultRow {
             access_path: "pkcs11-direct",
@@ -480,6 +532,8 @@ fn run_instance(cli: &Cli) -> Result<()> {
             instances: topology_instances,
             instance_id: this_instance_id,
             tenants: tenants.len() as u32,
+            tenant_index,
+            slot,
             threads: cli.threads,
             category, algorithm, security_level, op,
             ops_per_sec: total_ops as f64 / duration_s,
@@ -488,125 +542,146 @@ fn run_instance(cli: &Cli) -> Result<()> {
         }
     };
     let stdout = std::io::stdout();
-    let emit = |op: &'static str, category: &'static str, algorithm: &'static str, security_level: &'static str, total_ops: u64, latencies_ms: Vec<f64>, duration_s: f64| -> Result<()> {
-        let row = common(op, category, algorithm, security_level, total_ops, latencies_ms, duration_s);
-        eprintln!("[ok] measured {}/{}: {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.ops_per_sec, row.duration_s, row.total_ops);
+    #[allow(clippy::too_many_arguments)]
+    let emit = |op: &'static str, category: &'static str, algorithm: &'static str, security_level: &'static str, tenant_index: u32, slot: u64, total_ops: u64, latencies_ms: Vec<f64>, duration_s: f64| -> Result<()> {
+        let row = common(op, category, algorithm, security_level, tenant_index, slot, total_ops, latencies_ms, duration_s);
+        eprintln!("[ok] measured {}/{} (tenant {} slot {}): {:.0} ops/sec over {:.2}s ({} ops)", row.algorithm, row.op, row.tenant_index, row.slot, row.ops_per_sec, row.duration_s, row.total_ops);
         serde_json::to_writer(&stdout, &row)?;
         println!();
         Ok(())
     };
 
-    // keygen — one real sample per tenant (2 total), NOT a hot loop:
-    // these are the SAME `C_GenerateKeyPair` calls `provision_tenant`
-    // already had to make, timed in place — no extra calls made just to
+    // keygen — one real sample per tenant, NOT a hot loop: this is the
+    // SAME `C_GenerateKeyPair` call `provision_tenant` already had to
+    // make for that tenant, timed in place — no extra calls made just to
     // produce this row, and every sign/verify/derive/encapsulate/
     // decapsulate closure below still excludes keygen entirely (§A7).
-    // `duration_s` here is the sum of the 2 real samples' wall-clock
-    // time, not a fixed measurement window like the other rows.
-    let emit_keygen = |category: &'static str, name: &'static str, security_level: &'static str| -> Result<()> {
-        let latencies_ms = vec![alice_keygen_ms[name], bob_keygen_ms[name]];
-        let duration_s = (latencies_ms.iter().sum::<f64>() / 1000.0).max(1e-9);
-        emit("keygen", category, name, security_level, latencies_ms.len() as u64, latencies_ms, duration_s)
+    // One row per tenant now (previously one row pooling both tenants'
+    // 2 samples together) — matches the per-tenant model the rest of
+    // this loop uses, and is more natural besides: each tenant's own
+    // real keygen sample stands on its own instead of being averaged
+    // with a different tenant's.
+    let emit_keygen = |category: &'static str, name: &'static str, security_level: &'static str, tenant_index: u32, slot: u64, latency_ms: f64| -> Result<()> {
+        let duration_s = (latency_ms / 1000.0).max(1e-9);
+        emit("keygen", category, name, security_level, tenant_index, slot, 1, vec![latency_ms], duration_s)
     };
     for algo in &sig_algos {
-        emit_keygen("signature", algo.name, algo.security_level)?;
+        emit_keygen("signature", algo.name, algo.security_level, 0, alice.slot as u64, alice_keygen_ms[algo.name])?;
+        emit_keygen("signature", algo.name, algo.security_level, 1, bob.slot as u64, bob_keygen_ms[algo.name])?;
     }
     for algo in &kex_algos {
-        emit_keygen("key_establishment", algo.name, algo.security_level)?;
+        emit_keygen("key_establishment", algo.name, algo.security_level, 0, alice.slot as u64, alice_keygen_ms[algo.name])?;
+        emit_keygen("key_establishment", algo.name, algo.security_level, 1, bob.slot as u64, bob_keygen_ms[algo.name])?;
     }
     for algo in &kem_algos {
-        emit_keygen("key_establishment", algo.name, algo.security_level)?;
+        emit_keygen("key_establishment", algo.name, algo.security_level, 0, alice.slot as u64, alice_keygen_ms[algo.name])?;
+        emit_keygen("key_establishment", algo.name, algo.security_level, 1, bob.slot as u64, bob_keygen_ms[algo.name])?;
     }
 
-    // sign + verify, every signature algorithm
+    // sign + verify, every signature algorithm, per tenant
     for algo in &sig_algos {
-        {
-            let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
-                let engine = Arc::clone(&engine);
-                let priv_handle = tenants[idx].sig[algo.name].priv_handle;
-                let mechanism = algo.sign_mechanism;
-                let message = format!("hsm-perf-bench measured sign {} — tenant {idx}", algo.name).into_bytes();
-                move || -> Result<()> {
-                    engine.sign_init(session, mechanism, priv_handle)?;
-                    engine.sign(session, &message)?;
-                    Ok(())
-                }
-            }).collect();
-            let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
-            emit("sign", "signature", algo.name, algo.security_level, total_ops, latencies_ms, duration_s)?;
-        }
-        // verify — each worker signs ONE message once (setup, unmeasured)
-        // then the timed loop repeatedly verifies that same signature,
-        // exercising the real C_VerifyInit/C_Verify path only.
-        {
-            let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
-                let engine = Arc::clone(&engine);
-                let material = &tenants[idx].sig[algo.name];
-                let (priv_handle, pub_handle) = (material.priv_handle, material.pub_handle);
-                let mechanism = algo.sign_mechanism;
-                let message = format!("hsm-perf-bench measured verify {} — tenant {idx}", algo.name).into_bytes();
-                engine.sign_init(session, mechanism, priv_handle)?;
-                let signature = engine.sign(session, &message)?;
-                Ok::<_, anyhow::Error>(move || -> Result<()> {
-                    engine.verify_init(session, mechanism, pub_handle)?;
-                    engine.verify(session, &message, &signature)?;
-                    Ok(())
-                })
-            }).collect::<Result<Vec<_>>>()?;
-            let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
-            emit("verify", "signature", algo.name, algo.security_level, total_ops, latencies_ms, duration_s)?;
-        }
-    }
-
-    // derive, every key-agreement algorithm
-    for algo in &kex_algos {
-        let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
-            let engine = Arc::clone(&engine);
-            let priv_handle = tenants[idx].kex[algo.name].priv_handle;
-            let mut peer_point = tenants[idx].kex[algo.name].peer_point.clone();
-            move || -> Result<()> {
-                engine.ecdh1_derive(session, priv_handle, &mut peer_point)?;
-                Ok(())
+        for (tenant_index, tenant) in tenants.iter().enumerate() {
+            let tenant_index = tenant_index as u32;
+            let slot = tenant.slot as u64;
+            {
+                let workers: Vec<_> = worker_sessions_by_tenant[tenant_index as usize].iter().map(|&session| {
+                    let engine = Arc::clone(&engine);
+                    let priv_handle = tenant.sig[algo.name].priv_handle;
+                    let mechanism = algo.sign_mechanism;
+                    let message = format!("hsm-perf-bench measured sign {} — tenant {tenant_index}", algo.name).into_bytes();
+                    move || -> Result<()> {
+                        engine.sign_init(session, mechanism, priv_handle)?;
+                        engine.sign(session, &message)?;
+                        Ok(())
+                    }
+                }).collect();
+                let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+                emit("sign", "signature", algo.name, algo.security_level, tenant_index, slot, total_ops, latencies_ms, duration_s)?;
             }
-        }).collect();
-        let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
-        emit("derive", "key_establishment", algo.name, algo.security_level, total_ops, latencies_ms, duration_s)?;
+            // verify — each worker signs ONE message once (setup,
+            // unmeasured) then the timed loop repeatedly verifies that
+            // same signature, exercising the real C_VerifyInit/C_Verify
+            // path only.
+            {
+                let workers: Vec<_> = worker_sessions_by_tenant[tenant_index as usize].iter().map(|&session| {
+                    let engine = Arc::clone(&engine);
+                    let material = &tenant.sig[algo.name];
+                    let (priv_handle, pub_handle) = (material.priv_handle, material.pub_handle);
+                    let mechanism = algo.sign_mechanism;
+                    let message = format!("hsm-perf-bench measured verify {} — tenant {tenant_index}", algo.name).into_bytes();
+                    engine.sign_init(session, mechanism, priv_handle)?;
+                    let signature = engine.sign(session, &message)?;
+                    Ok::<_, anyhow::Error>(move || -> Result<()> {
+                        engine.verify_init(session, mechanism, pub_handle)?;
+                        engine.verify(session, &message, &signature)?;
+                        Ok(())
+                    })
+                }).collect::<Result<Vec<_>>>()?;
+                let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+                emit("verify", "signature", algo.name, algo.security_level, tenant_index, slot, total_ops, latencies_ms, duration_s)?;
+            }
+        }
     }
 
-    // encapsulate + decapsulate, every KEM
+    // derive, every key-agreement algorithm, per tenant
+    for algo in &kex_algos {
+        for (tenant_index, tenant) in tenants.iter().enumerate() {
+            let tenant_index = tenant_index as u32;
+            let slot = tenant.slot as u64;
+            let workers: Vec<_> = worker_sessions_by_tenant[tenant_index as usize].iter().map(|&session| {
+                let engine = Arc::clone(&engine);
+                let priv_handle = tenant.kex[algo.name].priv_handle;
+                let mut peer_point = tenant.kex[algo.name].peer_point.clone();
+                move || -> Result<()> {
+                    engine.ecdh1_derive(session, priv_handle, &mut peer_point)?;
+                    Ok(())
+                }
+            }).collect();
+            let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+            emit("derive", "key_establishment", algo.name, algo.security_level, tenant_index, slot, total_ops, latencies_ms, duration_s)?;
+        }
+    }
+
+    // encapsulate + decapsulate, every KEM, per tenant
     for algo in &kem_algos {
-        {
-            let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
-                let engine = Arc::clone(&engine);
-                let kem_pub = tenants[idx].kem[algo.name].pub_handle;
-                let mechanism = algo.kem_mechanism;
-                move || -> Result<()> {
-                    engine.encapsulate_key(session, mechanism, kem_pub, &mut [])?;
-                    Ok(())
-                }
-            }).collect();
-            let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
-            emit("encapsulate", "key_establishment", algo.name, algo.security_level, total_ops, latencies_ms, duration_s)?;
-        }
-        {
-            let workers: Vec<_> = worker_sessions.iter().map(|&(session, idx)| {
-                let engine = Arc::clone(&engine);
-                let material = &tenants[idx].kem[algo.name];
-                let kem_priv = material.priv_handle;
-                let ciphertext = material.ciphertext.clone();
-                let mechanism = algo.kem_mechanism;
-                move || -> Result<()> {
-                    engine.decapsulate_key(session, mechanism, kem_priv, &ciphertext, &mut [])?;
-                    Ok(())
-                }
-            }).collect();
-            let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
-            emit("decapsulate", "key_establishment", algo.name, algo.security_level, total_ops, latencies_ms, duration_s)?;
+        for (tenant_index, tenant) in tenants.iter().enumerate() {
+            let tenant_index = tenant_index as u32;
+            let slot = tenant.slot as u64;
+            {
+                let workers: Vec<_> = worker_sessions_by_tenant[tenant_index as usize].iter().map(|&session| {
+                    let engine = Arc::clone(&engine);
+                    let kem_pub = tenant.kem[algo.name].pub_handle;
+                    let mechanism = algo.kem_mechanism;
+                    move || -> Result<()> {
+                        engine.encapsulate_key(session, mechanism, kem_pub, &mut [])?;
+                        Ok(())
+                    }
+                }).collect();
+                let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+                emit("encapsulate", "key_establishment", algo.name, algo.security_level, tenant_index, slot, total_ops, latencies_ms, duration_s)?;
+            }
+            {
+                let workers: Vec<_> = worker_sessions_by_tenant[tenant_index as usize].iter().map(|&session| {
+                    let engine = Arc::clone(&engine);
+                    let material = &tenant.kem[algo.name];
+                    let kem_priv = material.priv_handle;
+                    let ciphertext = material.ciphertext.clone();
+                    let mechanism = algo.kem_mechanism;
+                    move || -> Result<()> {
+                        engine.decapsulate_key(session, mechanism, kem_priv, &ciphertext, &mut [])?;
+                        Ok(())
+                    }
+                }).collect();
+                let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+                emit("decapsulate", "key_establishment", algo.name, algo.security_level, tenant_index, slot, total_ops, latencies_ms, duration_s)?;
+            }
         }
     }
 
-    for (session, _) in worker_sessions {
-        engine.close_session(session).context("C_CloseSession (worker)")?;
+    for sessions in worker_sessions_by_tenant {
+        for session in sessions {
+            engine.close_session(session).context("C_CloseSession (worker)")?;
+        }
     }
     engine.close_session(alice.session).context("C_CloseSession (alice)")?;
     engine.close_session(bob.session).context("C_CloseSession (bob)")?;

--- a/rust/bench-harness/src/main.rs
+++ b/rust/bench-harness/src/main.rs
@@ -170,6 +170,12 @@ struct Tenant {
     sig: HashMap<&'static str, SigMaterial>,
     kex: HashMap<&'static str, KexMaterial>,
     kem: HashMap<&'static str, KemMaterial>,
+    // Keyed by EncAlgo.name, not SignatureAlgo.name — even when the
+    // handles are reused from `sig` (the common case), this map still
+    // needs its OWN entries so lookups by the enc algorithm's own name
+    // work. Reuses SigMaterial's shape (just a pub/priv keypair) rather
+    // than a near-identical duplicate struct.
+    enc: HashMap<&'static str, SigMaterial>,
 }
 
 /// Claim the next free slot (standard §5.4 `C_GetSlotList` auto-replenish
@@ -194,6 +200,7 @@ fn provision_tenant(
     sig_algos: &[algos::SignatureAlgo],
     kex_algos: &[algos::KeyAgreementAlgo],
     kem_algos: &[algos::KemAlgo],
+    enc_algos: &[algos::EncAlgo],
 ) -> Result<(Tenant, HashMap<&'static str, f64>)> {
     let slots_before = engine.get_slot_list().context("C_GetSlotList")?;
     let slot = *slots_before
@@ -260,7 +267,37 @@ fn provision_tenant(
         kem.insert(algo.name, KemMaterial { pub_handle, priv_handle, ciphertext });
     }
 
-    Ok((Tenant { slot, session, sig, kex, kem }, keygen_ms))
+    let mut enc = HashMap::new();
+    for algo in enc_algos {
+        // Reuse the matching RSA-PSS keypair when it was ALSO provisioned
+        // for this run (the common case, and the whole point of this
+        // reuse — see EncAlgo's doc comment); otherwise fall back to an
+        // independent keygen (only reachable if a run selects an EncAlgo
+        // without its matching SignatureAlgo, e.g. `--algorithms
+        // RSA-OAEP-2048` alone). No `keygen_ms` entry in the fallback
+        // case — RSA-OAEP has no dedicated "keygen" cell (see
+        // list_algorithms()); when the reuse path is taken, the keypair's
+        // real cost is already reported under its RSA-PSS entry's own
+        // keygen row, so reporting it again here would double-count it.
+        let (pub_handle, priv_handle) = if let Some(shared) = sig.get(algo.sig_algo_name) {
+            (shared.pub_handle, shared.priv_handle)
+        } else {
+            engine
+                .generate_key_pair_with_param(session, algo.keygen_mechanism, algo.keygen_param)
+                .with_context(|| format!("C_GenerateKeyPair({}, tenant={name})", algo.name))?
+        };
+        // Self-contained sanity: encrypt+decrypt round-trip with this
+        // tenant's own key.
+        let message = format!("hsm-perf-bench harness proof — {} — tenant {name}", algo.name).into_bytes();
+        engine.encrypt_init(session, algo.encrypt_mechanism, pub_handle).with_context(|| format!("C_EncryptInit({})", algo.name))?;
+        let ciphertext = engine.encrypt(session, &message).with_context(|| format!("C_Encrypt({})", algo.name))?;
+        engine.decrypt_init(session, algo.encrypt_mechanism, priv_handle).with_context(|| format!("C_DecryptInit({})", algo.name))?;
+        let recovered = engine.decrypt(session, &ciphertext).with_context(|| format!("C_Decrypt({})", algo.name))?;
+        assert_eq!(recovered, message, "tenant {name}'s {} decrypt must recover the original plaintext", algo.name);
+        enc.insert(algo.name, SigMaterial { pub_handle, priv_handle });
+    }
+
+    Ok((Tenant { slot, session, sig, kex, kem, enc }, keygen_ms))
 }
 
 fn main() -> Result<()> {
@@ -300,7 +337,10 @@ fn list_algorithms(cli: &Cli) -> Result<()> {
     let kem_algos: Vec<algos::KemAlgo> = algos::KEM_ALGOS.iter().copied()
         .filter(|a| algo_allowed(a.name, &selected))
         .collect();
-    if sig_algos.is_empty() && kex_algos.is_empty() && kem_algos.is_empty() {
+    let enc_algos: Vec<algos::EncAlgo> = algos::ENC_ALGOS.iter().copied()
+        .filter(|a| algo_allowed(a.name, &selected))
+        .collect();
+    if sig_algos.is_empty() && kex_algos.is_empty() && kem_algos.is_empty() && enc_algos.is_empty() {
         bail!("--algorithms matched no known algorithm: {:?}", cli.algorithms);
     }
 
@@ -317,6 +357,14 @@ fn list_algorithms(cli: &Cli) -> Result<()> {
     }
     for algo in &kem_algos {
         for op in ["keygen", "encapsulate", "decapsulate"] {
+            cells.push(AlgoCell { category: "key_establishment", algorithm: algo.name, security_level: algo.security_level, op });
+        }
+    }
+    // No "keygen" op here — RSA-OAEP's keypair is normally reused from its
+    // matching RSA-PSS entry (see EncAlgo's doc comment in algos.rs), so
+    // there's no dedicated keygen cost to report as its own cell.
+    for algo in &enc_algos {
+        for op in ["encrypt", "decrypt"] {
             cells.push(AlgoCell { category: "key_establishment", algorithm: algo.name, security_level: algo.security_level, op });
         }
     }
@@ -439,7 +487,10 @@ fn run_instance(cli: &Cli) -> Result<()> {
     let kem_algos: Vec<algos::KemAlgo> = algos::KEM_ALGOS.iter().copied()
         .filter(|a| algo_allowed(a.name, &selected))
         .collect();
-    if sig_algos.is_empty() && kex_algos.is_empty() && kem_algos.is_empty() {
+    let enc_algos: Vec<algos::EncAlgo> = algos::ENC_ALGOS.iter().copied()
+        .filter(|a| algo_allowed(a.name, &selected))
+        .collect();
+    if sig_algos.is_empty() && kex_algos.is_empty() && kem_algos.is_empty() && enc_algos.is_empty() {
         bail!("--algorithms matched no known algorithm: {:?}", cli.algorithms);
     }
 
@@ -447,15 +498,15 @@ fn run_instance(cli: &Cli) -> Result<()> {
     engine.initialize().context("C_Initialize")?;
     eprintln!("[ok] engine initialized: {}", cli.library);
     eprintln!(
-        "[ok] algorithm matrix: {} signature, {} key-agreement, {} KEM ({})",
-        sig_algos.len(), kex_algos.len(), kem_algos.len(),
+        "[ok] algorithm matrix: {} signature, {} key-agreement, {} KEM, {} key-transport ({})",
+        sig_algos.len(), kex_algos.len(), kem_algos.len(), enc_algos.len(),
         if cli.include_slow { "including slow algorithms" } else { "slow algorithms excluded, pass --include-slow to add them" }
     );
 
     // ── Two tenants, two real tokens, standard PKCS#11 v3.2 calls only. ─
-    let (mut alice, alice_keygen_ms) = provision_tenant(&engine, "alice", &sig_algos, &kex_algos, &kem_algos)?;
+    let (mut alice, alice_keygen_ms) = provision_tenant(&engine, "alice", &sig_algos, &kex_algos, &kem_algos, &enc_algos)?;
     eprintln!("[ok] alice bootstrapped on slot {}: session={}", alice.slot, alice.session);
-    let (mut bob, bob_keygen_ms) = provision_tenant(&engine, "bob", &sig_algos, &kex_algos, &kem_algos)?;
+    let (mut bob, bob_keygen_ms) = provision_tenant(&engine, "bob", &sig_algos, &kex_algos, &kem_algos, &enc_algos)?;
     eprintln!("[ok] bob bootstrapped on slot {}: session={}", bob.slot, bob.session);
     assert_ne!(alice.slot, bob.slot, "each tenant must land on its own slot");
     eprintln!("[ok] alice and bob each have their own token and full key material, every algorithm's own sign/verify or encap/decap round-trip verified");
@@ -739,6 +790,55 @@ fn run_instance(cli: &Cli) -> Result<()> {
                 }).collect();
                 let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
                 emit("decapsulate", "key_establishment", algo.name, algo.security_level, tenant_index, slot, total_ops, latencies_ms, duration_s)?;
+            }
+        }
+    }
+
+    // encrypt + decrypt, every RSA-OAEP key-transport algorithm, per
+    // tenant — same shape as encapsulate/decapsulate above, just
+    // C_Encrypt/C_Decrypt instead of C_EncapsulateKey/C_DecapsulateKey.
+    // No keygen row: see EncAlgo's doc comment (algos.rs) and
+    // list_algorithms() above for why.
+    for algo in &enc_algos {
+        for (tenant_index, tenant) in tenants.iter().enumerate() {
+            let tenant_index = tenant_index as u32;
+            let slot = tenant.slot as u64;
+            {
+                let workers: Vec<_> = worker_sessions_by_tenant[tenant_index as usize].iter().map(|&session| {
+                    let engine = Arc::clone(&engine);
+                    let pub_handle = tenant.enc[algo.name].pub_handle;
+                    let mechanism = algo.encrypt_mechanism;
+                    let message = format!("hsm-perf-bench measured encrypt {} — tenant {tenant_index}", algo.name).into_bytes();
+                    move || -> Result<()> {
+                        engine.encrypt_init(session, mechanism, pub_handle)?;
+                        engine.encrypt(session, &message)?;
+                        Ok(())
+                    }
+                }).collect();
+                let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+                emit("encrypt", "key_establishment", algo.name, algo.security_level, tenant_index, slot, total_ops, latencies_ms, duration_s)?;
+            }
+            // decrypt — each worker encrypts ONE message once (setup,
+            // unmeasured) then the timed loop repeatedly decrypts that
+            // same ciphertext, exercising the real C_DecryptInit/C_Decrypt
+            // path only (same pattern as the `verify` block above).
+            {
+                let workers: Vec<_> = worker_sessions_by_tenant[tenant_index as usize].iter().map(|&session| {
+                    let engine = Arc::clone(&engine);
+                    let material = &tenant.enc[algo.name];
+                    let (pub_handle, priv_handle) = (material.pub_handle, material.priv_handle);
+                    let mechanism = algo.encrypt_mechanism;
+                    let message = format!("hsm-perf-bench measured decrypt {} — tenant {tenant_index}", algo.name).into_bytes();
+                    engine.encrypt_init(session, mechanism, pub_handle)?;
+                    let ciphertext = engine.encrypt(session, &message)?;
+                    Ok::<_, anyhow::Error>(move || -> Result<()> {
+                        engine.decrypt_init(session, mechanism, priv_handle)?;
+                        engine.decrypt(session, &ciphertext)?;
+                        Ok(())
+                    })
+                }).collect::<Result<Vec<_>>>()?;
+                let (total_ops, latencies_ms, duration_s) = measure::run_point(cli.duration_secs, cli.warmup_secs, workers)?;
+                emit("decrypt", "key_establishment", algo.name, algo.security_level, tenant_index, slot, total_ops, latencies_ms, duration_s)?;
             }
         }
     }

--- a/rust/bench-harness/src/main.rs
+++ b/rust/bench-harness/src/main.rs
@@ -462,48 +462,65 @@ fn run_instance(cli: &Cli) -> Result<()> {
 
     // ── Cross-tenant isolation, proven with a real PKCS#11 v3.2 error
     // code — not asserted, not assumed. Bob's session attempting to sign
-    // with ALICE's private-key handle (Ed25519, guaranteed present in
-    // every matrix configuration) must fail: her handle is not
-    // visible/usable from his session's token scope. §6.3.2/§6.3.3
-    // (SignInit/Sign) list CKR_KEY_HANDLE_INVALID for exactly this case;
-    // this engine's own object-handle validation (`can_access_object`,
-    // hardened across this whole tenancy effort) may also surface the
-    // more general CKR_OBJECT_HANDLE_INVALID — both are spec-defined,
-    // and either is an honest "no", so both are accepted here. ─────────
-    let alice_ed25519_priv = alice.sig[algos::ED25519.name].priv_handle;
-    let bob_ed25519 = &bob.sig[algos::ED25519.name];
-    let cross_tenant_result = engine.sign_init(bob.session, algos::ED25519.sign_mechanism, alice_ed25519_priv);
-    match cross_tenant_result {
-        Ok(()) => {
-            panic!(
-                "SECURITY REGRESSION: Bob's session (slot {}) could SignInit with \
-                 Alice's private key handle {alice_ed25519_priv} (her slot {}) — cross-tenant isolation failed",
-                bob.slot, alice.slot
-            );
+    // with ALICE's private-key handle (using whichever signature
+    // algorithm this run's --algorithms selection actually includes) must
+    // fail: her handle is not visible/usable from his session's token
+    // scope. §6.3.2/§6.3.3 (SignInit/Sign) list CKR_KEY_HANDLE_INVALID for
+    // exactly this case; this engine's own object-handle validation
+    // (`can_access_object`, hardened across this whole tenancy effort)
+    // may also surface the more general CKR_OBJECT_HANDLE_INVALID — both
+    // are spec-defined, and either is an honest "no", so both are
+    // accepted here. ─────────────────────────────────────────────────
+    // Used to hardcode algos::ED25519 on the assumption it was
+    // "guaranteed present in every matrix configuration" — true when the
+    // only matrix-shaping toggle was --include-slow, false once
+    // --algorithms could restrict the run to an arbitrary subset.
+    // Confirmed live: an --algorithms ML-DSA-44,ML-DSA-65,ML-DSA-87
+    // selection panicked here ("no entry found for key") since alice's
+    // .sig map never had an "Ed25519" entry to begin with. Probing with
+    // whichever signature algorithm actually got provisioned fixes this
+    // for any signature-only selection; a selection with NO signature
+    // algorithm at all (pure key-establishment) has no natural probe for
+    // THIS specific check, so it's skipped with a clearly-logged reason
+    // rather than silently claimed as verified.
+    if let Some(probe) = sig_algos.first() {
+        let alice_probe_priv = alice.sig[probe.name].priv_handle;
+        let bob_probe = &bob.sig[probe.name];
+        let cross_tenant_result = engine.sign_init(bob.session, probe.sign_mechanism, alice_probe_priv);
+        match cross_tenant_result {
+            Ok(()) => {
+                panic!(
+                    "SECURITY REGRESSION: Bob's session (slot {}) could SignInit with \
+                     Alice's private key handle {alice_probe_priv} (her slot {}) — cross-tenant isolation failed",
+                    bob.slot, alice.slot
+                );
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                let is_expected = msg.contains(&format!("0x{CKR_KEY_HANDLE_INVALID:x}"))
+                    || msg.contains(&format!("0x{CKR_OBJECT_HANDLE_INVALID:x}"));
+                assert!(
+                    is_expected,
+                    "expected CKR_KEY_HANDLE_INVALID (0x{CKR_KEY_HANDLE_INVALID:x}) or \
+                     CKR_OBJECT_HANDLE_INVALID (0x{CKR_OBJECT_HANDLE_INVALID:x}), got: {msg}"
+                );
+                eprintln!("[ok] cross-tenant isolation verified via {}: Bob cannot use Alice's key handle ({msg})", probe.name);
+            }
         }
-        Err(e) => {
-            let msg = e.to_string();
-            let is_expected = msg.contains(&format!("0x{CKR_KEY_HANDLE_INVALID:x}"))
-                || msg.contains(&format!("0x{CKR_OBJECT_HANDLE_INVALID:x}"));
-            assert!(
-                is_expected,
-                "expected CKR_KEY_HANDLE_INVALID (0x{CKR_KEY_HANDLE_INVALID:x}) or \
-                 CKR_OBJECT_HANDLE_INVALID (0x{CKR_OBJECT_HANDLE_INVALID:x}), got: {msg}"
-            );
-            eprintln!("[ok] cross-tenant isolation verified: Bob cannot use Alice's key handle ({msg})");
-        }
-    }
 
-    // Bob's OWN key still works after the rejected cross-tenant attempt —
-    // proves the isolation check is a real gate, not a session-poisoning
-    // side effect.
-    let message = b"bob signs after the rejected cross-tenant attempt";
-    engine.sign_init(bob.session, algos::ED25519.sign_mechanism, bob_ed25519.priv_handle).context("C_SignInit (bob, post-check)")?;
-    let sig = engine.sign(bob.session, message).context("C_Sign (bob, post-check)")?;
-    engine.verify_init(bob.session, algos::ED25519.sign_mechanism, bob_ed25519.pub_handle).context("C_VerifyInit (bob, post-check)")?;
-    let valid = engine.verify(bob.session, message, &sig).context("C_Verify (bob, post-check)")?;
-    assert!(valid, "bob's own key must still work after the rejected cross-tenant attempt");
-    eprintln!("[ok] bob's own key still works after the rejected cross-tenant attempt — real gate, not a blanket deny");
+        // Bob's OWN key still works after the rejected cross-tenant
+        // attempt — proves the isolation check is a real gate, not a
+        // session-poisoning side effect.
+        let message = b"bob signs after the rejected cross-tenant attempt";
+        engine.sign_init(bob.session, probe.sign_mechanism, bob_probe.priv_handle).context("C_SignInit (bob, post-check)")?;
+        let sig = engine.sign(bob.session, message).context("C_Sign (bob, post-check)")?;
+        engine.verify_init(bob.session, probe.sign_mechanism, bob_probe.pub_handle).context("C_VerifyInit (bob, post-check)")?;
+        let valid = engine.verify(bob.session, message, &sig).context("C_Verify (bob, post-check)")?;
+        assert!(valid, "bob's own key must still work after the rejected cross-tenant attempt");
+        eprintln!("[ok] bob's own key still works after the rejected cross-tenant attempt — real gate, not a blanket deny");
+    } else {
+        eprintln!("[ok] cross-tenant isolation sign-based check skipped — no signature algorithm in this run's --algorithms selection to probe with (key-establishment-only run)");
+    }
 
     // ── ECDH-derive category, every key-agreement algorithm — genuine
     // two-party key agreement across alice's and bob's SEPARATE tokens,

--- a/rust/bench-harness/src/main.rs
+++ b/rust/bench-harness/src/main.rs
@@ -107,6 +107,14 @@ struct Cli {
     /// on the child's own invocation). Not meant to be set by hand.
     #[arg(long, hide = true)]
     topology_instances: Option<u32>,
+    /// INTERNAL — set by the parent orchestrator alongside
+    /// `--topology-instances`, distinct value per child (0..N), so each
+    /// child's rows are individually attributable instead of all N
+    /// children's rows carrying the same bare instance COUNT with no way
+    /// to tell which instance produced which row. Not meant to be set by
+    /// hand.
+    #[arg(long, hide = true)]
+    instance_id: Option<u32>,
 }
 
 struct SigMaterial {
@@ -308,7 +316,8 @@ fn run_parent(cli: &Cli) -> Result<()> {
             .arg("--duration-secs").arg(cli.duration_secs.to_string())
             .arg("--warmup-secs").arg(cli.warmup_secs.to_string())
             .arg("--instances").arg("1")
-            .arg("--topology-instances").arg(cli.instances.to_string());
+            .arg("--topology-instances").arg(cli.instances.to_string())
+            .arg("--instance-id").arg(instance_id.to_string());
         if cli.include_slow {
             cmd.arg("--include-slow");
         }
@@ -338,6 +347,11 @@ fn run_instance(cli: &Cli) -> Result<()> {
         Some(n) => ("independent-n-instances", n),
         None => ("shared-1-instance", 1),
     };
+    // §1 of the telemetry plan: this instance's OWN identity within the
+    // topology (0..topology_instances), set by the parent orchestrator
+    // alongside --topology-instances. Always 0 under shared-1-instance
+    // (there's only ever one instance to be).
+    let this_instance_id = cli.instance_id.unwrap_or(0);
 
     let sig_algos: Vec<algos::SignatureAlgo> = algos::SIGNATURE_ALGOS.iter().copied().filter(|a| cli.include_slow || !a.slow).collect();
     let kex_algos: Vec<algos::KeyAgreementAlgo> = algos::KEY_AGREEMENT_ALGOS.to_vec();
@@ -464,6 +478,7 @@ fn run_instance(cli: &Cli) -> Result<()> {
             access_path: "pkcs11-direct",
             topology,
             instances: topology_instances,
+            instance_id: this_instance_id,
             tenants: tenants.len() as u32,
             threads: cli.threads,
             category, algorithm, security_level, op,

--- a/rust/bench-harness/src/main.rs
+++ b/rust/bench-harness/src/main.rs
@@ -1,0 +1,139 @@
+//! hsm-perf-bench harness — pkcs11-direct mode (plan §A4.1/§P4).
+//!
+//! Proves the harness mechanism end to end against the REAL engine,
+//! through the REAL dlopen'd C ABI, before any threading/JSONL/algorithm-
+//! matrix complexity is added: load the library, bootstrap two SEPARATE
+//! tenant tokens via nothing but standard PKCS#11 v3.2 operations
+//! (`C_GetSlotList`/`C_InitToken`/`C_OpenSession`/`C_Login`/`C_InitPIN`/
+//! `C_Logout`/`C_CloseSession` — no vendor extensions), generate a real
+//! Ed25519 key pair per tenant, sign, verify, and prove cross-tenant
+//! isolation with a real spec-defined error code, not an assumption.
+
+mod algos;
+mod pkcs11;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use pkcs11::Engine;
+use softhsmrustv3::ck_abi::{CK_OBJECT_HANDLE, CK_SLOT_ID};
+use softhsmrustv3::constants::{CKR_KEY_HANDLE_INVALID, CKR_OBJECT_HANDLE_INVALID};
+
+#[derive(Parser, Debug)]
+#[command(name = "bench-harness", about = "hsm-perf-bench PKCS#11-direct measurement harness")]
+struct Cli {
+    /// Path to the compiled softhsmrustv3 shared library.
+    #[arg(long, default_value = "../target/release/libsofthsmrustv3.dylib")]
+    library: String,
+}
+
+/// One tenant's bootstrapped token + a real Ed25519 key pair on it,
+/// signed and verified once as a per-tenant sanity check.
+struct Tenant {
+    slot: CK_SLOT_ID,
+    session: softhsmrustv3::ck_abi::CK_SESSION_HANDLE,
+    pub_handle: CK_OBJECT_HANDLE,
+    priv_handle: CK_OBJECT_HANDLE,
+}
+
+/// Claim the next free slot (standard §5.4 `C_GetSlotList` auto-replenish
+/// — see `pkcs11.rs::get_slot_list`'s doc comment) and bring up a real
+/// token + Ed25519 key pair on it, per-tenant PINs so each tenant's token
+/// stays independently openable (matching the KMIP server's own
+/// per-tenant-PIN tenancy model).
+fn provision_tenant(engine: &Engine, name: &str) -> Result<Tenant> {
+    let slots_before = engine.get_slot_list().context("C_GetSlotList")?;
+    let slot = *slots_before
+        .last()
+        .expect("engine always reports at least one slot (§5.4 auto-replenish)");
+
+    let session = engine
+        .bootstrap_token(slot, &format!("so-pin-{name}"), &format!("user-pin-{name}"), &format!("bench-{name}"))
+        .with_context(|| format!("bootstrap_token(slot={slot}, tenant={name})"))?;
+
+    let algo = algos::ED25519;
+    let (pub_handle, priv_handle) = engine
+        .generate_key_pair(session, algo.keygen_mechanism, &mut [], &mut [])
+        .with_context(|| format!("C_GenerateKeyPair(tenant={name})"))?;
+
+    // Per-tenant sanity: this tenant's own key round-trips correctly.
+    let message = format!("hsm-perf-bench harness proof — tenant {name}").into_bytes();
+    engine.sign_init(session, algo.sign_mechanism, priv_handle).context("C_SignInit")?;
+    let signature = engine.sign(session, &message).context("C_Sign")?;
+    engine.verify_init(session, algo.sign_mechanism, pub_handle).context("C_VerifyInit")?;
+    let valid = engine.verify(session, &message, &signature).context("C_Verify")?;
+    assert!(valid, "tenant {name}'s own signature must verify");
+
+    Ok(Tenant { slot, session, pub_handle, priv_handle })
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    let engine = Engine::load(&cli.library).with_context(|| format!("loading engine library at {:?}", cli.library))?;
+    engine.initialize().context("C_Initialize")?;
+    eprintln!("[ok] engine initialized: {}", cli.library);
+
+    // ── Two tenants, two real tokens, real Ed25519 keys, standard PKCS#11
+    // v3.2 calls only. ──────────────────────────────────────────────────
+    let alice = provision_tenant(&engine, "alice")?;
+    eprintln!(
+        "[ok] alice bootstrapped on slot {}: session={} pub={} priv={}",
+        alice.slot, alice.session, alice.pub_handle, alice.priv_handle
+    );
+    let bob = provision_tenant(&engine, "bob")?;
+    eprintln!(
+        "[ok] bob bootstrapped on slot {}: session={} pub={} priv={}",
+        bob.slot, bob.session, bob.pub_handle, bob.priv_handle
+    );
+    assert_ne!(alice.slot, bob.slot, "each tenant must land on its own slot");
+    eprintln!("[ok] alice and bob each have their own token, own key pair, own signature round-trip");
+
+    // ── Cross-tenant isolation, proven with a real PKCS#11 v3.2 error
+    // code — not asserted, not assumed. Bob's session attempting to sign
+    // with ALICE's private-key handle must fail: her handle is not
+    // visible/usable from his session's token scope. §6.3.2/§6.3.3
+    // (SignInit/Sign) list CKR_KEY_HANDLE_INVALID for exactly this case;
+    // this engine's own object-handle validation (`can_access_object`,
+    // hardened across this whole tenancy effort) may also surface the
+    // more general CKR_OBJECT_HANDLE_INVALID — both are spec-defined,
+    // and either is an honest "no", so both are accepted here. ─────────
+    let cross_tenant_result = engine.sign_init(bob.session, algos::ED25519.sign_mechanism, alice.priv_handle);
+    match cross_tenant_result {
+        Ok(()) => {
+            panic!(
+                "SECURITY REGRESSION: Bob's session (slot {}) could SignInit with \
+                 Alice's private key handle {} (her slot {}) — cross-tenant isolation failed",
+                bob.slot, alice.priv_handle, alice.slot
+            );
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            let is_expected = msg.contains(&format!("0x{CKR_KEY_HANDLE_INVALID:x}"))
+                || msg.contains(&format!("0x{CKR_OBJECT_HANDLE_INVALID:x}"));
+            assert!(
+                is_expected,
+                "expected CKR_KEY_HANDLE_INVALID (0x{CKR_KEY_HANDLE_INVALID:x}) or \
+                 CKR_OBJECT_HANDLE_INVALID (0x{CKR_OBJECT_HANDLE_INVALID:x}), got: {msg}"
+            );
+            eprintln!("[ok] cross-tenant isolation verified: Bob cannot use Alice's key handle ({msg})");
+        }
+    }
+
+    // Bob's OWN key still works after the rejected cross-tenant attempt —
+    // proves the isolation check is a real gate, not a session-poisoning
+    // side effect.
+    let message = b"bob signs after the rejected cross-tenant attempt";
+    engine.sign_init(bob.session, algos::ED25519.sign_mechanism, bob.priv_handle).context("C_SignInit (bob, post-check)")?;
+    let sig = engine.sign(bob.session, message).context("C_Sign (bob, post-check)")?;
+    engine.verify_init(bob.session, algos::ED25519.sign_mechanism, bob.pub_handle).context("C_VerifyInit (bob, post-check)")?;
+    let valid = engine.verify(bob.session, message, &sig).context("C_Verify (bob, post-check)")?;
+    assert!(valid, "bob's own key must still work after the rejected cross-tenant attempt");
+    eprintln!("[ok] bob's own key still works after the rejected cross-tenant attempt — real gate, not a blanket deny");
+
+    engine.close_session(alice.session).context("C_CloseSession (alice)")?;
+    engine.close_session(bob.session).context("C_CloseSession (bob)")?;
+    engine.finalize().context("C_Finalize")?;
+    eprintln!("[ok] mechanism + isolation proof complete — engine finalized cleanly");
+
+    Ok(())
+}

--- a/rust/bench-harness/src/measure.rs
+++ b/rust/bench-harness/src/measure.rs
@@ -12,13 +12,23 @@ use anyhow::Result;
 
 /// One JSONL result row — field set and order match the harness's output
 /// contract from the plan (§A4.1 component 1): `{access_path, topology,
-/// instances, tenants, threads, category, algorithm, security_level, op,
-/// ops_per_sec, p50_ms, p99_ms, duration_s, total_ops, engine_version}`.
+/// instances, instance_id, tenants, threads, category, algorithm,
+/// security_level, op, ops_per_sec, p50_ms, p99_ms, duration_s, total_ops,
+/// engine_version}`.
+///
+/// `instances` is the COUNT of independent-topology instances in this run
+/// (e.g. `3`); `instance_id` is WHICH one produced this specific row
+/// (`0..instances`, always `0` under shared-1-instance topology, where
+/// there's only ever one). Conflating the two was a real gap
+/// (hsm-perf-bench-instance-slot-telemetry-plan-07192026.md §1, row 1) —
+/// every row in a 3-instance run used to carry `instances: 3` with
+/// nothing distinguishing which instance it came from.
 #[derive(serde::Serialize)]
 pub struct ResultRow {
     pub access_path: &'static str,
     pub topology: &'static str,
     pub instances: u32,
+    pub instance_id: u32,
     pub tenants: u32,
     pub threads: u32,
     pub category: &'static str,

--- a/rust/bench-harness/src/measure.rs
+++ b/rust/bench-harness/src/measure.rs
@@ -12,9 +12,9 @@ use anyhow::Result;
 
 /// One JSONL result row — field set and order match the harness's output
 /// contract from the plan (§A4.1 component 1): `{access_path, topology,
-/// instances, instance_id, tenants, threads, category, algorithm,
-/// security_level, op, ops_per_sec, p50_ms, p99_ms, duration_s, total_ops,
-/// engine_version}`.
+/// instances, instance_id, tenants, tenant_index, slot, threads, category,
+/// algorithm, security_level, op, ops_per_sec, p50_ms, p99_ms, duration_s,
+/// total_ops, engine_version}`.
 ///
 /// `instances` is the COUNT of independent-topology instances in this run
 /// (e.g. `3`); `instance_id` is WHICH one produced this specific row
@@ -23,6 +23,20 @@ use anyhow::Result;
 /// (hsm-perf-bench-instance-slot-telemetry-plan-07192026.md §1, row 1) —
 /// every row in a 3-instance run used to carry `instances: 3` with
 /// nothing distinguishing which instance it came from.
+///
+/// Likewise `tenants` is the COUNT of tenants provisioned (fixed at 2
+/// today); `tenant_index`/`slot` identify WHICH tenant's own worker
+/// threads produced this row — the measurement loop used to pool every
+/// worker thread across every tenant into one aggregate row per
+/// (algorithm, op), which silently averaged away exactly the per-tenant
+/// fairness/contention question a shared-vs-independent-topology
+/// benchmark exists to answer (telemetry plan §2.2). `tenant_index` is
+/// this harness's own 0-based ordinal (0=alice, 1=bob); `slot` is the
+/// real PKCS#11 slot number that tenant's token landed on (via the
+/// standard `C_GetSlotList` auto-replenish — see `pkcs11.rs`) — the two
+/// happen to coincide today (alice always lands on slot 0, bob on slot
+/// 1) but are conceptually distinct, so both are reported rather than
+/// assuming a caller can derive one from the other.
 #[derive(serde::Serialize)]
 pub struct ResultRow {
     pub access_path: &'static str,
@@ -30,6 +44,8 @@ pub struct ResultRow {
     pub instances: u32,
     pub instance_id: u32,
     pub tenants: u32,
+    pub tenant_index: u32,
+    pub slot: u64,
     pub threads: u32,
     pub category: &'static str,
     pub algorithm: &'static str,

--- a/rust/bench-harness/src/measure.rs
+++ b/rust/bench-harness/src/measure.rs
@@ -1,0 +1,112 @@
+//! Fixed-duration, multi-threaded measurement primitive (plan §A7): "count
+//! ops in T seconds, not fixed-op-count." Each worker closure is already
+//! bound to its own PKCS#11 session and pre-generated key material — the
+//! measured loop calls nothing but that one real engine operation,
+//! repeatedly, through the same dlopen'd C ABI the mechanism proofs used.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+
+/// One JSONL result row — field set and order match the harness's output
+/// contract from the plan (§A4.1 component 1): `{access_path, topology,
+/// instances, tenants, threads, category, algorithm, security_level, op,
+/// ops_per_sec, p50_ms, p99_ms, duration_s, total_ops, engine_version}`.
+#[derive(serde::Serialize)]
+pub struct ResultRow {
+    pub access_path: &'static str,
+    pub topology: &'static str,
+    pub instances: u32,
+    pub tenants: u32,
+    pub threads: u32,
+    pub category: &'static str,
+    pub algorithm: &'static str,
+    pub security_level: &'static str,
+    pub op: &'static str,
+    pub ops_per_sec: f64,
+    pub p50_ms: f64,
+    pub p99_ms: f64,
+    pub duration_s: f64,
+    pub total_ops: u64,
+    pub engine_version: String,
+}
+
+/// Run `worker_fns.len()` OS threads concurrently, each calling its own
+/// closure in a tight loop: `warmup_secs` unmeasured (lazy_static init,
+/// allocator warm-up — §A7), then `duration_secs` measured with a
+/// per-op monotonic timestamp recorded into a per-thread `Vec<f64>`
+/// (millisecond latencies) — merged into one reservoir on return
+/// ("bounded" per §A7 in spirit: bounded by however many ops a single
+/// thread completes in a few seconds, not literally capacity-limited,
+/// since this harness measures single points rather than a long-running
+/// service). Each worker checks a shared `AtomicBool` deadline flag
+/// between ops rather than each thread reading its own clock every
+/// iteration, so the measured window closes at (very nearly) the same
+/// wall-clock instant across all threads.
+///
+/// A worker closure returning `Err` aborts that thread's loop early and
+/// the error is propagated after `join` — a real engine failure mid-run
+/// must surface as a hard error, not a silently-short count.
+pub fn run_point<F>(duration_secs: f64, warmup_secs: f64, worker_fns: Vec<F>) -> Result<(u64, Vec<f64>, f64)>
+where
+    F: FnMut() -> Result<()> + Send + 'static,
+{
+    let warmup_deadline = Instant::now() + Duration::from_secs_f64(warmup_secs);
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let handles: Vec<std::thread::JoinHandle<Result<(u64, Vec<f64>)>>> = worker_fns
+        .into_iter()
+        .map(|mut op| {
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                // Warm-up: run the real op, discard timings.
+                while Instant::now() < warmup_deadline {
+                    op()?;
+                }
+                let mut count: u64 = 0;
+                let mut latencies_ms = Vec::new();
+                while !stop.load(Ordering::Relaxed) {
+                    let start = Instant::now();
+                    op()?;
+                    latencies_ms.push(start.elapsed().as_secs_f64() * 1000.0);
+                    count += 1;
+                }
+                Ok((count, latencies_ms))
+            })
+        })
+        .collect();
+
+    // The measured window starts once every thread has cleared warm-up
+    // (they share one `warmup_deadline`, so this sleep is that deadline
+    // plus the measured duration) and ends when `stop` flips.
+    std::thread::sleep(warmup_deadline.saturating_duration_since(Instant::now()));
+    let measured_start = Instant::now();
+    std::thread::sleep(Duration::from_secs_f64(duration_secs));
+    stop.store(true, Ordering::Relaxed);
+    let actual_duration_s = measured_start.elapsed().as_secs_f64();
+
+    let mut total_ops: u64 = 0;
+    let mut all_latencies_ms = Vec::new();
+    for h in handles {
+        let (count, mut latencies) = h.join().expect("worker thread panicked")?;
+        total_ops += count;
+        all_latencies_ms.append(&mut latencies);
+    }
+    Ok((total_ops, all_latencies_ms, actual_duration_s))
+}
+
+/// p50/p99 from a latency sample. Nearest-rank on the sorted vector —
+/// sufficient for a benchmark chart, not a claim of statistical rigor.
+pub fn percentiles_ms(mut latencies_ms: Vec<f64>) -> (f64, f64) {
+    if latencies_ms.is_empty() {
+        return (0.0, 0.0);
+    }
+    latencies_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let rank = |p: f64| -> f64 {
+        let idx = ((p * latencies_ms.len() as f64).ceil() as usize).saturating_sub(1);
+        latencies_ms[idx.min(latencies_ms.len() - 1)]
+    };
+    (rank(0.50), rank(0.99))
+}

--- a/rust/bench-harness/src/pkcs11.rs
+++ b/rust/bench-harness/src/pkcs11.rs
@@ -1,0 +1,345 @@
+//! Thin, safety-scoped wrapper around a dlopen'd `softhsmrustv3` shared
+//! library, driven purely through its standard PKCS#11 C ABI function
+//! table (`CK_FUNCTION_LIST`).
+//!
+//! hsm-perf-bench plan §A4.1/§P4 — this is deliberately the ONLY way this
+//! crate talks to the engine. It never calls into `softhsmrustv3::native::*`
+//! or `softhsmrustv3::ffi::*` directly (the crate is a path dependency
+//! purely for its public `CK_*` type/const definitions — the Rust-native
+//! equivalent of `#include`-ing `pkcs11.h`/`pkcs11t.h`/`pkcs11f.h`, resolved
+//! at compile time, touching no runtime state). Every operation goes
+//! through the ONE loaded library instance's own function pointers, so all
+//! engine state — sessions, tokens, objects — lives in exactly the memory
+//! image a real PKCS#11 application would load. Mixing this with a native
+//! Rust dependency on the crate's stateful functions would silently create
+//! a SECOND, independent copy of the engine's process-global state in the
+//! harness's own statically-linked code — sessions/handles from one would
+//! be invisible to the other. This module's whole point is to make that
+//! mistake impossible: nothing outside `pkcs11.rs` ever sees the raw
+//! function table.
+
+use softhsmrustv3::ck_abi::{
+    CK_ATTRIBUTE, CK_FLAGS, CK_FUNCTION_LIST, CK_FUNCTION_LIST_PTR, CK_MECHANISM,
+    CK_OBJECT_HANDLE, CK_RV, CK_SESSION_HANDLE, CK_SLOT_ID, CK_ULONG, CK_USER_TYPE,
+};
+use softhsmrustv3::constants::{CKF_RW_SESSION, CKF_SERIAL_SESSION, CKR_OK, CKU_SO, CKU_USER};
+
+use anyhow::{bail, Context, Result};
+
+/// `CK_ULONG`/`CK_RV`/`CK_FLAGS` are all `c_ulong` in the engine's ABI
+/// (matching the real PKCS#11 C header — `unsigned long`, 64-bit on
+/// macOS/Linux LP64), while this crate's `constants` module keeps its
+/// `CKR_*`/`CKF_*` values as plain `u32` (their true bit width — PKCS#11
+/// reserves the upper 32 bits of `CK_ULONG` for vendor use, never sets
+/// them for defined constants). `as CK_RV` at each use site bridges that,
+/// matching the pattern the engine's own `ck_abi.rs` uses internally.
+const CKR_OK_RV: CK_RV = CKR_OK as CK_RV;
+
+/// A loaded engine instance and its resolved v2.40 function table.
+///
+/// Holds the `libloading::Library` for the process's lifetime — the
+/// function pointers inside `CK_FUNCTION_LIST` are only valid while the
+/// library stays mapped, so this struct must outlive every call made
+/// through it. `functions` points into the LOADED LIBRARY's own static
+/// data (see `ck_abi.rs::FUNCTION_LIST`), not anything in this process's
+/// own binary.
+pub struct Engine {
+    // Never read after construction — kept alive so the dlopen'd image
+    // (and the function pointers `functions` points into) stays mapped.
+    _library: libloading::Library,
+    functions: *const CK_FUNCTION_LIST,
+}
+
+// SAFETY: `CK_FUNCTION_LIST`'s entries are `unsafe extern "C" fn` pointers
+// into a loaded shared library's own read-only code segment — calling them
+// concurrently from multiple threads is exactly what a PKCS#11 library is
+// required to support (PKCS#11 v3.2 §6.5.1: "Cryptoki libraries... are
+// safe for multi-threaded access"), and is the whole point of this
+// benchmark. The pointer itself never changes after construction.
+unsafe impl Send for Engine {}
+unsafe impl Sync for Engine {}
+
+impl Engine {
+    /// Load `library_path` and resolve its v2.40 function table via
+    /// `C_GetFunctionList` — the standard PKCS#11 §5.4 pre-initialization
+    /// entry point every real application uses.
+    pub fn load(library_path: &str) -> Result<Self> {
+        // SAFETY: dlopen'ing an arbitrary path is inherently unsafe (the
+        // loaded code runs with this process's full privileges) — bounded
+        // here to a path the harness's own caller supplies (a benchmark
+        // tool operated by whoever is already running it, not untrusted
+        // input from a network request).
+        let library = unsafe { libloading::Library::new(library_path) }
+            .with_context(|| format!("dlopen {library_path:?}"))?;
+
+        type GetFunctionListFn =
+            unsafe extern "C" fn(*mut CK_FUNCTION_LIST_PTR) -> CK_RV;
+        // SAFETY: `C_GetFunctionList` is the one symbol PKCS#11 §5.4
+        // guarantees every conformant library exports under this exact
+        // name, with this exact signature.
+        let get_function_list: libloading::Symbol<GetFunctionListFn> =
+            unsafe { library.get(b"C_GetFunctionList\0") }
+                .context("resolve C_GetFunctionList")?;
+
+        let mut list_ptr: CK_FUNCTION_LIST_PTR = std::ptr::null_mut();
+        // SAFETY: `list_ptr` is a valid, non-null out-pointer; the callee
+        // (this very library) is required by §5.4 to write a pointer to
+        // its own static function-list table, valid for the library's
+        // entire loaded lifetime.
+        let rv = unsafe { get_function_list(&mut list_ptr) };
+        if rv != CKR_OK_RV || list_ptr.is_null() {
+            bail!("C_GetFunctionList failed: rv=0x{rv:x}");
+        }
+
+        Ok(Self { _library: library, functions: list_ptr })
+    }
+
+    // SAFETY (every accessor below): `self.functions` was populated by a
+    // successful `C_GetFunctionList` call and the backing library is kept
+    // alive by `self._library` for as long as `self` exists, so
+    // dereferencing it is sound for the lifetime of every borrow below.
+    // `CK_FUNCTION_LIST { version, f: FnListV240 }` — `.f` is the actual
+    // per-function pointer table; `funcs()` skips straight to it.
+    fn funcs(&self) -> &softhsmrustv3::ck_abi::FnListV240 {
+        unsafe { &(*self.functions).f }
+    }
+
+    pub fn initialize(&self) -> Result<()> {
+        // SAFETY: PKCS#11 §5.6 — a null pInitArgs is always valid.
+        ck(unsafe { (self.funcs().C_Initialize)(std::ptr::null_mut()) }, "C_Initialize")
+    }
+
+    pub fn finalize(&self) -> Result<()> {
+        // SAFETY: PKCS#11 §5.6 — pReserved must be null; we pass null.
+        ck(unsafe { (self.funcs().C_Finalize)(std::ptr::null_mut()) }, "C_Finalize")
+    }
+
+    /// §5.5 two-call convention: query the count, allocate, fill.
+    /// Per this engine's own `C_GetSlotList` (mirroring real SoftHSM):
+    /// if every existing slot already has an initialized token, the call
+    /// itself manufactures a fresh UNINITIALIZED slot before returning —
+    /// "always keep one blank token available for `C_InitToken`" is the
+    /// documented SoftHSM multi-token model, not a vendor extension. This
+    /// is the ONLY mechanism this harness uses to grow beyond slot 0.
+    pub fn get_slot_list(&self) -> Result<Vec<CK_SLOT_ID>> {
+        let mut count: CK_ULONG = 0;
+        // SAFETY: a null slot-list pointer with a valid `count` out-param
+        // is the documented "size query" call (§5.5).
+        ck(
+            unsafe { (self.funcs().C_GetSlotList)(0, std::ptr::null_mut(), &mut count) },
+            "C_GetSlotList(size)",
+        )?;
+        let mut slots = vec![0 as CK_SLOT_ID; count as usize];
+        // SAFETY: `slots` has exactly `count` elements, matching what we
+        // just told the engine to expect via `&mut count`.
+        ck(
+            unsafe { (self.funcs().C_GetSlotList)(0, slots.as_mut_ptr(), &mut count) },
+            "C_GetSlotList(fill)",
+        )?;
+        slots.truncate(count as usize);
+        Ok(slots)
+    }
+
+    pub fn init_token(&self, slot: CK_SLOT_ID, so_pin: &str, label: &str) -> Result<()> {
+        let mut pin = so_pin.as_bytes().to_vec();
+        // PKCS#11 §5.4 — C_InitToken's label is ALWAYS a fixed 32-byte,
+        // space-padded field with NO separate length parameter; the
+        // engine reads exactly 32 bytes from this pointer regardless of
+        // what we intend, so under-sizing it would read out of bounds.
+        let mut label_buf = [0x20u8; 32];
+        let label_bytes = label.as_bytes();
+        let n = label_bytes.len().min(32);
+        label_buf[..n].copy_from_slice(&label_bytes[..n]);
+        // SAFETY: `pin`/`label_buf` are valid, correctly-sized buffers
+        // for the duration of this call.
+        ck(
+            unsafe {
+                (self.funcs().C_InitToken)(
+                    slot,
+                    pin.as_mut_ptr(),
+                    pin.len() as CK_ULONG,
+                    label_buf.as_mut_ptr(),
+                )
+            },
+            "C_InitToken",
+        )
+    }
+
+    pub fn open_session(&self, slot: CK_SLOT_ID) -> Result<CK_SESSION_HANDLE> {
+        let flags: CK_FLAGS = (CKF_SERIAL_SESSION | CKF_RW_SESSION) as CK_FLAGS;
+        let mut handle: CK_SESSION_HANDLE = 0;
+        // SAFETY: notify callback/application pointers are optional per
+        // §5.6 when the library never issues surrender callbacks (this
+        // engine doesn't); null is the documented "no callback" value.
+        ck(
+            unsafe {
+                (self.funcs().C_OpenSession)(
+                    slot,
+                    flags,
+                    std::ptr::null_mut(),
+                    None,
+                    &mut handle,
+                )
+            },
+            "C_OpenSession",
+        )?;
+        Ok(handle)
+    }
+
+    pub fn close_session(&self, session: CK_SESSION_HANDLE) -> Result<()> {
+        ck(unsafe { (self.funcs().C_CloseSession)(session) }, "C_CloseSession")
+    }
+
+    pub fn login(&self, session: CK_SESSION_HANDLE, user_type: CK_USER_TYPE, pin: &str) -> Result<()> {
+        let mut pin_bytes = pin.as_bytes().to_vec();
+        ck(
+            unsafe {
+                (self.funcs().C_Login)(session, user_type, pin_bytes.as_mut_ptr(), pin_bytes.len() as CK_ULONG)
+            },
+            "C_Login",
+        )
+    }
+
+    pub fn login_so(&self, session: CK_SESSION_HANDLE, pin: &str) -> Result<()> {
+        self.login(session, CKU_SO as CK_USER_TYPE, pin)
+    }
+
+    pub fn login_user(&self, session: CK_SESSION_HANDLE, pin: &str) -> Result<()> {
+        self.login(session, CKU_USER as CK_USER_TYPE, pin)
+    }
+
+    pub fn logout(&self, session: CK_SESSION_HANDLE) -> Result<()> {
+        ck(unsafe { (self.funcs().C_Logout)(session) }, "C_Logout")
+    }
+
+    pub fn init_pin(&self, session: CK_SESSION_HANDLE, pin: &str) -> Result<()> {
+        let mut pin_bytes = pin.as_bytes().to_vec();
+        ck(
+            unsafe { (self.funcs().C_InitPIN)(session, pin_bytes.as_mut_ptr(), pin_bytes.len() as CK_ULONG) },
+            "C_InitPIN",
+        )
+    }
+
+    /// Full multi-tenant token bring-up on `slot`, mirroring the exact
+    /// sequence `softhsmrustv3::native::session::bootstrap_default_token`
+    /// uses internally (and what the KMIP server's `provision_tenant`
+    /// calls natively) — reproduced here purely through the standard C
+    /// ABI. Returns a live, USER-logged-in session on `slot`.
+    pub fn bootstrap_token(&self, slot: CK_SLOT_ID, so_pin: &str, user_pin: &str, label: &str) -> Result<CK_SESSION_HANDLE> {
+        self.init_token(slot, so_pin, label)?;
+        let so_session = self.open_session(slot)?;
+        self.login_so(so_session, so_pin)?;
+        self.init_pin(so_session, user_pin)?;
+        // PKCS#11 §11.4 — C_CloseSession does not auto-logout; must
+        // explicitly logout the SO before a USER login on the same slot,
+        // else C_Login(USER) returns CKR_USER_ANOTHER_ALREADY_LOGGED_IN.
+        self.logout(so_session)?;
+        self.close_session(so_session)?;
+        let user_session = self.open_session(slot)?;
+        self.login_user(user_session, user_pin)?;
+        Ok(user_session)
+    }
+
+    pub fn generate_key_pair(
+        &self,
+        session: CK_SESSION_HANDLE,
+        mechanism: u32,
+        pub_template: &mut [CK_ATTRIBUTE],
+        priv_template: &mut [CK_ATTRIBUTE],
+    ) -> Result<(CK_OBJECT_HANDLE, CK_OBJECT_HANDLE)> {
+        let mut mech = CK_MECHANISM {
+            mechanism: mechanism as CK_ULONG,
+            pParameter: std::ptr::null_mut(),
+            ulParameterLen: 0,
+        };
+        let mut pub_handle: CK_OBJECT_HANDLE = 0;
+        let mut priv_handle: CK_OBJECT_HANDLE = 0;
+        ck(
+            unsafe {
+                (self.funcs().C_GenerateKeyPair)(
+                    session,
+                    &mut mech,
+                    pub_template.as_mut_ptr(),
+                    pub_template.len() as CK_ULONG,
+                    priv_template.as_mut_ptr(),
+                    priv_template.len() as CK_ULONG,
+                    &mut pub_handle,
+                    &mut priv_handle,
+                )
+            },
+            "C_GenerateKeyPair",
+        )?;
+        Ok((pub_handle, priv_handle))
+    }
+
+    pub fn sign_init(&self, session: CK_SESSION_HANDLE, mechanism: u32, key: CK_OBJECT_HANDLE) -> Result<()> {
+        let mut mech = CK_MECHANISM {
+            mechanism: mechanism as CK_ULONG,
+            pParameter: std::ptr::null_mut(),
+            ulParameterLen: 0,
+        };
+        ck(unsafe { (self.funcs().C_SignInit)(session, &mut mech, key) }, "C_SignInit")
+    }
+
+    /// Two-call convention: query length, then fill.
+    pub fn sign(&self, session: CK_SESSION_HANDLE, data: &[u8]) -> Result<Vec<u8>> {
+        let mut data = data.to_vec();
+        let mut sig_len: CK_ULONG = 0;
+        ck(
+            unsafe {
+                (self.funcs().C_Sign)(session, data.as_mut_ptr(), data.len() as CK_ULONG, std::ptr::null_mut(), &mut sig_len)
+            },
+            "C_Sign(size)",
+        )?;
+        let mut sig = vec![0u8; sig_len as usize];
+        ck(
+            unsafe {
+                (self.funcs().C_Sign)(session, data.as_mut_ptr(), data.len() as CK_ULONG, sig.as_mut_ptr(), &mut sig_len)
+            },
+            "C_Sign(fill)",
+        )?;
+        sig.truncate(sig_len as usize);
+        Ok(sig)
+    }
+
+    pub fn verify_init(&self, session: CK_SESSION_HANDLE, mechanism: u32, key: CK_OBJECT_HANDLE) -> Result<()> {
+        let mut mech = CK_MECHANISM {
+            mechanism: mechanism as CK_ULONG,
+            pParameter: std::ptr::null_mut(),
+            ulParameterLen: 0,
+        };
+        ck(unsafe { (self.funcs().C_VerifyInit)(session, &mut mech, key) }, "C_VerifyInit")
+    }
+
+    /// `Ok(true)` valid, `Ok(false)` genuinely invalid signature
+    /// (`CKR_SIGNATURE_INVALID`/`CKR_SIGNATURE_LEN_RANGE`), `Err` for any
+    /// other failure.
+    pub fn verify(&self, session: CK_SESSION_HANDLE, data: &[u8], signature: &[u8]) -> Result<bool> {
+        let mut data = data.to_vec();
+        let mut sig = signature.to_vec();
+        let rv = unsafe {
+            (self.funcs().C_Verify)(
+                session,
+                data.as_mut_ptr(),
+                data.len() as CK_ULONG,
+                sig.as_mut_ptr(),
+                sig.len() as CK_ULONG,
+            )
+        };
+        const CKR_SIGNATURE_INVALID: CK_RV = 0xC0;
+        const CKR_SIGNATURE_LEN_RANGE: CK_RV = 0xC1;
+        match rv {
+            CKR_OK_RV => Ok(true),
+            CKR_SIGNATURE_INVALID | CKR_SIGNATURE_LEN_RANGE => Ok(false),
+            other => bail!("C_Verify failed: rv=0x{other:x}"),
+        }
+    }
+}
+
+fn ck(rv: CK_RV, op: &str) -> Result<()> {
+    if rv == CKR_OK_RV {
+        Ok(())
+    } else {
+        bail!("{op} failed: rv=0x{rv:x}")
+    }
+}

--- a/rust/bench-harness/src/pkcs11.rs
+++ b/rust/bench-harness/src/pkcs11.rs
@@ -162,6 +162,17 @@ impl Engine {
         ck(unsafe { (self.funcs().C_Finalize)(std::ptr::null_mut()) }, "C_Finalize")
     }
 
+    /// §5.4 `C_GetInfo` — `libraryVersion` as `"major.minor"`. Stamped on
+    /// every JSONL result row (plan §A7 honesty item: "engine version...
+    /// stamped on every result set") so before/after engine-side changes
+    /// (e.g. the F2–F5 lock-collapse gate) are distinguishable in the data,
+    /// not just asserted in a commit message.
+    pub fn library_version(&self) -> Result<String> {
+        let mut info: softhsmrustv3::ck_abi::CK_INFO = unsafe { std::mem::zeroed() };
+        ck(unsafe { (self.funcs().C_GetInfo)(&mut info) }, "C_GetInfo")?;
+        Ok(format!("{}.{}", info.libraryVersion.major, info.libraryVersion.minor))
+    }
+
     /// §5.5 two-call convention: query the count, allocate, fill.
     /// Per this engine's own `C_GetSlotList` (mirroring real SoftHSM):
     /// if every existing slot already has an initialized token, the call

--- a/rust/bench-harness/src/pkcs11.rs
+++ b/rust/bench-harness/src/pkcs11.rs
@@ -24,8 +24,11 @@ use softhsmrustv3::ck_abi::{
     CK_OBJECT_HANDLE, CK_RV, CK_SESSION_HANDLE, CK_SLOT_ID, CK_ULONG, CK_USER_TYPE,
     CK_VERSION, CK_VOID_PTR,
 };
-use softhsmrustv3::constants::{CKF_RW_SESSION, CKF_SERIAL_SESSION, CKR_OK, CKU_SO, CKU_USER};
+use softhsmrustv3::constants::{
+    CKA_EC_PARAMS, CKA_PARAMETER_SET, CKF_RW_SESSION, CKF_SERIAL_SESSION, CKR_OK, CKU_SO, CKU_USER,
+};
 
+use crate::algos::KeygenParam;
 use anyhow::{bail, Context, Result};
 
 /// `CK_ULONG`/`CK_RV`/`CK_FLAGS` are all `c_ulong` in the engine's ABI
@@ -461,6 +464,44 @@ impl Engine {
             "C_GenerateKeyPair",
         )?;
         Ok((pub_handle, priv_handle))
+    }
+
+    /// `generate_key_pair`, but builds the public-key template from an
+    /// `algos::KeygenParam` — the one place that knows how to encode each
+    /// kind of required attribute (raw `CKA_EC_PARAMS` OID bytes at their
+    /// real declared length, vs. `CKA_PARAMETER_SET` as a bare 4-byte
+    /// `u32` regardless of this platform's 8-byte native `CK_ULONG` —
+    /// see `crypto/handlers.rs::get_attr_ulong`, which reads exactly 4
+    /// bytes at `pValue` no matter what `ulValueLen` says). Keeping this
+    /// encoding logic here, not in `algos.rs`, matches the module's own
+    /// rule: nothing outside `pkcs11.rs` builds a `CK_ATTRIBUTE` by hand.
+    pub fn generate_key_pair_with_param(
+        &self,
+        session: CK_SESSION_HANDLE,
+        mechanism: u32,
+        param: KeygenParam,
+    ) -> Result<(CK_OBJECT_HANDLE, CK_OBJECT_HANDLE)> {
+        match param {
+            KeygenParam::None => self.generate_key_pair(session, mechanism, &mut [], &mut []),
+            KeygenParam::EcParamsOid(oid) => {
+                let mut oid = oid.to_vec();
+                let mut pub_template = [CK_ATTRIBUTE {
+                    attrType: CKA_EC_PARAMS as CK_ATTRIBUTE_TYPE,
+                    pValue: oid.as_mut_ptr() as CK_VOID_PTR,
+                    ulValueLen: oid.len() as CK_ULONG,
+                }];
+                self.generate_key_pair(session, mechanism, &mut pub_template, &mut [])
+            }
+            KeygenParam::ParameterSet(value) => {
+                let mut value = value;
+                let mut pub_template = [CK_ATTRIBUTE {
+                    attrType: CKA_PARAMETER_SET as CK_ATTRIBUTE_TYPE,
+                    pValue: &mut value as *mut u32 as CK_VOID_PTR,
+                    ulValueLen: std::mem::size_of::<u32>() as CK_ULONG,
+                }];
+                self.generate_key_pair(session, mechanism, &mut pub_template, &mut [])
+            }
+        }
     }
 
     pub fn sign_init(&self, session: CK_SESSION_HANDLE, mechanism: u32, key: CK_OBJECT_HANDLE) -> Result<()> {

--- a/rust/bench-harness/src/pkcs11.rs
+++ b/rust/bench-harness/src/pkcs11.rs
@@ -19,8 +19,10 @@
 //! function table.
 
 use softhsmrustv3::ck_abi::{
-    CK_ATTRIBUTE, CK_FLAGS, CK_FUNCTION_LIST, CK_FUNCTION_LIST_PTR, CK_MECHANISM,
+    CK_ATTRIBUTE, CK_ATTRIBUTE_TYPE, CK_FLAGS, CK_FUNCTION_LIST, CK_FUNCTION_LIST_3_2,
+    CK_FUNCTION_LIST_PTR, CK_INTERFACE_PTR, CK_INTERFACE_PTR_PTR, CK_MECHANISM,
     CK_OBJECT_HANDLE, CK_RV, CK_SESSION_HANDLE, CK_SLOT_ID, CK_ULONG, CK_USER_TYPE,
+    CK_VERSION, CK_VOID_PTR,
 };
 use softhsmrustv3::constants::{CKF_RW_SESSION, CKF_SERIAL_SESSION, CKR_OK, CKU_SO, CKU_USER};
 
@@ -45,9 +47,17 @@ const CKR_OK_RV: CK_RV = CKR_OK as CK_RV;
 /// own binary.
 pub struct Engine {
     // Never read after construction — kept alive so the dlopen'd image
-    // (and the function pointers `functions` points into) stays mapped.
+    // (and the function pointers `functions`/`functions_3_2` point into)
+    // stays mapped.
     _library: libloading::Library,
     functions: *const CK_FUNCTION_LIST,
+    /// The v3.2 interface (§5.3/§5.5 `C_GetInterface`), needed for
+    /// functions added after v2.40 — `C_EncapsulateKey`/`C_DecapsulateKey`
+    /// here. `C_GetFunctionList` is frozen at v2.40 for ABI back-compat
+    /// (confirmed against `rust/src/ck_abi.rs`'s own doc comments); a
+    /// v3.2-aware client resolves the newer functions through the
+    /// interface mechanism instead, exactly as done here.
+    functions_3_2: *const CK_FUNCTION_LIST_3_2,
 }
 
 // SAFETY: `CK_FUNCTION_LIST`'s entries are `unsafe extern "C" fn` pointers
@@ -91,7 +101,39 @@ impl Engine {
             bail!("C_GetFunctionList failed: rv=0x{rv:x}");
         }
 
-        Ok(Self { _library: library, functions: list_ptr })
+        // §5.3/§5.5 — resolve the v3.2 interface via C_GetInterface, the
+        // standard way to reach functions added after v2.40. Interface
+        // name is the literal "PKCS 11" (with a space) per the spec;
+        // requesting version {3,2} explicitly avoids relying on the
+        // library's default-interface ordering.
+        type GetInterfaceFn = unsafe extern "C" fn(
+            *mut u8,
+            *mut CK_VERSION,
+            CK_INTERFACE_PTR_PTR,
+            CK_FLAGS,
+        ) -> CK_RV;
+        let get_interface: libloading::Symbol<GetInterfaceFn> =
+            unsafe { library.get(b"C_GetInterface\0") }.context("resolve C_GetInterface")?;
+        let mut interface_name: [u8; 8] = *b"PKCS 11\0";
+        let mut version_3_2 = CK_VERSION { major: 3, minor: 2 };
+        let mut interface_ptr: CK_INTERFACE_PTR = std::ptr::null_mut();
+        // SAFETY: `interface_name`/`version_3_2` are valid buffers for the
+        // duration of this call; `interface_ptr` is a valid non-null
+        // out-pointer per §5.5.
+        let rv = unsafe {
+            get_interface(interface_name.as_mut_ptr(), &mut version_3_2, &mut interface_ptr, 0)
+        };
+        if rv != CKR_OK_RV || interface_ptr.is_null() {
+            bail!("C_GetInterface(\"PKCS 11\", 3.2) failed: rv=0x{rv:x}");
+        }
+        // SAFETY: a successful C_GetInterface returns a CK_INTERFACE whose
+        // pFunctionList, per the {3,2} version we requested, points to a
+        // CK_FUNCTION_LIST_3_2 — the engine's own C_GetInterface dispatch
+        // (rust/src/ck_abi.rs) only ever populates it that way for a 3.2
+        // match.
+        let functions_3_2 = unsafe { (*interface_ptr).pFunctionList as *const CK_FUNCTION_LIST_3_2 };
+
+        Ok(Self { _library: library, functions: list_ptr, functions_3_2 })
     }
 
     // SAFETY (every accessor below): `self.functions` was populated by a
@@ -102,6 +144,12 @@ impl Engine {
     // per-function pointer table; `funcs()` skips straight to it.
     fn funcs(&self) -> &softhsmrustv3::ck_abi::FnListV240 {
         unsafe { &(*self.functions).f }
+    }
+
+    /// The v3.2-only function segment (`C_EncapsulateKey`/`C_DecapsulateKey`),
+    /// resolved via `C_GetInterface` in `load()`.
+    fn funcs_32(&self) -> &softhsmrustv3::ck_abi::FnListV32Ext {
+        unsafe { &(*self.functions_3_2).f32 }
     }
 
     pub fn initialize(&self) -> Result<()> {
@@ -238,6 +286,138 @@ impl Engine {
         let user_session = self.open_session(slot)?;
         self.login_user(user_session, user_pin)?;
         Ok(user_session)
+    }
+
+    /// §5.7.5 two-call convention. `CKR_ATTRIBUTE_TYPE_INVALID` (attribute
+    /// absent on this object — not this crate's harness-only convention,
+    /// the engine's own real return code, see `ffi.rs::C_GetAttributeValue`)
+    /// is surfaced as a normal `Err`, same as any other non-OK `rv`.
+    pub fn get_attribute_value(&self, session: CK_SESSION_HANDLE, object: CK_OBJECT_HANDLE, attr_type: u32) -> Result<Vec<u8>> {
+        let mut attr = CK_ATTRIBUTE { attrType: attr_type as CK_ATTRIBUTE_TYPE, pValue: std::ptr::null_mut(), ulValueLen: 0 };
+        ck(
+            unsafe { (self.funcs().C_GetAttributeValue)(session, object, &mut attr, 1) },
+            "C_GetAttributeValue(size)",
+        )?;
+        let mut buf = vec![0u8; attr.ulValueLen as usize];
+        attr.pValue = buf.as_mut_ptr() as CK_VOID_PTR;
+        ck(
+            unsafe { (self.funcs().C_GetAttributeValue)(session, object, &mut attr, 1) },
+            "C_GetAttributeValue(fill)",
+        )?;
+        buf.truncate(attr.ulValueLen as usize);
+        Ok(buf)
+    }
+
+    /// §5.18.5 `C_DeriveKey` with `CKM_ECDH1_DERIVE` (§6.7 — also the
+    /// mechanism for X25519/X448 Montgomery-curve agreement, dispatched by
+    /// the engine from the base key's own stored algorithm family; see
+    /// `algos::KeyAgreementAlgo`'s doc comment). Builds the standard
+    /// `CK_ECDH1_DERIVE_PARAMS` internally — nothing outside this module
+    /// needs to know that struct's raw layout, same discipline as `funcs()`
+    /// keeping the function table private. `kdf = CKD_NULL` (§6.7 — no
+    /// post-processing; the raw shared value becomes the key), no shared
+    /// data, `peer_public_point` is the peer's `CKA_EC_POINT` value
+    /// (DER-OCTET-STRING-wrapped — the engine strips the wrapper itself,
+    /// confirmed against `ffi.rs`'s `C_DeriveKey` ECDH branch).
+    pub fn ecdh1_derive(
+        &self,
+        session: CK_SESSION_HANDLE,
+        base_key: CK_OBJECT_HANDLE,
+        peer_public_point: &mut [u8],
+    ) -> Result<CK_OBJECT_HANDLE> {
+        const CKD_NULL: CK_ULONG = 1; // PKCS#11 v3.2 §6.7 Table 26 — no KDF.
+        #[repr(C)]
+        struct CkEcdh1DeriveParams {
+            kdf: CK_ULONG,
+            ul_shared_data_len: CK_ULONG,
+            p_shared_data: CK_VOID_PTR,
+            ul_public_data_len: CK_ULONG,
+            p_public_data: CK_VOID_PTR,
+        }
+        let mut params = CkEcdh1DeriveParams {
+            kdf: CKD_NULL,
+            ul_shared_data_len: 0,
+            p_shared_data: std::ptr::null_mut(),
+            ul_public_data_len: peer_public_point.len() as CK_ULONG,
+            p_public_data: peer_public_point.as_mut_ptr() as CK_VOID_PTR,
+        };
+        let mut mech = CK_MECHANISM {
+            mechanism: softhsmrustv3::constants::CKM_ECDH1_DERIVE as CK_ULONG,
+            pParameter: &mut params as *mut CkEcdh1DeriveParams as CK_VOID_PTR,
+            ulParameterLen: std::mem::size_of::<CkEcdh1DeriveParams>() as CK_ULONG,
+        };
+        let mut derived: CK_OBJECT_HANDLE = 0;
+        ck(
+            unsafe {
+                (self.funcs().C_DeriveKey)(session, &mut mech, base_key, std::ptr::null_mut(), 0, &mut derived)
+            },
+            "C_DeriveKey(ECDH1)",
+        )?;
+        Ok(derived)
+    }
+
+    /// §5.18.8 `C_EncapsulateKey`. `public_key` must carry `CKA_ENCAPSULATE`
+    /// (engine-set by default on ML-KEM public keys). Two-call convention
+    /// for the ciphertext buffer, same pattern as `sign`.
+    pub fn encapsulate_key(
+        &self,
+        session: CK_SESSION_HANDLE,
+        mechanism: u32,
+        public_key: CK_OBJECT_HANDLE,
+        template: &mut [CK_ATTRIBUTE],
+    ) -> Result<(Vec<u8>, CK_OBJECT_HANDLE)> {
+        let mut mech = CK_MECHANISM { mechanism: mechanism as CK_ULONG, pParameter: std::ptr::null_mut(), ulParameterLen: 0 };
+        let mut ct_len: CK_ULONG = 0;
+        let mut ss_handle: CK_OBJECT_HANDLE = 0;
+        ck(
+            unsafe {
+                (self.funcs_32().C_EncapsulateKey)(
+                    session, &mut mech, public_key,
+                    template.as_mut_ptr(), template.len() as CK_ULONG,
+                    std::ptr::null_mut(), &mut ct_len, &mut ss_handle,
+                )
+            },
+            "C_EncapsulateKey(size)",
+        )?;
+        let mut ciphertext = vec![0u8; ct_len as usize];
+        ck(
+            unsafe {
+                (self.funcs_32().C_EncapsulateKey)(
+                    session, &mut mech, public_key,
+                    template.as_mut_ptr(), template.len() as CK_ULONG,
+                    ciphertext.as_mut_ptr(), &mut ct_len, &mut ss_handle,
+                )
+            },
+            "C_EncapsulateKey(fill)",
+        )?;
+        ciphertext.truncate(ct_len as usize);
+        Ok((ciphertext, ss_handle))
+    }
+
+    /// §5.18.9 `C_DecapsulateKey`. `private_key` must carry `CKA_DECAPSULATE`
+    /// (engine-set by default on ML-KEM private keys).
+    pub fn decapsulate_key(
+        &self,
+        session: CK_SESSION_HANDLE,
+        mechanism: u32,
+        private_key: CK_OBJECT_HANDLE,
+        ciphertext: &[u8],
+        template: &mut [CK_ATTRIBUTE],
+    ) -> Result<CK_OBJECT_HANDLE> {
+        let mut mech = CK_MECHANISM { mechanism: mechanism as CK_ULONG, pParameter: std::ptr::null_mut(), ulParameterLen: 0 };
+        let mut ciphertext = ciphertext.to_vec();
+        let mut ss_handle: CK_OBJECT_HANDLE = 0;
+        ck(
+            unsafe {
+                (self.funcs_32().C_DecapsulateKey)(
+                    session, &mut mech, private_key,
+                    template.as_mut_ptr(), template.len() as CK_ULONG,
+                    ciphertext.as_mut_ptr(), ciphertext.len() as CK_ULONG, &mut ss_handle,
+                )
+            },
+            "C_DecapsulateKey",
+        )?;
+        Ok(ss_handle)
     }
 
     pub fn generate_key_pair(

--- a/rust/bench-harness/src/pkcs11.rs
+++ b/rust/bench-harness/src/pkcs11.rs
@@ -25,7 +25,8 @@ use softhsmrustv3::ck_abi::{
     CK_VERSION, CK_VOID_PTR,
 };
 use softhsmrustv3::constants::{
-    CKA_EC_PARAMS, CKA_PARAMETER_SET, CKF_RW_SESSION, CKF_SERIAL_SESSION, CKR_OK, CKU_SO, CKU_USER,
+    CKA_EC_PARAMS, CKA_MODULUS_BITS, CKA_PARAMETER_SET, CKF_RW_SESSION, CKF_SERIAL_SESSION, CKR_OK,
+    CKU_SO, CKU_USER,
 };
 
 use crate::algos::KeygenParam;
@@ -501,6 +502,20 @@ impl Engine {
                 }];
                 self.generate_key_pair(session, mechanism, &mut pub_template, &mut [])
             }
+            KeygenParam::RsaModulusBits(bits) => {
+                // Same plain-4-byte-u32 convention as ParameterSet above —
+                // confirmed against ffi.rs's CKM_RSA_PKCS_KEY_PAIR_GEN
+                // dispatch (get_attr_ulong), not native CK_ULONG width.
+                // No CKA_PUBLIC_EXPONENT: the engine generates and stores
+                // that itself, not caller-supplied.
+                let mut bits = bits;
+                let mut pub_template = [CK_ATTRIBUTE {
+                    attrType: CKA_MODULUS_BITS as CK_ATTRIBUTE_TYPE,
+                    pValue: &mut bits as *mut u32 as CK_VOID_PTR,
+                    ulValueLen: std::mem::size_of::<u32>() as CK_ULONG,
+                }];
+                self.generate_key_pair(session, mechanism, &mut pub_template, &mut [])
+            }
         }
     }
 
@@ -566,6 +581,95 @@ impl Engine {
             other => bail!("C_Verify failed: rv=0x{other:x}"),
         }
     }
+
+    /// Builds a real `CK_RSA_PKCS_OAEP_PARAMS` (§6.4.4) at native width —
+    /// `#[repr(C)]` struct of `CK_ULONG`/`CK_VOID_PTR` fields, same pattern
+    /// as `ecdh1_derive`'s own params struct above. `mechanism` comes from
+    /// the caller (`algo.encrypt_mechanism`, matching how `sign_init`
+    /// takes `algo.sign_mechanism` rather than hardcoding it here) — one
+    /// fixed, standard OAEP configuration regardless of which RSA-OAEP
+    /// mechanism is passed: SHA-256 / MGF1-SHA256 / CKZ_DATA_SPECIFIED
+    /// with an empty label, no per-algorithm parameterization needed.
+    fn oaep_mechanism(mechanism: u32) -> (CK_MECHANISM, Box<CkRsaPkcsOaepParams>) {
+        use softhsmrustv3::constants::{CKG_MGF1_SHA256, CKM_SHA256, CKZ_DATA_SPECIFIED};
+        let mut params = Box::new(CkRsaPkcsOaepParams {
+            hash_alg: CKM_SHA256 as CK_ULONG,
+            mgf: CKG_MGF1_SHA256 as CK_ULONG,
+            source: CKZ_DATA_SPECIFIED as CK_ULONG,
+            p_source_data: std::ptr::null_mut(),
+            ul_source_data_len: 0,
+        });
+        let mech = CK_MECHANISM {
+            mechanism: mechanism as CK_ULONG,
+            pParameter: params.as_mut() as *mut CkRsaPkcsOaepParams as CK_VOID_PTR,
+            ulParameterLen: std::mem::size_of::<CkRsaPkcsOaepParams>() as CK_ULONG,
+        };
+        (mech, params)
+    }
+
+    pub fn encrypt_init(&self, session: CK_SESSION_HANDLE, mechanism: u32, key: CK_OBJECT_HANDLE) -> Result<()> {
+        let (mut mech, _params) = Self::oaep_mechanism(mechanism);
+        ck(unsafe { (self.funcs().C_EncryptInit)(session, &mut mech, key) }, "C_EncryptInit")
+    }
+
+    /// Two-call convention, same as `sign`.
+    pub fn encrypt(&self, session: CK_SESSION_HANDLE, data: &[u8]) -> Result<Vec<u8>> {
+        let mut data = data.to_vec();
+        let mut out_len: CK_ULONG = 0;
+        ck(
+            unsafe {
+                (self.funcs().C_Encrypt)(session, data.as_mut_ptr(), data.len() as CK_ULONG, std::ptr::null_mut(), &mut out_len)
+            },
+            "C_Encrypt(size)",
+        )?;
+        let mut out = vec![0u8; out_len as usize];
+        ck(
+            unsafe {
+                (self.funcs().C_Encrypt)(session, data.as_mut_ptr(), data.len() as CK_ULONG, out.as_mut_ptr(), &mut out_len)
+            },
+            "C_Encrypt(fill)",
+        )?;
+        out.truncate(out_len as usize);
+        Ok(out)
+    }
+
+    pub fn decrypt_init(&self, session: CK_SESSION_HANDLE, mechanism: u32, key: CK_OBJECT_HANDLE) -> Result<()> {
+        let (mut mech, _params) = Self::oaep_mechanism(mechanism);
+        ck(unsafe { (self.funcs().C_DecryptInit)(session, &mut mech, key) }, "C_DecryptInit")
+    }
+
+    /// Two-call convention, same as `sign`.
+    pub fn decrypt(&self, session: CK_SESSION_HANDLE, ciphertext: &[u8]) -> Result<Vec<u8>> {
+        let mut ct = ciphertext.to_vec();
+        let mut out_len: CK_ULONG = 0;
+        ck(
+            unsafe {
+                (self.funcs().C_Decrypt)(session, ct.as_mut_ptr(), ct.len() as CK_ULONG, std::ptr::null_mut(), &mut out_len)
+            },
+            "C_Decrypt(size)",
+        )?;
+        let mut out = vec![0u8; out_len as usize];
+        ck(
+            unsafe {
+                (self.funcs().C_Decrypt)(session, ct.as_mut_ptr(), ct.len() as CK_ULONG, out.as_mut_ptr(), &mut out_len)
+            },
+            "C_Decrypt(fill)",
+        )?;
+        out.truncate(out_len as usize);
+        Ok(out)
+    }
+}
+
+/// `CK_RSA_PKCS_OAEP_PARAMS` (§6.4.4) — `CK_ULONG`/`CK_VOID_PTR` fields are
+/// native width on this platform (matching the fixed `parse_oaep_params`
+/// on the engine side, see hsm-perf-bench FIPS-gap plan Part B2).
+#[repr(C)]
+struct CkRsaPkcsOaepParams {
+    hash_alg: CK_ULONG,
+    mgf: CK_ULONG,
+    source: CK_ULONG,
+    p_source_data: CK_VOID_PTR,
+    ul_source_data_len: CK_ULONG,
 }
 
 fn ck(rv: CK_RV, op: &str) -> Result<()> {

--- a/rust/docs/NATIVE_API.md
+++ b/rust/docs/NATIVE_API.md
@@ -178,41 +178,72 @@ pub fn init_pin(session: u32, user_pin: &str) -> Result<(), CkRv>;
 
 ## 4. Threading model
 
+CORRECTED 2026-07-18 — this section previously documented "Option A
+(pinned engine thread)" as the v0.1 decision, including a `Session:
+!Send` constraint in `pqctoday-hsm/kmip/`. That plan was never
+implemented; the code instead took the shape of Option B below without
+this doc being updated. Fixed now — see
+`rust-hsm-perf-bench-scenario-plan-07182026.md` §B7 in the workspace root
+for the audit that caught this.
+
 The engine's internal storage (`OBJECTS`, `SESSIONS`, `SIGN_STATE`,
-`ENCRYPT_STATE`, etc.) is currently `thread_local!`. That's correct for
-wasm32 (single-threaded execution model).
+`ENCRYPT_STATE`, `TOKEN_STORE`, etc., all in `state.rs`) is **global
+`lazy_static! ref _: Mutex<T>`, not `thread_local!`**. This is what
+Option B below describes, and it is what the engine actually is today —
+on both wasm32 (where the `Mutex` is simply uncontended, since wasm32 is
+single-threaded) and native.
 
-For native callers (tokio multi-threaded), two viable approaches:
+**Empirically verified**, not just source-read:
+`tests/multitenant_concurrency.rs` drives 20 threads concurrently through
+keygen/sign/verify on one shared token — real contention on the global
+`OBJECTS` mutex — with zero corruption, every thread's signature
+verifying against its own key. The same work also found and fixed a real
+concurrency bug in `ffi::C_Login`: a TOCTOU race where the per-token
+login-exclusivity check read a stale snapshot before the state write,
+letting concurrent logins silently double-succeed. Fixed by making the
+check-then-write one atomic critical section (single lock acquisition);
+see `login_exclusivity_holds_under_concurrent_attempts` in the same test
+file for the regression test.
 
-### Option A — pinned engine thread (recommended)
+`pqctoday-hsm/kmip/` has **no** `Session: !Send` wrapper (never
+implemented) and needs none — it already calls `native::*` from tokio's
+multi-threaded blocking pool today, relying on the engine's own global
+mutexes for safety, which is exactly Option B's model.
 
-The `softhsmrustv3::native` API documents that **all calls must come from
-a single thread**. Native callers pin one OS thread (e.g.
-`tokio::task::spawn_blocking` onto a single-thread runtime) and route all
-crypto requests through it. Phase 4's `Session: !Send` already encodes
-this constraint.
+### Still-open gap: `native::*` does not enforce token-scoping
 
-**Pros**: No engine changes. Thread-local storage is correct as-is. Lowest
-risk of state corruption.
+Unlike `ffi::C_*` (which enforces `state::can_access_object` — the
+`CKA_PRIV_SLOT_ID` tenant-isolation gate — at 8 call sites), `native::*`
+does **not** call it anywhere. A native caller holding a numeric object
+handle can operate on it regardless of which slot/tenant it belongs to.
+KMIP, which uses `native::*` exclusively with one shared
+`engine_session` for every client, has no compensating ownership check
+of its own (verified: no owner/Identity field anywhere in the KeyStore
+trait, no ownership check in the dispatcher). **This must be closed —
+either by adding the `can_access_object` gate to `native::*`, or by KMIP
+tracking per-Identity object ownership — before any multi-tenant design
+that relies on native-surface isolation is real.** Not fixed as part of
+this pass; it's a scoped decision that touches KMIP's authorization
+model, tracked in the hsm-perf-bench plan.
 
-**Cons**: Caller has to manage thread affinity. KMIP `Deps` needs an
-`Arc<Mutex<Session>>` and all crypto goes through a single-thread executor.
+### Option A — pinned engine thread (historical, not taken)
 
-### Option B — replace thread_local with parking_lot::Mutex
+Native callers would pin one OS thread and route all crypto requests
+through it (`tokio::task::spawn_blocking` onto a single-thread runtime).
+Would have avoided any engine-side locking change, at the cost of thread
+affinity management in every caller. Superseded by the simpler approach
+below, which the code already implements.
 
-Convert `OBJECTS`, `SESSIONS`, `SIGN_STATE`, `ENCRYPT_STATE` to global
+### Option B — global `Mutex` (what the engine actually does)
+
+`OBJECTS`, `SESSIONS`, `SIGN_STATE`, `ENCRYPT_STATE`, etc. are global
 `Mutex<HashMap<...>>`. Multi-threaded callers serialise via the mutex.
-
-**Pros**: API users don't need thread affinity.
-
-**Cons**: Wider engine change. Mutex contention under load. Risk of
-deadlocks if engine internals ever call out and back.
-
-### Decision: **Option A for v0.1; Option B as a future option if profiling shows contention.**
-
-The Phase 4 `Session: !Send` constraint already aligns the KMIP server
-with Option A. The KMIP server can route crypto through a single
-`tokio::task::spawn_blocking` thread without touching the engine.
+Hot crypto paths copy key material out under a brief lock, drop it, then
+compute lock-free — so the mutex only guards map access, not the
+cryptographic work itself. API users need no thread affinity.
+Contention-reduction work (per-token sharding, atomic allocators, etc.)
+is tracked incrementally in the hsm-perf-bench plan rather than
+addressed all at once.
 
 ## 5. C ABI relationship
 

--- a/rust/src/ck_abi.rs
+++ b/rust/src/ck_abi.rs
@@ -579,9 +579,18 @@ macro_rules! guard_gcm_msg_param {
 // ─────────────────────────────────────────────────────────────────────────
 
 /// Native CK_C_INITIALIZE_ARGS (pkcs11t.h): four mutex callbacks, flags,
-/// pReserved. The engine is single-threaded (thread-local state) — the
-/// mutex callbacks and CKF_* locking flags are accepted and ignored;
-/// pReserved must be NULL (PKCS#11 v3.2 §5.6).
+/// pReserved. CORRECTED 2026-07-18 (was stale): the engine is NOT
+/// single-threaded — its state is a global `Mutex` shared by every
+/// thread (see `native/mod.rs` "Threading model" and
+/// `tests/multitenant_concurrency.rs`'s 20-thread contention test), so
+/// it does its own internal locking regardless of what the caller
+/// requests. Per PKCS#11 v3.2 §5.6, a library that locks internally MAY
+/// ignore the caller's `CKF_OS_LOCKING_OK` flag and mutex callbacks — so
+/// accepting and ignoring them here is conformant, not a shortcut.
+/// pReserved must still be NULL (this crate has no C_Initialize
+/// extension reachable through the native ABI; the wasm-facing
+/// `ffi::C_Initialize` has a separate, `#[cfg(feature = "acvp")]`-gated
+/// pReserved use for test/KAT tooling only).
 #[repr(C)]
 struct CK_C_INITIALIZE_ARGS {
     CreateMutex: *mut c_void,

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -15,14 +15,29 @@ use rand::SeedableRng;
 use rand::rngs::OsRng;
 
 /// ACVP-aware RNG selection macro.
-/// In ACVP mode, uses the persistent ChaCha20Rng from thread-local state
-/// so the counter advances across operations (matching C++ OpenSSL behaviour).
+/// In ACVP mode, uses the persistent ChaCha20Rng from global engine state
+/// (`ACVP_RNG`, a `Mutex<Option<ChaCha20Rng>>` — see `state.rs`) so the
+/// counter advances across operations (matching C++ OpenSSL behaviour).
 /// In normal mode, uses OsRng for non-deterministic randomness.
 ///
-/// Implementation: `take()` extracts the RNG from thread-local into a local
+/// Implementation: `take()` extracts the RNG from `ACVP_RNG` into a local
 /// variable, runs $body inline (NOT in a closure — so `return` works normally),
-/// then restores the advanced RNG back to thread-local. If $body exits via
+/// then restores the advanced RNG back to `ACVP_RNG`. If $body exits via
 /// `return` (error paths), the RNG is lost but `C_Initialize` recreates it.
+///
+/// PERF-BENCH FIX (2026-07-18, B4 step 1): the `acvp` Cargo feature is
+/// opt-in and OFF in every shipped artifact (KMIP server, wasm playground
+/// bundle, this crate's cdylib — see the feature doc comment in
+/// Cargo.toml). `C_Initialize` only ever populates `ACVP_RNG` with `Some`
+/// under `#[cfg(feature = "acvp")]`; without that feature it is `None`
+/// for the lifetime of the process. So every production `with_rng!` call
+/// was taking the `ACVP_RNG` mutex, finding `None`, and moving on — a
+/// pure-overhead lock acquisition on every rng-using FFI operation with
+/// zero chance of ever finding work to do. Below, the `acvp`-feature
+/// build keeps the original mutex-checking macro; the default
+/// (non-`acvp`) build gets a second definition that goes straight to
+/// `OsRng`, touching no lock at all.
+#[cfg(feature = "acvp")]
 macro_rules! with_rng {
     ($rng:ident, $body:block) => {{
         let mut _acvp_rng_cell = crate::state::ACVP_RNG.with(|r| r.borrow_mut().take());
@@ -34,7 +49,7 @@ macro_rules! with_rng {
             // `&mut $rng` borrow-check on wasm32 (E0596).
             let mut $rng = _acvp;
             let _with_rng_result = { $body };
-            // Restore the (now-advanced) RNG back to thread-local state
+            // Restore the (now-advanced) RNG back to global state
             crate::state::ACVP_RNG.with(|r| {
                 *r.borrow_mut() = _acvp_rng_cell;
             });
@@ -43,6 +58,14 @@ macro_rules! with_rng {
             let mut $rng = OsRng;
             $body
         }
+    }};
+}
+
+#[cfg(not(feature = "acvp"))]
+macro_rules! with_rng {
+    ($rng:ident, $body:block) => {{
+        let mut $rng = OsRng;
+        $body
     }};
 }
 
@@ -149,7 +172,7 @@ pub fn C_Finalize(p_reserved: *mut u8) -> u32 {
         }
         store.clear();
     });
-    NEXT_HANDLE.with(|h| *h.borrow_mut() = 100);
+    NEXT_HANDLE.store(100, std::sync::atomic::Ordering::Relaxed);
     SIGN_STATE.with(|s| s.borrow_mut().clear());
     VERIFY_STATE.with(|s| s.borrow_mut().clear());
     VERIFY_SIG_STATE.with(|s| s.borrow_mut().clear());
@@ -323,11 +346,7 @@ pub fn C_OpenSession(
         return CKR_SESSION_READ_WRITE_SO_EXISTS;
     }
     unsafe {
-        let handle = NEXT_SESSION_HANDLE.with(|h| {
-            let current = *h.borrow();
-            *h.borrow_mut() = current + 1;
-            current
-        });
+        let handle = NEXT_SESSION_HANDLE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         *ph_session = handle;
         SESSIONS.with(|s| {
             s.borrow_mut().insert(
@@ -503,71 +522,74 @@ pub fn C_Login(h_session: u32, user_type: u32, p_pin: *mut u8, ul_pin_len: u32) 
         return CKR_SESSION_READ_ONLY_EXISTS;
     }
 
-    let token_opt = TOKEN_STORE.with(|ts| ts.borrow().get(&slot_id).cloned());
-    let token = if let Some(t) = token_opt {
-        t
-    } else {
-        return CKR_GENERAL_ERROR;
-    };
-    if !token.initialized {
-        return CKR_OPERATION_NOT_INITIALIZED;
-    }
+    // PERF-BENCH FIX (2026-07-18): the exclusivity check (§5.6 "only one
+    // login wins") and the login_state write used to happen in two SEPARATE
+    // TOKEN_STORE lock acquisitions, with the check evaluated against a
+    // `.cloned()` snapshot taken before the write. Under concurrent
+    // C_Login calls on the same token (20-thread spike,
+    // p0_spike_multitenant_concurrency.rs::p0c) this is a TOCTOU race: many
+    // threads can all read the pre-login snapshot before any of them
+    // writes, so all of them pass the "not already logged in" check and
+    // all "succeed" — silently violating the one-login-wins guarantee.
+    // Fixed by making read-check-PIN-hash-write one atomic critical
+    // section per branch, inside a single lock acquisition (matching the
+    // pattern C_Logout already used correctly). `has_ro` still reads
+    // SESSIONS before entering the TOKEN_STORE closure, preserving the
+    // existing lock-acquisition order used throughout this file.
+    let has_ro = SESSIONS.with(|s| {
+        s.borrow()
+            .values()
+            .any(|sess| sess.slot_id == slot_id && !sess.rw_session)
+    });
+    let pin_bytes = unsafe { std::slice::from_raw_parts(p_pin, ul_pin_len as usize) };
 
-    // Evaluate PKCS#11 v3.2 Exclusivity Boundaries
-    match user_type {
-        CKU_SO => {
-            if token.login_state == LoginState::SO {
-                return CKR_USER_ALREADY_LOGGED_IN;
-            }
-            if token.login_state == LoginState::User {
-                return CKR_USER_ANOTHER_ALREADY_LOGGED_IN;
-            }
-            let has_ro = SESSIONS.with(|s| {
-                s.borrow()
-                    .values()
-                    .any(|sess| sess.slot_id == slot_id && !sess.rw_session)
-            });
-            if has_ro {
-                return CKR_SESSION_READ_ONLY_EXISTS;
-            }
-
-            let pin_bytes = unsafe { std::slice::from_raw_parts(p_pin, ul_pin_len as usize) };
-            if hash_pin(pin_bytes, &token.so_pin_salt) != token.so_pin_hash {
-                return CKR_PIN_INCORRECT;
-            }
-            TOKEN_STORE.with(|ts| {
-                if let Some(mut t) = ts.borrow_mut().get_mut(&slot_id) {
-                    t.login_state = LoginState::SO;
-                }
-            });
+    TOKEN_STORE.with(|ts| {
+        let mut store = ts.borrow_mut();
+        let token = match store.get_mut(&slot_id) {
+            Some(t) => t,
+            None => return CKR_GENERAL_ERROR,
+        };
+        if !token.initialized {
+            return CKR_OPERATION_NOT_INITIALIZED;
         }
-        CKU_USER => {
-            if token.login_state == LoginState::User {
-                return CKR_USER_ALREADY_LOGGED_IN;
-            }
-            if token.login_state == LoginState::SO {
-                return CKR_USER_ANOTHER_ALREADY_LOGGED_IN;
-            }
-            if token.user_pin_hash.is_none() || token.user_pin_salt.is_none() {
-                return CKR_USER_PIN_NOT_INITIALIZED;
-            }
-            let pin_bytes = unsafe { std::slice::from_raw_parts(p_pin, ul_pin_len as usize) };
-            if let (Some(salt), Some(hash)) = (&token.user_pin_salt, &token.user_pin_hash) {
-                if hash_pin(pin_bytes, salt) != *hash {
+
+        // Evaluate PKCS#11 v3.2 Exclusivity Boundaries
+        match user_type {
+            CKU_SO => {
+                if token.login_state == LoginState::SO {
+                    return CKR_USER_ALREADY_LOGGED_IN;
+                }
+                if token.login_state == LoginState::User {
+                    return CKR_USER_ANOTHER_ALREADY_LOGGED_IN;
+                }
+                if has_ro {
+                    return CKR_SESSION_READ_ONLY_EXISTS;
+                }
+                if hash_pin(pin_bytes, &token.so_pin_salt) != token.so_pin_hash {
                     return CKR_PIN_INCORRECT;
                 }
-            } else {
-                return CKR_USER_PIN_NOT_INITIALIZED;
+                token.login_state = LoginState::SO;
             }
-            TOKEN_STORE.with(|ts| {
-                if let Some(mut t) = ts.borrow_mut().get_mut(&slot_id) {
-                    t.login_state = LoginState::User;
+            CKU_USER => {
+                if token.login_state == LoginState::User {
+                    return CKR_USER_ALREADY_LOGGED_IN;
                 }
-            });
+                if token.login_state == LoginState::SO {
+                    return CKR_USER_ANOTHER_ALREADY_LOGGED_IN;
+                }
+                let (salt, hash) = match (&token.user_pin_salt, &token.user_pin_hash) {
+                    (Some(salt), Some(hash)) => (*salt, *hash),
+                    _ => return CKR_USER_PIN_NOT_INITIALIZED,
+                };
+                if hash_pin(pin_bytes, &salt) != hash {
+                    return CKR_PIN_INCORRECT;
+                }
+                token.login_state = LoginState::User;
+            }
+            _ => return CKR_USER_TYPE_INVALID,
         }
-        _ => return CKR_USER_TYPE_INVALID,
-    }
-    CKR_OK
+        CKR_OK
+    })
 }
 
 #[wasm_bindgen(js_name = _C_Logout)]

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -4828,27 +4828,40 @@ fn oaep_padding(hash_alg: u32, mgf: u32, label: &[u8]) -> Result<rsa::Oaep, u32>
     })
 }
 
-/// Parse CK_RSA_PKCS_OAEP_PARAMS (wasm32, 20 B: hashAlg, mgf, source,
-/// pSourceData, ulSourceDataLen) → (hashAlg, mgf, label). Absent/short param
-/// keeps the legacy default (SHA-256, MGF1-SHA256, no label).
+/// Parse CK_RSA_PKCS_OAEP_PARAMS (§6.4.4: hashAlg, mgf, source, pSourceData,
+/// ulSourceDataLen) at NATIVE width → (hashAlg, mgf, label). Absent/short
+/// param keeps the legacy default (SHA-256, MGF1-SHA256, no label).
+///
+/// Fixed from a hardcoded-4-byte-word parse (`*const u32`), which only
+/// matched wasm32's 4-byte `usize`/`CK_ULONG` layout and misparsed on
+/// native 64-bit builds (where `CK_ULONG`/pointer fields are 8 bytes —
+/// `pSourceData` at word-index 3 would land at the wrong byte offset
+/// entirely, and `ulSourceDataLen` past it further still). Same bug class
+/// `CKM_AES_GCM`'s and `CKM_CHACHA20_POLY1305`'s params parsing already
+/// had fixed elsewhere in this file (see `parse_chacha20_params` above for
+/// the exact precedent this copies: read as `*const usize`, which is 4
+/// bytes on wasm32 and 8 bytes on native 64-bit — one code path, both
+/// targets, matching the real struct's actual field width on each).
 unsafe fn parse_oaep_params(p_param: *const u8, ul_param_len: u32) -> Result<(u32, u32, Vec<u8>), u32> {
-    if p_param.is_null() || ul_param_len < 4 {
+    let usz = core::mem::size_of::<usize>();
+    if p_param.is_null() || (ul_param_len as usize) < usz {
         return Ok((CKM_SHA256, CKG_MGF1_SHA256, Vec::new()));
     }
-    let hash_alg = std::ptr::read_unaligned(p_param as *const u32);
-    if ul_param_len < 20 {
+    let prm = p_param as *const usize;
+    let hash_alg = *prm as u32;
+    if (ul_param_len as usize) < 5 * usz {
         return Ok((hash_alg, 0, Vec::new()));
     }
-    let mgf = std::ptr::read_unaligned((p_param as *const u32).add(1));
-    let source = std::ptr::read_unaligned((p_param as *const u32).add(2));
-    let src_ptr = std::ptr::read_unaligned((p_param as *const u32).add(3));
-    let src_len = std::ptr::read_unaligned((p_param as *const u32).add(4)) as usize;
-    let label = if src_ptr != 0 && src_len > 0 {
+    let mgf = *prm.add(1) as u32;
+    let source = *prm.add(2) as u32;
+    let src_ptr = *prm.add(3) as *const u8;
+    let src_len = *prm.add(4);
+    let label = if !src_ptr.is_null() && src_len > 0 {
         // §6.4.4 — only CKZ_DATA_SPECIFIED carries a label.
         if source != CKZ_DATA_SPECIFIED {
             return Err(CKR_MECHANISM_PARAM_INVALID);
         }
-        std::slice::from_raw_parts(src_ptr as *const u8, src_len).to_vec()
+        std::slice::from_raw_parts(src_ptr, src_len).to_vec()
     } else {
         Vec::new()
     };

--- a/rust/src/native/agree.rs
+++ b/rust/src/native/agree.rs
@@ -9,7 +9,9 @@
 
 use super::CkRv;
 use crate::constants::*;
-use crate::state::{get_object_attr_u32, get_object_value};
+use crate::state::{
+    get_object_attr_u32_from, get_object_value_from, resolve_session_access, with_object_checked,
+};
 
 /// Compute the ECDH shared secret between the private key at `priv_handle` and
 /// `peer_public`. The curve is inferred from the private key's PKCS#11 type +
@@ -21,9 +23,21 @@ use crate::state::{get_object_attr_u32, get_object_value};
 ///
 /// Returns `CKR_KEY_TYPE_INCONSISTENT` for any other key, `CKR_ARGUMENTS_BAD`
 /// for a malformed peer public.
-pub fn ecdh_agree(_session: u32, priv_handle: u32, peer_public: &[u8]) -> Result<Vec<u8>, CkRv> {
-    let key_type = get_object_attr_u32(priv_handle, CKA_KEY_TYPE).ok_or(CKR_KEY_HANDLE_INVALID)?;
-    let scalar = get_object_value(priv_handle).ok_or(CKR_KEY_HANDLE_INVALID)?;
+pub fn ecdh_agree(session: u32, priv_handle: u32, peer_public: &[u8]) -> Result<Vec<u8>, CkRv> {
+    // Isolation gate folded into the existing single lookup. This
+    // function's pre-existing error vocabulary (CKR_KEY_HANDLE_INVALID,
+    // the derive-context code C_DeriveKey callers expect) is preserved
+    // for missing/cross-slot/not-logged-in alike — the gate's generic
+    // CKR_OBJECT_HANDLE_INVALID is remapped so callers see no behavior
+    // change, while cross-tenant access now denies exactly like a
+    // missing handle (same anti-oracle property, this function's code).
+    let access = resolve_session_access(session)?;
+    let (key_type, scalar) = with_object_checked(&access, priv_handle, |attrs| {
+        (get_object_attr_u32_from(attrs, CKA_KEY_TYPE), get_object_value_from(attrs))
+    })
+    .map_err(|_| CKR_KEY_HANDLE_INVALID)?;
+    let key_type = key_type.ok_or(CKR_KEY_HANDLE_INVALID)?;
+    let scalar = scalar.ok_or(CKR_KEY_HANDLE_INVALID)?;
     match (key_type, scalar.len()) {
         // ── X25519 (RFC 7748) ───────────────────────────────────────────────
         (CKK_EC_MONTGOMERY, 32) => {

--- a/rust/src/native/derive.rs
+++ b/rust/src/native/derive.rs
@@ -19,7 +19,8 @@ use super::CkRv;
 use crate::constants::*;
 use crate::crypto::handlers::Attributes;
 use crate::state::{
-    allocate_handle_owned, compute_kcv, get_object_value, store_bool, store_ulong,
+    allocate_handle_owned, compute_kcv, get_object_value, get_object_value_from,
+    resolve_session_access, store_bool, store_ulong, with_object_checked,
 };
 
 /// Register a freshly-derived generic-secret key `value` as a session object
@@ -65,8 +66,17 @@ fn register_derived_secret(session: u32, value: Vec<u8>) -> u32 {
 /// **Pre-condition**: `session` must be a valid R/W user session; both
 /// handles must reference secret-key objects with a `CKA_VALUE`.
 pub fn concatenate_keys(session: u32, base: u32, second: u32) -> Result<u32, CkRv> {
-    let base_val = get_object_value(base).ok_or(CKR_KEY_HANDLE_INVALID)?;
-    let second_val = get_object_value(second).ok_or(CKR_KEY_HANDLE_INVALID)?;
+    // Isolation gate on both component handles — preserves this
+    // function's existing CKR_KEY_HANDLE_INVALID error code (the
+    // derive-context vocabulary C_DeriveKey callers expect) for missing,
+    // cross-slot, or not-logged-in handles alike.
+    let access = resolve_session_access(session).map_err(|_| CKR_KEY_HANDLE_INVALID)?;
+    let base_val = with_object_checked(&access, base, get_object_value_from)
+        .map_err(|_| CKR_KEY_HANDLE_INVALID)?
+        .ok_or(CKR_KEY_HANDLE_INVALID)?;
+    let second_val = with_object_checked(&access, second, get_object_value_from)
+        .map_err(|_| CKR_KEY_HANDLE_INVALID)?
+        .ok_or(CKR_KEY_HANDLE_INVALID)?;
     let combined = [base_val.as_slice(), second_val.as_slice()].concat();
     Ok(register_derived_secret(session, combined))
 }
@@ -80,7 +90,10 @@ pub fn concatenate_keys(session: u32, base: u32, second: u32) -> Result<u32, CkR
 ///
 /// **Pre-condition**: `session` valid R/W; `base` a secret key with a value.
 pub fn concatenate_data(session: u32, base: u32, data: &[u8]) -> Result<u32, CkRv> {
-    let base_val = get_object_value(base).ok_or(CKR_KEY_HANDLE_INVALID)?;
+    let access = resolve_session_access(session).map_err(|_| CKR_KEY_HANDLE_INVALID)?;
+    let base_val = with_object_checked(&access, base, get_object_value_from)
+        .map_err(|_| CKR_KEY_HANDLE_INVALID)?
+        .ok_or(CKR_KEY_HANDLE_INVALID)?;
     let combined = [base_val.as_slice(), data].concat();
     Ok(register_derived_secret(session, combined))
 }
@@ -103,7 +116,10 @@ pub fn digest_key_derivation(
     mech: u32,
     out_len: Option<usize>,
 ) -> Result<u32, CkRv> {
-    let base_val = get_object_value(base).ok_or(CKR_KEY_HANDLE_INVALID)?;
+    let access = resolve_session_access(session).map_err(|_| CKR_KEY_HANDLE_INVALID)?;
+    let base_val = with_object_checked(&access, base, get_object_value_from)
+        .map_err(|_| CKR_KEY_HANDLE_INVALID)?
+        .ok_or(CKR_KEY_HANDLE_INVALID)?;
     let mut digest = digest_of(mech, &base_val)?;
     if let Some(n) = out_len {
         if n > digest.len() {

--- a/rust/src/native/encrypt.rs
+++ b/rust/src/native/encrypt.rs
@@ -22,7 +22,11 @@
 
 use super::CkRv;
 use crate::constants::*;
-use crate::state::{get_ec_point_sec1, get_object_attr_u32, get_object_param_set, get_object_value, OBJECTS};
+use crate::state::{
+    check_mechanism_allowed_from, get_ec_point_sec1_from, get_object_attr_u32_from,
+    get_object_param_set_from, get_object_value, get_object_value_from, read_bool_attr,
+    resolve_session_access, with_object_checked, SessionAccess, OBJECTS,
+};
 
 // PKCS#11 v3.2 §5.18 — KEM permission flags. CKA_ENCAPSULATE / CKA_DECAPSULATE.
 use crate::constants::{CKA_DECAPSULATE, CKA_DECRYPT, CKA_ENCAPSULATE, CKA_ENCRYPT};
@@ -51,42 +55,54 @@ use crate::constants::{CKA_DECAPSULATE, CKA_DECRYPT, CKA_ENCAPSULATE, CKA_ENCRYP
 /// - ECDH-P256/P384/P521: ct = SEC1 uncompressed point (65/97/133), ss = curve field size (32/48/66).
 /// - X25519/X448 (RFC 7748): ct = 32/56, ss = 32/56.
 pub fn encapsulate(
-    _session: u32,
+    session: u32,
     public_key_handle: u32,
     mechanism: u32,
 ) -> Result<(Vec<u8>, Vec<u8>), CkRv> {
     use ml_kem::{kem::Encapsulate, EncodedSizeUser, KemCore};
 
+    let access = resolve_session_access(session)?;
+
     if mechanism == CKM_ECDH1_DERIVE || mechanism == CKM_EC_MONTGOMERY_KEY_DERIVE {
-        return classical_encapsulate(public_key_handle, mechanism);
+        return classical_encapsulate(&access, public_key_handle, mechanism);
     }
     if mechanism == CKM_PQCTODAY_FRODOKEM_ENCAPSULATE {
-        return frodokem_encapsulate(public_key_handle);
+        return frodokem_encapsulate(&access, public_key_handle);
     }
     if mechanism == CKM_PQCTODAY_CLASSIC_MCELIECE_ENCAPSULATE {
-        return classic_mceliece_encapsulate(public_key_handle);
+        return classic_mceliece_encapsulate(&access, public_key_handle);
     }
     if mechanism != CKM_ML_KEM {
         return Err(CKR_MECHANISM_INVALID);
     }
-    if !check_flag(public_key_handle, CKA_ENCAPSULATE) {
+
+    // Isolation gate + CKA_ENCAPSULATE + CKA_ALLOWED_MECHANISMS +
+    // CKA_KEY_TYPE + CKA_PRIV_PARAM_SET + CKA_VALUE, all from ONE borrow.
+    let (can_encap, mech_ok, key_type, ps, pub_key_bytes) =
+        with_object_checked(&access, public_key_handle, |attrs| {
+            (
+                read_bool_attr(attrs, CKA_ENCAPSULATE),
+                check_mechanism_allowed_from(attrs, mechanism),
+                get_object_attr_u32_from(attrs, CKA_KEY_TYPE),
+                get_object_param_set_from(attrs),
+                get_object_value_from(attrs),
+            )
+        })?;
+    if !can_encap {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    // PKCS#11 v3.2 §4.8 Table 13 — CKA_ALLOWED_MECHANISMS.
-    crate::state::check_mechanism_allowed(public_key_handle, mechanism)?;
-
+    mech_ok?;
     // PKCS#11 v3.2 §5.18.8 — CKM_ML_KEM requires an ML-KEM key
     // (compliance-audit P-10).
-    if get_object_attr_u32(public_key_handle, CKA_KEY_TYPE) != Some(CKK_ML_KEM) {
+    if key_type != Some(CKK_ML_KEM) {
         return Err(CKR_KEY_TYPE_INCONSISTENT);
     }
-    let ps = get_object_param_set(public_key_handle);
     // P-10: no silent ML-KEM-768 default — a key without
     // CKA_PARAMETER_SET is an incomplete object.
     if ps == 0 {
         return Err(CKR_TEMPLATE_INCOMPLETE);
     }
-    let pub_key_bytes = get_object_value(public_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+    let pub_key_bytes = pub_key_bytes.ok_or(CKR_ARGUMENTS_BAD)?;
     let mut rng = rand::rngs::OsRng;
 
     let (ct, ss) = match ps {
@@ -136,7 +152,7 @@ pub fn encapsulate(
 ///
 /// `coins` must be exactly 32 bytes → otherwise `CKR_ARGUMENTS_BAD`.
 pub fn encapsulate_deterministic(
-    _session: u32,
+    session: u32,
     public_key_handle: u32,
     mechanism: u32,
     coins: &[u8],
@@ -146,21 +162,30 @@ pub fn encapsulate_deterministic(
     if mechanism != CKM_ML_KEM {
         return Err(CKR_MECHANISM_INVALID);
     }
-    if !check_flag(public_key_handle, CKA_ENCAPSULATE) {
+    let access = resolve_session_access(session)?;
+    let (can_encap, mech_ok, key_type, ps, pub_key_bytes) =
+        with_object_checked(&access, public_key_handle, |attrs| {
+            (
+                read_bool_attr(attrs, CKA_ENCAPSULATE),
+                check_mechanism_allowed_from(attrs, mechanism),
+                get_object_attr_u32_from(attrs, CKA_KEY_TYPE),
+                get_object_param_set_from(attrs),
+                get_object_value_from(attrs),
+            )
+        })?;
+    if !can_encap {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    // PKCS#11 v3.2 §4.8 Table 13 — CKA_ALLOWED_MECHANISMS.
-    crate::state::check_mechanism_allowed(public_key_handle, mechanism)?;
-    if get_object_attr_u32(public_key_handle, CKA_KEY_TYPE) != Some(CKK_ML_KEM) {
+    mech_ok?;
+    if key_type != Some(CKK_ML_KEM) {
         return Err(CKR_KEY_TYPE_INCONSISTENT);
     }
-    let ps = get_object_param_set(public_key_handle);
     if ps == 0 {
         return Err(CKR_TEMPLATE_INCOMPLETE);
     }
     // FIPS 203 §7.2 — m is exactly 32 bytes.
     let m = ml_kem::B32::try_from(coins).map_err(|_| CKR_ARGUMENTS_BAD)?;
-    let pub_key_bytes = get_object_value(public_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+    let pub_key_bytes = pub_key_bytes.ok_or(CKR_ARGUMENTS_BAD)?;
 
     let (ct, ss) = match ps {
         CKP_ML_KEM_512 => {
@@ -201,37 +226,47 @@ pub fn encapsulate_deterministic(
 /// `CKA_DECAPSULATE = true`. `ciphertext` length must match the
 /// parameter set's ML-KEM ct size (768 / 1088 / 1568 for 512 / 768 / 1024).
 pub fn decapsulate(
-    _session: u32,
+    session: u32,
     private_key_handle: u32,
     mechanism: u32,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>, CkRv> {
     use ml_kem::{kem::Decapsulate, EncodedSizeUser, KemCore};
 
+    let access = resolve_session_access(session)?;
+
     if mechanism == CKM_ECDH1_DERIVE || mechanism == CKM_EC_MONTGOMERY_KEY_DERIVE {
-        return classical_decapsulate(private_key_handle, mechanism, ciphertext);
+        return classical_decapsulate(&access, private_key_handle, mechanism, ciphertext);
     }
     if mechanism == CKM_PQCTODAY_FRODOKEM_ENCAPSULATE {
-        return frodokem_decapsulate(private_key_handle, ciphertext);
+        return frodokem_decapsulate(&access, private_key_handle, ciphertext);
     }
     if mechanism == CKM_PQCTODAY_CLASSIC_MCELIECE_ENCAPSULATE {
-        return classic_mceliece_decapsulate(private_key_handle, ciphertext);
+        return classic_mceliece_decapsulate(&access, private_key_handle, ciphertext);
     }
     if mechanism != CKM_ML_KEM {
         return Err(CKR_MECHANISM_INVALID);
     }
-    if !check_flag(private_key_handle, CKA_DECAPSULATE) {
+
+    let (can_decap, mech_ok, key_type, ps, prv_key_bytes) =
+        with_object_checked(&access, private_key_handle, |attrs| {
+            (
+                read_bool_attr(attrs, CKA_DECAPSULATE),
+                check_mechanism_allowed_from(attrs, mechanism),
+                get_object_attr_u32_from(attrs, CKA_KEY_TYPE),
+                get_object_param_set_from(attrs),
+                get_object_value_from(attrs),
+            )
+        })?;
+    if !can_decap {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    // PKCS#11 v3.2 §4.8 Table 13 — CKA_ALLOWED_MECHANISMS.
-    crate::state::check_mechanism_allowed(private_key_handle, mechanism)?;
-
+    mech_ok?;
     // PKCS#11 v3.2 §5.18.9 — CKM_ML_KEM requires an ML-KEM key
     // (compliance-audit P-10).
-    if get_object_attr_u32(private_key_handle, CKA_KEY_TYPE) != Some(CKK_ML_KEM) {
+    if key_type != Some(CKK_ML_KEM) {
         return Err(CKR_KEY_TYPE_INCONSISTENT);
     }
-    let ps = get_object_param_set(private_key_handle);
     // P-10: no silent ML-KEM-768 default — a key without
     // CKA_PARAMETER_SET is an incomplete object.
     if ps == 0 {
@@ -247,7 +282,7 @@ pub fn decapsulate(
         return Err(CKR_ARGUMENTS_BAD);
     }
 
-    let prv_key_bytes = get_object_value(private_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+    let prv_key_bytes = prv_key_bytes.ok_or(CKR_ARGUMENTS_BAD)?;
 
     let ss = match ps {
         CKP_ML_KEM_512 => {
@@ -286,20 +321,39 @@ pub fn decapsulate(
 /// classical half (KAT-verified there — see `classical_kem` unit tests
 /// below for the standalone curve-by-curve coverage), reused here rather
 /// than duplicated.
-fn classical_encapsulate(public_key_handle: u32, mechanism: u32) -> Result<(Vec<u8>, Vec<u8>), CkRv> {
-    if !check_flag(public_key_handle, CKA_ENCAPSULATE) {
+fn classical_encapsulate(
+    access: &SessionAccess,
+    public_key_handle: u32,
+    mechanism: u32,
+) -> Result<(Vec<u8>, Vec<u8>), CkRv> {
+    // Isolation gate + CKA_ENCAPSULATE + CKA_ALLOWED_MECHANISMS +
+    // CKA_KEY_TYPE + CKA_PRIV_PARAM_SET + CKA_EC_POINT + CKA_VALUE — every
+    // field either mechanism branch below might need, fetched together
+    // under ONE OBJECTS lock (cheap absent-key lookups for the branch not
+    // taken, rather than a second lock acquisition per branch).
+    let (can_encap, mech_ok, key_type, ps, ec_point, raw_value) =
+        with_object_checked(access, public_key_handle, |attrs| {
+            (
+                read_bool_attr(attrs, CKA_ENCAPSULATE),
+                check_mechanism_allowed_from(attrs, mechanism),
+                get_object_attr_u32_from(attrs, CKA_KEY_TYPE),
+                get_object_param_set_from(attrs),
+                get_ec_point_sec1_from(attrs),
+                get_object_value_from(attrs),
+            )
+        })?;
+    if !can_encap {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    // PKCS#11 v3.2 §4.8 Table 13 — CKA_ALLOWED_MECHANISMS.
-    crate::state::check_mechanism_allowed(public_key_handle, mechanism)?;
+    mech_ok?;
     let mut rng = rand::rngs::OsRng;
     match mechanism {
         CKM_ECDH1_DERIVE => {
-            if get_object_attr_u32(public_key_handle, CKA_KEY_TYPE) != Some(CKK_EC) {
+            if key_type != Some(CKK_EC) {
                 return Err(CKR_KEY_TYPE_INCONSISTENT);
             }
-            let point = get_ec_point_sec1(public_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
-            match get_object_param_set(public_key_handle) {
+            let point = ec_point.ok_or(CKR_ARGUMENTS_BAD)?;
+            match ps {
                 256 => {
                     let peer = p256::PublicKey::from_sec1_bytes(&point)
                         .map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
@@ -328,10 +382,10 @@ fn classical_encapsulate(public_key_handle: u32, mechanism: u32) -> Result<(Vec<
             }
         }
         CKM_EC_MONTGOMERY_KEY_DERIVE => {
-            if get_object_attr_u32(public_key_handle, CKA_KEY_TYPE) != Some(CKK_EC_MONTGOMERY) {
+            if key_type != Some(CKK_EC_MONTGOMERY) {
                 return Err(CKR_KEY_TYPE_INCONSISTENT);
             }
-            let point = get_object_value(public_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+            let point = raw_value.ok_or(CKR_ARGUMENTS_BAD)?;
             match point.len() {
                 32 => {
                     let peer: [u8; 32] = point.as_slice().try_into().map_err(|_| CKR_ARGUMENTS_BAD)?;
@@ -359,19 +413,33 @@ fn classical_encapsulate(public_key_handle: u32, mechanism: u32) -> Result<(Vec<
 /// Classical-KEM decapsulation — the inverse of `classical_encapsulate`.
 /// Reads the static scalar from its handle (never exported) and DHs it
 /// against the ephemeral public key carried in `ciphertext`.
-fn classical_decapsulate(private_key_handle: u32, mechanism: u32, ciphertext: &[u8]) -> Result<Vec<u8>, CkRv> {
-    if !check_flag(private_key_handle, CKA_DECAPSULATE) {
+fn classical_decapsulate(
+    access: &SessionAccess,
+    private_key_handle: u32,
+    mechanism: u32,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, CkRv> {
+    let (can_decap, mech_ok, key_type, ps, scalar) =
+        with_object_checked(access, private_key_handle, |attrs| {
+            (
+                read_bool_attr(attrs, CKA_DECAPSULATE),
+                check_mechanism_allowed_from(attrs, mechanism),
+                get_object_attr_u32_from(attrs, CKA_KEY_TYPE),
+                get_object_param_set_from(attrs),
+                get_object_value_from(attrs),
+            )
+        })?;
+    if !can_decap {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    // PKCS#11 v3.2 §4.8 Table 13 — CKA_ALLOWED_MECHANISMS.
-    crate::state::check_mechanism_allowed(private_key_handle, mechanism)?;
+    mech_ok?;
     match mechanism {
         CKM_ECDH1_DERIVE => {
-            if get_object_attr_u32(private_key_handle, CKA_KEY_TYPE) != Some(CKK_EC) {
+            if key_type != Some(CKK_EC) {
                 return Err(CKR_KEY_TYPE_INCONSISTENT);
             }
-            let scalar = get_object_value(private_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
-            match get_object_param_set(private_key_handle) {
+            let scalar = scalar.ok_or(CKR_ARGUMENTS_BAD)?;
+            match ps {
                 256 => {
                     let secret = p256::SecretKey::from_slice(&scalar).map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
                     let eph_pub = p256::PublicKey::from_sec1_bytes(ciphertext)
@@ -397,10 +465,10 @@ fn classical_decapsulate(private_key_handle: u32, mechanism: u32, ciphertext: &[
             }
         }
         CKM_EC_MONTGOMERY_KEY_DERIVE => {
-            if get_object_attr_u32(private_key_handle, CKA_KEY_TYPE) != Some(CKK_EC_MONTGOMERY) {
+            if key_type != Some(CKK_EC_MONTGOMERY) {
                 return Err(CKR_KEY_TYPE_INCONSISTENT);
             }
-            let scalar = get_object_value(private_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+            let scalar = scalar.ok_or(CKR_ARGUMENTS_BAD)?;
             match scalar.len() {
                 32 => {
                     let arr: [u8; 32] = scalar.as_slice().try_into().map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
@@ -433,22 +501,30 @@ fn classical_decapsulate(private_key_handle: u32, mechanism: u32, ciphertext: &[
 /// RNG note — see [`super::keygen::generate_frodokem_keypair`]: `frodo-kem`
 /// needs `rand_core 0.10`'s `CryptoRng`, not this engine's usual
 /// `rand::rngs::OsRng`.
-fn frodokem_encapsulate(public_key_handle: u32) -> Result<(Vec<u8>, Vec<u8>), CkRv> {
+fn frodokem_encapsulate(access: &SessionAccess, public_key_handle: u32) -> Result<(Vec<u8>, Vec<u8>), CkRv> {
     use getrandom_0_4::rand_core::UnwrapErr;
     use getrandom_0_4::SysRng;
 
-    if !check_flag(public_key_handle, CKA_ENCAPSULATE) {
+    let (can_encap, key_type, ps, pub_key_bytes) =
+        with_object_checked(access, public_key_handle, |attrs| {
+            (
+                read_bool_attr(attrs, CKA_ENCAPSULATE),
+                get_object_attr_u32_from(attrs, CKA_KEY_TYPE),
+                get_object_param_set_from(attrs),
+                get_object_value_from(attrs),
+            )
+        })?;
+    if !can_encap {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    if get_object_attr_u32(public_key_handle, CKA_KEY_TYPE) != Some(CKK_PQCTODAY_FRODOKEM) {
+    if key_type != Some(CKK_PQCTODAY_FRODOKEM) {
         return Err(CKR_KEY_TYPE_INCONSISTENT);
     }
-    let ps = get_object_param_set(public_key_handle);
     if ps == 0 {
         return Err(CKR_TEMPLATE_INCOMPLETE);
     }
     let alg = super::keygen::frodokem_algorithm(ps)?;
-    let pub_key_bytes = get_object_value(public_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+    let pub_key_bytes = pub_key_bytes.ok_or(CKR_ARGUMENTS_BAD)?;
     let ek = frodo_kem::EncryptionKey::from_bytes(alg, &pub_key_bytes)
         .map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
     let mut rng = UnwrapErr(SysRng);
@@ -460,19 +536,27 @@ fn frodokem_encapsulate(public_key_handle: u32) -> Result<(Vec<u8>, Vec<u8>), Ck
 
 /// FrodoKEM decapsulation (`CKM_PQCTODAY_FRODOKEM_ENCAPSULATE`). Returns the
 /// recovered shared secret.
-fn frodokem_decapsulate(private_key_handle: u32, ciphertext: &[u8]) -> Result<Vec<u8>, CkRv> {
-    if !check_flag(private_key_handle, CKA_DECAPSULATE) {
+fn frodokem_decapsulate(access: &SessionAccess, private_key_handle: u32, ciphertext: &[u8]) -> Result<Vec<u8>, CkRv> {
+    let (can_decap, key_type, ps, prv_key_bytes) =
+        with_object_checked(access, private_key_handle, |attrs| {
+            (
+                read_bool_attr(attrs, CKA_DECAPSULATE),
+                get_object_attr_u32_from(attrs, CKA_KEY_TYPE),
+                get_object_param_set_from(attrs),
+                get_object_value_from(attrs),
+            )
+        })?;
+    if !can_decap {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    if get_object_attr_u32(private_key_handle, CKA_KEY_TYPE) != Some(CKK_PQCTODAY_FRODOKEM) {
+    if key_type != Some(CKK_PQCTODAY_FRODOKEM) {
         return Err(CKR_KEY_TYPE_INCONSISTENT);
     }
-    let ps = get_object_param_set(private_key_handle);
     if ps == 0 {
         return Err(CKR_TEMPLATE_INCOMPLETE);
     }
     let alg = super::keygen::frodokem_algorithm(ps)?;
-    let prv_key_bytes = get_object_value(private_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+    let prv_key_bytes = prv_key_bytes.ok_or(CKR_ARGUMENTS_BAD)?;
     let dk = frodo_kem::DecryptionKey::from_bytes(alg, &prv_key_bytes)
         .map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
     let ct = frodo_kem::Ciphertext::from_bytes(alg, ciphertext).map_err(|_| CKR_ARGUMENTS_BAD)?;
@@ -491,19 +575,28 @@ fn frodokem_decapsulate(private_key_handle: u32, ciphertext: &[u8]) -> Result<Ve
 /// Unlike FrodoKEM, `classic-mceliece-rust` uses `rand 0.8` — the same
 /// version this engine already uses elsewhere — so `rand::rngs::OsRng`
 /// works directly.
-fn classic_mceliece_encapsulate(public_key_handle: u32) -> Result<(Vec<u8>, Vec<u8>), CkRv> {
+fn classic_mceliece_encapsulate(access: &SessionAccess, public_key_handle: u32) -> Result<(Vec<u8>, Vec<u8>), CkRv> {
     use classic_mceliece_rust::{encapsulate_boxed, PublicKey, CRYPTO_PUBLICKEYBYTES};
 
-    if !check_flag(public_key_handle, CKA_ENCAPSULATE) {
+    let (can_encap, key_type, ps, pub_key_bytes) =
+        with_object_checked(access, public_key_handle, |attrs| {
+            (
+                read_bool_attr(attrs, CKA_ENCAPSULATE),
+                get_object_attr_u32_from(attrs, CKA_KEY_TYPE),
+                get_object_param_set_from(attrs),
+                get_object_value_from(attrs),
+            )
+        })?;
+    if !can_encap {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    if get_object_attr_u32(public_key_handle, CKA_KEY_TYPE) != Some(CKK_PQCTODAY_CLASSIC_MCELIECE) {
+    if key_type != Some(CKK_PQCTODAY_CLASSIC_MCELIECE) {
         return Err(CKR_KEY_TYPE_INCONSISTENT);
     }
-    if get_object_param_set(public_key_handle) != CKP_CLASSIC_MCELIECE_6688128 {
+    if ps != CKP_CLASSIC_MCELIECE_6688128 {
         return Err(CKR_ARGUMENTS_BAD);
     }
-    let pub_key_bytes = get_object_value(public_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+    let pub_key_bytes = pub_key_bytes.ok_or(CKR_ARGUMENTS_BAD)?;
     let mut pk_arr: [u8; CRYPTO_PUBLICKEYBYTES] = pub_key_bytes
         .as_slice()
         .try_into()
@@ -518,22 +611,31 @@ fn classic_mceliece_encapsulate(public_key_handle: u32) -> Result<(Vec<u8>, Vec<
 
 /// Classic McEliece decapsulation (`CKM_PQCTODAY_CLASSIC_MCELIECE_ENCAPSULATE`).
 /// Returns the recovered shared secret.
-fn classic_mceliece_decapsulate(private_key_handle: u32, ciphertext: &[u8]) -> Result<Vec<u8>, CkRv> {
+fn classic_mceliece_decapsulate(access: &SessionAccess, private_key_handle: u32, ciphertext: &[u8]) -> Result<Vec<u8>, CkRv> {
     use classic_mceliece_rust::{decapsulate_boxed, Ciphertext, SecretKey, CRYPTO_CIPHERTEXTBYTES, CRYPTO_SECRETKEYBYTES};
 
-    if !check_flag(private_key_handle, CKA_DECAPSULATE) {
+    let (can_decap, key_type, ps, prv_key_bytes) =
+        with_object_checked(access, private_key_handle, |attrs| {
+            (
+                read_bool_attr(attrs, CKA_DECAPSULATE),
+                get_object_attr_u32_from(attrs, CKA_KEY_TYPE),
+                get_object_param_set_from(attrs),
+                get_object_value_from(attrs),
+            )
+        })?;
+    if !can_decap {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    if get_object_attr_u32(private_key_handle, CKA_KEY_TYPE) != Some(CKK_PQCTODAY_CLASSIC_MCELIECE) {
+    if key_type != Some(CKK_PQCTODAY_CLASSIC_MCELIECE) {
         return Err(CKR_KEY_TYPE_INCONSISTENT);
     }
-    if get_object_param_set(private_key_handle) != CKP_CLASSIC_MCELIECE_6688128 {
+    if ps != CKP_CLASSIC_MCELIECE_6688128 {
         return Err(CKR_ARGUMENTS_BAD);
     }
     if ciphertext.len() != CRYPTO_CIPHERTEXTBYTES {
         return Err(CKR_ARGUMENTS_BAD);
     }
-    let mut prv_key_bytes = get_object_value(private_key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+    let mut prv_key_bytes = prv_key_bytes.ok_or(CKR_ARGUMENTS_BAD)?;
     let sk_arr: &mut [u8; CRYPTO_SECRETKEYBYTES] = (&mut prv_key_bytes[..])
         .try_into()
         .map_err(|_| CKR_KEY_TYPE_INCONSISTENT)?;
@@ -575,7 +677,7 @@ fn classic_mceliece_decapsulate(private_key_handle: u32, ciphertext: &[u8]) -> R
 /// paths run the identical match body instead of two copies that used
 /// to silently drift apart.
 pub fn encrypt(
-    _session: u32,
+    session: u32,
     key_handle: u32,
     mechanism: u32,
     plaintext: &[u8],
@@ -584,12 +686,19 @@ pub fn encrypt(
     aad: &[u8],
     tag_len: Option<usize>,
 ) -> Result<Vec<u8>, CkRv> {
-    if !check_flag(key_handle, CKA_ENCRYPT) {
+    let access = resolve_session_access(session)?;
+    let (can_encrypt, mech_ok, key_bytes) = with_object_checked(&access, key_handle, |attrs| {
+        (
+            read_bool_attr(attrs, CKA_ENCRYPT),
+            check_mechanism_allowed_from(attrs, mechanism),
+            get_object_value_from(attrs),
+        )
+    })?;
+    if !can_encrypt {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    // PKCS#11 v3.2 §4.8 Table 13 — CKA_ALLOWED_MECHANISMS.
-    crate::state::check_mechanism_allowed(key_handle, mechanism)?;
-    let key_bytes = get_object_value(key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+    mech_ok?;
+    let key_bytes = key_bytes.ok_or(CKR_ARGUMENTS_BAD)?;
     encrypt_with_key_bytes(&key_bytes, mechanism, plaintext, iv, oaep, aad, tag_len)
 }
 
@@ -597,7 +706,7 @@ pub fn encrypt(
 /// Gap-remediation Phase F note on why this now delegates to
 /// [`decrypt_with_key_bytes`].
 pub fn decrypt(
-    _session: u32,
+    session: u32,
     key_handle: u32,
     mechanism: u32,
     ciphertext: &[u8],
@@ -606,12 +715,19 @@ pub fn decrypt(
     aad: &[u8],
     tag_len: Option<usize>,
 ) -> Result<Vec<u8>, CkRv> {
-    if !check_flag(key_handle, CKA_DECRYPT) {
+    let access = resolve_session_access(session)?;
+    let (can_decrypt, mech_ok, key_bytes) = with_object_checked(&access, key_handle, |attrs| {
+        (
+            read_bool_attr(attrs, CKA_DECRYPT),
+            check_mechanism_allowed_from(attrs, mechanism),
+            get_object_value_from(attrs),
+        )
+    })?;
+    if !can_decrypt {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    // PKCS#11 v3.2 §4.8 Table 13 — CKA_ALLOWED_MECHANISMS.
-    crate::state::check_mechanism_allowed(key_handle, mechanism)?;
-    let key_bytes = get_object_value(key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+    mech_ok?;
+    let key_bytes = key_bytes.ok_or(CKR_ARGUMENTS_BAD)?;
     decrypt_with_key_bytes(&key_bytes, mechanism, ciphertext, iv, oaep, aad, tag_len)
 }
 
@@ -1221,20 +1337,10 @@ fn aes_cbc_decrypt(key: &[u8], iv: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, 
     Ok(out)
 }
 
-// ── Helpers ─────────────────────────────────────────────────────────────────
-
-/// Check a single CK_BBOOL attribute on the key. Returns `false` if the
-/// key is missing or the flag is not set. Mirrors `check_can_sign`
-/// in [`super::sign`].
-fn check_flag(key_handle: u32, attr_type: u32) -> bool {
-    OBJECTS.with(|o| {
-        o.borrow()
-            .get(&key_handle)
-            .and_then(|attrs| attrs.get(&attr_type))
-            .map(|v| !v.is_empty() && v[0] == 0x01)
-            .unwrap_or(false)
-    })
-}
+// The former `check_flag(key_handle, attr_type)` free function (a direct,
+// ungated OBJECTS lock) is gone — CKA_ENCAPSULATE/CKA_DECAPSULATE/
+// CKA_ENCRYPT/CKA_DECRYPT are now read via `read_bool_attr` inside the
+// isolation gate's single borrow (`with_object_checked` above).
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/native/hybrid.rs
+++ b/rust/src/native/hybrid.rs
@@ -202,6 +202,15 @@ pub fn decapsulate(
     classical_priv: u32,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>, CkRv> {
+    // Isolation gate on the classical half's handle. NOTE: the ML-KEM
+    // half is gated TRANSITIVELY (native::encrypt::decapsulate below is
+    // gated in encrypt.rs) — this direct fetch is the one place a
+    // transitive gate is NOT enough, since this function reads
+    // classical_priv's CKA_VALUE itself rather than delegating.
+    let access = crate::state::resolve_session_access(session).map_err(|_| CKR_KEY_HANDLE_INVALID)?;
+    let scalar = crate::state::with_object_checked(&access, classical_priv, crate::state::get_object_value_from)
+        .map_err(|_| CKR_KEY_HANDLE_INVALID)?
+        .ok_or(CKR_KEY_HANDLE_INVALID)?;
     match hybrid {
         Hybrid::X25519MlKem768 => {
             if ciphertext.len() != MLKEM768_CT + X25519_LEN {
@@ -209,7 +218,6 @@ pub fn decapsulate(
             }
             let (ct_mlkem_b, eph_x_b) = ciphertext.split_at(MLKEM768_CT);
             let ss_mlkem = crate::native::encrypt::decapsulate(session, mlkem_priv, CKM_ML_KEM, ct_mlkem_b)?;
-            let scalar = crate::state::get_object_value(classical_priv).ok_or(CKR_KEY_HANDLE_INVALID)?;
             let x_sec: [u8; 32] = scalar.as_slice().try_into().map_err(|_| CKR_KEY_HANDLE_INVALID)?;
             let eph_pub: [u8; 32] = eph_x_b.try_into().map_err(|_| CKR_ARGUMENTS_BAD)?;
             let secret = x25519_dalek::StaticSecret::from(x_sec);
@@ -222,7 +230,6 @@ pub fn decapsulate(
             }
             let (eph_p_b, ct_mlkem_b) = ciphertext.split_at(P256_PUB);
             let ss_mlkem = crate::native::encrypt::decapsulate(session, mlkem_priv, CKM_ML_KEM, ct_mlkem_b)?;
-            let scalar = crate::state::get_object_value(classical_priv).ok_or(CKR_KEY_HANDLE_INVALID)?;
             let arr: [u8; 32] = scalar.as_slice().try_into().map_err(|_| CKR_KEY_HANDLE_INVALID)?;
             let secret = p256::SecretKey::from_bytes((&arr).into()).map_err(|_| CKR_KEY_HANDLE_INVALID)?;
             let eph_pub = p256::PublicKey::from_sec1_bytes(eph_p_b).map_err(|_| CKR_ARGUMENTS_BAD)?;
@@ -235,7 +242,6 @@ pub fn decapsulate(
             }
             let (eph_p_b, ct_mlkem_b) = ciphertext.split_at(P384_PUB);
             let ss_mlkem = crate::native::encrypt::decapsulate(session, mlkem_priv, CKM_ML_KEM, ct_mlkem_b)?;
-            let scalar = crate::state::get_object_value(classical_priv).ok_or(CKR_KEY_HANDLE_INVALID)?;
             let arr: [u8; 48] = scalar.as_slice().try_into().map_err(|_| CKR_KEY_HANDLE_INVALID)?;
             let secret = p384::SecretKey::from_bytes((&arr).into()).map_err(|_| CKR_KEY_HANDLE_INVALID)?;
             let eph_pub = p384::PublicKey::from_sec1_bytes(eph_p_b).map_err(|_| CKR_ARGUMENTS_BAD)?;

--- a/rust/src/native/mod.rs
+++ b/rust/src/native/mod.rs
@@ -35,10 +35,40 @@
 //!
 //! ## Threading model
 //!
-//! Native callers MUST pin all `native::*` calls to one OS thread (the
-//! engine's `OBJECTS` / `SESSIONS` storage is `thread_local!`). Phase 4's
-//! `Session: !Send` in `pqctoday-hsm/kmip/` already aligns the KMIP
-//! server with this constraint. See `docs/NATIVE_API.md` §4 (Option A).
+//! CORRECTED 2026-07-18 (was stale — see the hsm-perf-bench plan,
+//! `rust-hsm-perf-bench-scenario-plan-07182026.md` §B7, and the
+//! `test_lock` doc comment below, which already had this right). Engine
+//! storage (`OBJECTS`, `SESSIONS`, `TOKEN_STORE`, and everything else in
+//! `state.rs`) is `lazy_static! ref _: Mutex<T>` — **global, not
+//! `thread_local!`** — so `native::*` calls from multiple OS threads are
+//! memory-safe with no pinning requirement. This is empirically verified,
+//! not just source-read: `tests/multitenant_concurrency.rs` drives 20
+//! threads concurrently through keygen/sign/verify on one shared token
+//! (real contention on the global `OBJECTS` mutex) with zero corruption.
+//! `pqctoday-hsm/kmip/` has no `Session: !Send` wrapper (never
+//! implemented — the pinned-thread "Option A" design in
+//! `docs/NATIVE_API.md` §4 describes a plan that was superseded by the
+//! simpler global-mutex approach the code actually took); KMIP already
+//! calls `native::*` from tokio's multi-threaded blocking pool today.
+//!
+//! What IS still true and load-bearing: two DIFFERENT sessions must not
+//! share one multi-part operation across threads (SIGN_STATE etc. are
+//! keyed by session handle, not thread — see `state.rs`), and PKCS#11
+//! login state is per-TOKEN, not per-session (§5.6) — only the first
+//! `C_Login` on a token succeeds, so concurrent callers on one token
+//! should log in once, then open sessions without repeating login.
+//!
+//! One CONFIRMED, currently-open gap: unlike `ffi::C_*` (which enforces
+//! `state::can_access_object` token-scoping at 8 call sites), `native::*`
+//! does NOT enforce it — a native caller holding a numeric object handle
+//! can operate on it regardless of which slot/tenant it belongs to. KMIP
+//! uses `native::*` exclusively with one shared `engine_session` for
+//! every client and has no compensating ownership check of its own
+//! (verified: no owner/Identity field in the KeyStore trait, no
+//! ownership check in the dispatcher). This must be closed — either by
+//! adding the `can_access_object` gate to `native::*`, or by KMIP
+//! tracking per-Identity object ownership — before any multi-tenant
+//! design that relies on native-surface isolation is real.
 
 pub mod agree;
 pub mod derive;

--- a/rust/src/native/object.rs
+++ b/rust/src/native/object.rs
@@ -11,7 +11,8 @@ use super::CkRv;
 use super::keygen::CKA_ID;
 use crate::constants::*;
 use crate::state::{
-    get_object_attr_bytes, get_object_attr_u32 as state_get_object_attr_u32, OBJECTS,
+    can_access_object_with, get_object_attr_bytes_from, resolve_session_access,
+    take_object_checked, with_object_checked, OBJECTS,
 };
 
 /// Destroy an object by handle. Wraps `ffi::C_DestroyObject`'s engine
@@ -21,26 +22,21 @@ use crate::state::{
 ///
 /// After this call the handle is invalid; subsequent ops return
 /// `CKR_OBJECT_HANDLE_INVALID`.
-pub fn destroy_object(_session: u32, handle: u32) -> Result<(), CkRv> {
+pub fn destroy_object(session: u32, handle: u32) -> Result<(), CkRv> {
     use crate::state::{DECRYPT_STATE, ENCRYPT_STATE, SIGN_STATE, VERIFY_STATE};
     use zeroize::Zeroize;
 
-    let removed = OBJECTS.with(|objs| {
-        let mut store = objs.borrow_mut();
-        if let Some(mut attrs) = store.remove(&handle) {
-            // Zeroise key material before deallocation (RS-02 — matches
-            // ffi::C_DestroyObject).
-            if let Some(val) = attrs.get_mut(&CKA_VALUE) {
-                val.zeroize();
-            }
-            true
-        } else {
-            false
-        }
-    });
-
-    if !removed {
-        return Err(CKR_OBJECT_HANDLE_INVALID);
+    // Isolation gate folded into the removal itself (take_object_checked
+    // verifies access BEFORE removing, under one write-lock acquisition —
+    // a failed check never mutates OBJECTS). Same error code
+    // (CKR_OBJECT_HANDLE_INVALID) the un-gated version already returned
+    // for a missing handle, now also covering cross-slot / not-logged-in.
+    let access = resolve_session_access(session)?;
+    let mut attrs = take_object_checked(&access, handle)?;
+    // Zeroise key material before deallocation (RS-02 — matches
+    // ffi::C_DestroyObject).
+    if let Some(val) = attrs.get_mut(&CKA_VALUE) {
+        val.zeroize();
     }
 
     // PKCS#11 v3.2 — clean up any active operation state referencing the
@@ -75,21 +71,25 @@ pub fn find_by_cka_id(session: u32, cka_id: &[u8]) -> Result<Option<u32>, CkRv> 
 ///
 /// T3 (multi-slot scoping) — enumeration is TOKEN-scoped: only objects owned
 /// by `session`'s slot match (PKCS#11 v3.2 §2.4 — tokens do not see each
-/// other's objects). An unknown session scopes to slot 0, the primary token,
-/// which preserves the single-slot KMIP/wasm behavior. By-handle native
-/// accessors (`get_attribute*`, `destroy_object`) intentionally stay
-/// handle-global: handles are unique across slots and the native surface is
-/// the engine-internal trusted boundary (the KMIP server owns one session on
-/// slot 0 and never holds foreign handles).
+/// other's objects).
+///
+/// CORRECTED 2026-07-18 (rust-hsm-perf-bench-scenario-plan-07182026.md
+/// Part F): by-handle native accessors are NO LONGER handle-global — every
+/// one gates through `state::can_access_object_with` (this function's own
+/// filter predicate below), the same token-scoping `ffi::C_*` has always
+/// enforced. An unknown session now errors (`CKR_SESSION_HANDLE_INVALID`)
+/// instead of silently scoping to slot 0. The filter also gains the LOGIN
+/// clause (`can_access_object_with`, not just a slot comparison), so
+/// FindObjects parity with `ffi::C_FindObjects`'s enumeration gate
+/// (ffi.rs ~5888) is exact: a private object on a not-logged-in token no
+/// longer matches.
 pub fn find_all_by_cka_id(session: u32, cka_id: &[u8]) -> Result<Vec<u32>, CkRv> {
-    let slot = crate::state::session_slot(session).unwrap_or(0);
+    let access = resolve_session_access(session)?;
     let matches: Vec<u32> = OBJECTS.with(|o| {
         o.borrow()
             .iter()
             .filter_map(|(handle, attrs)| match attrs.get(&CKA_ID) {
-                Some(v) if v == cka_id && crate::state::object_slot_of(attrs) == slot => {
-                    Some(*handle)
-                }
+                Some(v) if v == cka_id && can_access_object_with(&access, attrs) => Some(*handle),
                 _ => None,
             })
             .collect()
@@ -105,20 +105,25 @@ pub fn find_all_by_cka_id(session: u32, cka_id: &[u8]) -> Result<Vec<u32>, CkRv>
 /// For known-sized scalar attrs the caller decodes the returned bytes as
 /// LE u32 etc.; convenience wrappers [`get_attribute_u32`] and
 /// [`get_attribute_bool`] do the decode.
-pub fn get_attribute(_session: u32, handle: u32, attr_type: u32) -> Option<Vec<u8>> {
-    // Same predicates as ffi::C_GetAttributeValue (state::value_is_blocked +
+pub fn get_attribute(session: u32, handle: u32, attr_type: u32) -> Option<Vec<u8>> {
+    // Isolation gate + sensitivity policy, one borrow. Same predicates as
+    // ffi::C_GetAttributeValue (state::value_is_blocked +
     // state::attr_is_sensitive_material): CKA_VALUE / CKA_SEED of
     // private/secret keys are blocked when CKA_SENSITIVE=TRUE **or**
     // CKA_EXTRACTABLE=FALSE (PKCS#11 v3.2 §4.9/§4.10; the v3.2 PQC key tables
     // footnote CKA_SEED identically to CKA_VALUE). Sharing the predicates
-    // keeps the native and C-ABI surfaces from drifting.
-    if crate::state::attr_is_sensitive_material(attr_type) {
-        let blocked = OBJECTS.with(|o| o.borrow().get(&handle).map(crate::state::value_is_blocked));
-        if blocked == Some(true) {
+    // keeps the native and C-ABI surfaces from drifting. Gate failure (bad
+    // session, unknown/cross-slot/not-logged-in handle) folds into `None`,
+    // matching this function's existing "absent" contract.
+    let access = resolve_session_access(session).ok()?;
+    with_object_checked(&access, handle, |attrs| {
+        if crate::state::attr_is_sensitive_material(attr_type) && crate::state::value_is_blocked(attrs) {
             return None;
         }
-    }
-    get_object_attr_bytes(handle, attr_type)
+        get_object_attr_bytes_from(attrs, attr_type)
+    })
+    .ok()
+    .flatten()
 }
 
 /// SHA-256 digest of an object's `CKA_VALUE` bytes, computed inside the
@@ -132,9 +137,14 @@ pub fn get_attribute(_session: u32, handle: u32, attr_type: u32) -> Option<Vec<u
 ///
 /// Returns `None` when the object has no `CKA_VALUE` (e.g. a destroyed
 /// or value-less object).
-pub fn get_value_digest_sha256(_session: u32, handle: u32) -> Option<Vec<u8>> {
+pub fn get_value_digest_sha256(session: u32, handle: u32) -> Option<Vec<u8>> {
     use sha2::{Digest, Sha256};
-    get_object_attr_bytes(handle, CKA_VALUE).map(|v| Sha256::digest(&v).to_vec())
+    let access = resolve_session_access(session).ok()?;
+    with_object_checked(&access, handle, |attrs| {
+        get_object_attr_bytes_from(attrs, CKA_VALUE).map(|v| Sha256::digest(&v).to_vec())
+    })
+    .ok()
+    .flatten()
 }
 
 /// Mutate an attribute, enforcing PKCS#11 v3.2 §4.1.1 policy: server-managed
@@ -142,11 +152,17 @@ pub fn get_value_digest_sha256(_session: u32, handle: u32) -> Option<Vec<u8>> {
 /// CKA_EXTRACTABLE only TRUE→FALSE. Vendor stateful-key attrs (≥0x8000_0000)
 /// bypass the policy — they are the engine/KMIP internal state channel.
 pub fn set_attribute(
-    _session: u32,
+    session: u32,
     handle: u32,
     attr_type: u32,
     value: Vec<u8>,
 ) -> Result<(), CkRv> {
+    // Isolation gate first (separate lock — `set_object_attr_checked` is
+    // shared with `ffi::C_SetAttributeValue`'s mutation-policy logic and
+    // does its own locking; kept untouched rather than folded in, to
+    // avoid touching a function ffi.rs also depends on).
+    let access = resolve_session_access(session)?;
+    with_object_checked(&access, handle, |_| ())?;
     crate::state::set_object_attr_checked(handle, attr_type, value)
 }
 
@@ -208,24 +224,28 @@ pub fn register_certificate(
 /// Read a `u32` attribute (4-byte little-endian — engine's storage
 /// convention). Returns `None` if the attribute is absent or is
 /// blocked by sensitivity policy.
-pub fn get_attribute_u32(_session: u32, handle: u32, attr_type: u32) -> Option<u32> {
-    if crate::state::attr_is_sensitive_material(attr_type)
-        && get_attribute(_session, handle, attr_type).is_none()
-    {
-        return None;
+pub fn get_attribute_u32(session: u32, handle: u32, attr_type: u32) -> Option<u32> {
+    // Routes through the already-gated `get_attribute` (equivalent to the
+    // prior "only sensitivity-check for sensitive material" logic: for
+    // non-sensitive types `value_is_blocked` is never reached, so this is
+    // the same bytes, now also isolation-gated).
+    let bytes = get_attribute(session, handle, attr_type)?;
+    if bytes.len() >= 4 {
+        Some(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    } else {
+        None
     }
-    state_get_object_attr_u32(handle, attr_type)
 }
 
 /// Read a `CK_BBOOL` attribute (1 byte: 0x01 = true, 0x00 = false).
 /// Returns `None` if the attribute is absent.
-pub fn get_attribute_bool(_session: u32, handle: u32, attr_type: u32) -> Option<bool> {
-    OBJECTS.with(|o| {
-        o.borrow()
-            .get(&handle)
-            .and_then(|attrs| attrs.get(&attr_type))
-            .map(|v| !v.is_empty() && v[0] == 0x01)
+pub fn get_attribute_bool(session: u32, handle: u32, attr_type: u32) -> Option<bool> {
+    let access = resolve_session_access(session).ok()?;
+    with_object_checked(&access, handle, |attrs| {
+        attrs.get(&attr_type).map(|v| !v.is_empty() && v[0] == 0x01)
     })
+    .ok()
+    .flatten()
 }
 
 #[cfg(test)]
@@ -304,6 +324,13 @@ mod tests {
     /// (and vice versa), even when both share the same CKA_ID. Slot 1 is
     /// brought online via the `state::ensure_slot` activation hook (the
     /// engine boots single-slot).
+    ///
+    /// FLIPPED 2026-07-18 (Part F, isolation gate): by-handle native
+    /// access is no longer handle-global — a foreign-slot handle now
+    /// correctly fails to resolve, same as `ffi::C_*` has always
+    /// enforced. This test used to assert the opposite (a documented,
+    /// intentional gap); see rust-hsm-perf-bench-scenario-plan-07182026.md
+    /// §E2/§F for the history.
     #[test]
     fn find_by_cka_id_is_token_scoped() {
         let _guard = test_lock::acquire();
@@ -320,9 +347,16 @@ mod tests {
         let found1 = find_all_by_cka_id(s1, cka_id).unwrap();
         assert_eq!(found1, vec![h1], "slot-1 search sees only slot-1's key");
 
-        // By-handle native access stays handle-global (engine-internal
-        // trusted surface) — the foreign handle still resolves.
-        assert_eq!(get_attribute_u32(s0, h1, CKA_VALUE_LEN), Some(32));
+        // Isolation gate now denies cross-tenant handle access: slot-0's
+        // session cannot use slot-1's object handle at all.
+        assert_eq!(
+            get_attribute_u32(s0, h1, CKA_VALUE_LEN),
+            None,
+            "cross-slot handle access must now be denied"
+        );
+        // Each token's own session still works normally.
+        assert_eq!(get_attribute_u32(s0, h0, CKA_VALUE_LEN), Some(32));
+        assert_eq!(get_attribute_u32(s1, h1, CKA_VALUE_LEN), Some(32));
 
         close_session(s0).unwrap();
         close_session(s1).unwrap();

--- a/rust/src/native/parity.rs
+++ b/rust/src/native/parity.rs
@@ -263,13 +263,17 @@ fn sign_after_destroy_fails_in_both_apis() {
         generate_ml_dsa_keypair(session, CKP_ML_DSA_65, b"\x01", "sign-after-destroy").unwrap();
     destroy_object(session, prv_h).unwrap();
 
-    // Native sign on destroyed handle — get_object_value returns None
-    // (object gone), so the gate is hit before reaching the sign primitive.
+    // Native sign on destroyed handle. Since Part F's isolation gate
+    // (rust-hsm-perf-bench-scenario-plan-07182026.md), `sign` now checks
+    // handle validity/token-scoping BEFORE the CKA_SIGN / CKA_VALUE
+    // checks — same object-handle-first priority the FFI assertion below
+    // already documents — so a destroyed handle uniformly returns
+    // CKR_OBJECT_HANDLE_INVALID now (an improvement: native:: and ffi::
+    // agree it's a handle-invalid-class error, not a permission or
+    // arguments error).
     let err = sign(session, prv_h, CKM_ML_DSA, b"data").unwrap_err();
-    // The exact error depends on which check fires first
-    // (CKA_SIGN gate or CKA_VALUE missing); both are valid failure modes.
-    assert!(
-        err == CKR_KEY_FUNCTION_NOT_PERMITTED || err == CKR_ARGUMENTS_BAD,
+    assert_eq!(
+        err, CKR_OBJECT_HANDLE_INVALID,
         "destroyed handle: got rv=0x{err:x}"
     );
 

--- a/rust/src/native/session.rs
+++ b/rust/src/native/session.rs
@@ -21,8 +21,10 @@ use crate::ffi as ffi;
 /// this typed wrapper absorbs it so callers like
 /// [`bootstrap_default_token`] can call `init()` defensively.
 ///
-/// Native callers pin all subsequent `native::*` calls to the same OS
-/// thread as the `init()` call (`thread_local!` storage in the engine).
+/// Engine storage is a global `Mutex`, not `thread_local!` — subsequent
+/// `native::*` calls are NOT required to stay on the `init()` call's OS
+/// thread (see the corrected "Threading model" section in
+/// `native/mod.rs`).
 pub fn init() -> Result<(), CkRv> {
     use crate::constants::CKR_CRYPTOKI_ALREADY_INITIALIZED;
     let rv = ffi::C_Initialize(std::ptr::null_mut());
@@ -123,7 +125,8 @@ pub fn close_session(session: u32) -> Result<(), CkRv> {
 
 /// Initialise a token on `slot` with the security-officer PIN + label.
 /// Token state survives `close_session` and engine `init()` re-entries
-/// within the same process (storage is `thread_local!`).
+/// within the same process (storage is a global `Mutex`, shared by every
+/// thread — not `thread_local!`).
 ///
 /// `label` is padded with spaces to PKCS#11's required 32 bytes by the
 /// engine; callers pass any printable string.

--- a/rust/src/native/sign.rs
+++ b/rust/src/native/sign.rs
@@ -25,8 +25,9 @@ use crate::crypto::handlers::{
     verify_ml_dsa_internal, verify_rsa, verify_slh_dsa, verify_slh_dsa_internal,
 };
 use crate::state::{
-    get_ec_point_sec1, get_object_attr_u32, get_object_param_set, get_object_value,
-    get_rsa_public_components, OBJECTS,
+    check_mechanism_allowed_from, get_ec_point_sec1_from, get_object_attr_u32_from,
+    get_object_param_set_from, get_object_value_from, get_rsa_public_components_from,
+    read_bool_attr, resolve_session_access, with_object_checked,
 };
 
 // PKCS#11 v3.2 §5.12.4 — `CKA_SIGN` (private key) / `CKA_VERIFY` (public key)
@@ -61,24 +62,41 @@ pub fn sign(
 /// length). Ignored for non-PSS mechanisms. KMIP slice K18 threads the
 /// `Cryptographic Parameters` `Salt Length` field through here.
 pub fn sign_with_pss_salt(
-    _session: u32,
+    session: u32,
     key_handle: u32,
     mechanism: u32,
     data: &[u8],
     pss_salt_len: Option<usize>,
 ) -> Result<Vec<u8>, CkRv> {
-    // CKA_SIGN gate.
-    if !check_can_sign(key_handle, CKA_SIGN) {
+    // Isolation gate (rust-hsm-perf-bench-scenario-plan-07182026.md Part F)
+    // + CKA_SIGN + CKA_ALLOWED_MECHANISMS + CKA_VALUE + CKA_PRIV_PARAM_SET,
+    // ALL read from the SAME borrowed attrs — one OBJECTS lock instead of
+    // the four separate locks this function used to take. `sk_bytes` is
+    // `None` for HSS keys (their material lives in
+    // `CKA_STATEFUL_KEY_STATE`, not `CKA_VALUE`) — harmless, discarded on
+    // the HSS branch below.
+    let access = resolve_session_access(session)?;
+    let (can_sign, mech_ok, sk_bytes, ps) = with_object_checked(&access, key_handle, |attrs| {
+        (
+            read_bool_attr(attrs, CKA_SIGN),
+            check_mechanism_allowed_from(attrs, mechanism),
+            get_object_value_from(attrs),
+            get_object_param_set_from(attrs),
+        )
+    })?;
+    if !can_sign {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    // PKCS#11 v3.2 §4.8 Table 13 — CKA_ALLOWED_MECHANISMS.
-    crate::state::check_mechanism_allowed(key_handle, mechanism)?;
+    mech_ok?;
 
     // HSS/LMS is stateful and keeps its key material in
     // `CKA_STATEFUL_KEY_STATE`, not `CKA_VALUE` (mirrors `ffi::C_Sign`'s
     // separate stateful-sign branch) — dispatch it BEFORE the generic
-    // `CKA_VALUE` fetch below, which would otherwise fail closed with
-    // `CKR_ARGUMENTS_BAD` for every HSS key.
+    // `sk_bytes` use below, which would otherwise fail closed with
+    // `CKR_ARGUMENTS_BAD` for every HSS key. The gate above already
+    // covers HSS (CKA_SIGN + slot/login) — `hbs::sign_prepare`/
+    // `sign_commit` are `pub(crate)` and deliberately ungated; this
+    // function is their only caller and is where the gate must live.
     if mechanism == CKM_HSS {
         // Stateful — the two-phase prepare/commit in `native::hbs` is the
         // single source of truth for leaf advance-and-persist, shared
@@ -90,8 +108,7 @@ pub fn sign_with_pss_salt(
         return Ok(prepared.signature);
     }
 
-    let sk_bytes = get_object_value(key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
-    let ps = get_object_param_set(key_handle);
+    let sk_bytes = sk_bytes.ok_or(CKR_ARGUMENTS_BAD)?;
 
     match mechanism {
         m if m == CKM_ML_DSA || is_prehash_ml_dsa(m) => {
@@ -148,25 +165,38 @@ pub fn verify(
 /// two-candidate acceptance (salt = hash length, salt = maximal — see
 /// `crypto::handlers::verify_rsa`). Ignored for non-PSS mechanisms.
 pub fn verify_with_pss_salt(
-    _session: u32,
+    session: u32,
     key_handle: u32,
     mechanism: u32,
     data: &[u8],
     signature: &[u8],
     pss_salt_len: Option<usize>,
 ) -> Result<bool, CkRv> {
-    // CKA_VERIFY gate.
-    if !check_can_sign(key_handle, CKA_VERIFY) {
+    // Isolation gate + CKA_VERIFY + CKA_ALLOWED_MECHANISMS + every
+    // key-material shape a verify mechanism might need, ALL read from one
+    // borrowed attrs — one OBJECTS lock. `CKA_VALUE` holds the
+    // verification key bytes for most algorithms (ML-DSA, SLH-DSA, EdDSA,
+    // HMAC, KMAC, HSS); RSA/ECDSA public keys additionally need the
+    // dedicated modulus+exponent / EC-point attributes, fetched
+    // unconditionally here (cheap absent-key lookups) rather than
+    // re-locking per mechanism branch below.
+    let access = resolve_session_access(session)?;
+    let (can_verify, mech_ok, pk_bytes, ps, ec_point, rsa_components, lms_param) =
+        with_object_checked(&access, key_handle, |attrs| {
+            (
+                read_bool_attr(attrs, CKA_VERIFY),
+                check_mechanism_allowed_from(attrs, mechanism),
+                get_object_value_from(attrs).unwrap_or_default(),
+                get_object_param_set_from(attrs),
+                get_ec_point_sec1_from(attrs),
+                get_rsa_public_components_from(attrs),
+                get_object_attr_u32_from(attrs, CKA_LMS_PARAM_SET).unwrap_or(0x05),
+            )
+        })?;
+    if !can_verify {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    // PKCS#11 v3.2 §4.8 Table 13 — CKA_ALLOWED_MECHANISMS.
-    crate::state::check_mechanism_allowed(key_handle, mechanism)?;
-
-    // For most algorithms `CKA_VALUE` holds the verification key bytes
-    // (ML-DSA, SLH-DSA, EdDSA, HMAC, KMAC). RSA/ECDSA public keys are
-    // stored in dedicated attributes (modulus+exp / EC point).
-    let pk_bytes = get_object_value(key_handle).unwrap_or_default();
-    let ps = get_object_param_set(key_handle);
+    mech_ok?;
 
     let result: Result<(), CkRv> = match mechanism {
         m if m == CKM_ML_DSA || is_prehash_ml_dsa(m) => {
@@ -194,14 +224,14 @@ pub fn verify_with_pss_salt(
         }
         CKM_SHA256_RSA_PKCS | CKM_SHA384_RSA_PKCS | CKM_SHA512_RSA_PKCS
         | CKM_SHA256_RSA_PKCS_PSS | CKM_SHA384_RSA_PKCS_PSS | CKM_SHA512_RSA_PKCS_PSS => {
-            match get_rsa_public_components(key_handle) {
+            match rsa_components {
                 Some((n, e)) => verify_rsa(mechanism, &n, &e, data, signature, pss_salt_len),
                 None => Err(CKR_KEY_TYPE_INCONSISTENT),
             }
         }
         CKM_ECDSA | CKM_ECDSA_SHA256 | CKM_ECDSA_SHA384 | CKM_ECDSA_SHA512
         | CKM_ECDSA_SHA3_224 | CKM_ECDSA_SHA3_256 | CKM_ECDSA_SHA3_384
-        | CKM_ECDSA_SHA3_512 => match get_ec_point_sec1(key_handle) {
+        | CKM_ECDSA_SHA3_512 => match ec_point {
             Some(point) => verify_ecdsa(mechanism, ps, &point, data, signature),
             None => Err(CKR_KEY_TYPE_INCONSISTENT),
         },
@@ -210,7 +240,6 @@ pub fn verify_with_pss_salt(
         CKM_HSS => {
             // Stateless — RFC 8554 verification needs no key-object
             // mutation, unlike sign's leaf advance-and-persist.
-            let lms_param = get_object_attr_u32(key_handle, CKA_LMS_PARAM_SET).unwrap_or(0x05);
             if crate::crypto::lms::hss_verify(&pk_bytes, data, signature, lms_param) {
                 Ok(())
             } else {
@@ -239,7 +268,7 @@ pub fn verify_with_pss_salt(
 /// hedge randomizer (ML-DSA rnd / SLH-DSA addrnd) when not deterministic.
 #[allow(clippy::too_many_arguments)]
 pub fn sign_pqc(
-    _session: u32,
+    session: u32,
     key_handle: u32,
     mechanism: u32,
     data: &[u8],
@@ -249,14 +278,21 @@ pub fn sign_pqc(
     external_mu: bool,
     random: Option<&[u8]>,
 ) -> Result<Vec<u8>, CkRv> {
-    if !check_can_sign(key_handle, CKA_SIGN) {
+    let access = resolve_session_access(session)?;
+    let (can_sign, mech_ok, sk, ps) = with_object_checked(&access, key_handle, |attrs| {
+        (
+            read_bool_attr(attrs, CKA_SIGN),
+            check_mechanism_allowed_from(attrs, mechanism),
+            get_object_value_from(attrs),
+            get_object_param_set_from(attrs),
+        )
+    })?;
+    if !can_sign {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    // PKCS#11 v3.2 §4.8 Table 13 — CKA_ALLOWED_MECHANISMS.
-    crate::state::check_mechanism_allowed(key_handle, mechanism)?;
+    mech_ok?;
+    let sk = sk.ok_or(CKR_ARGUMENTS_BAD)?;
     use rand::RngCore;
-    let sk = get_object_value(key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
-    let ps = get_object_param_set(key_handle);
     match mechanism {
         m if m == CKM_ML_DSA || is_prehash_ml_dsa(m) => {
             // rnd: deterministic ⇒ 0^32; hedged ⇒ explicit <Random> (must be
@@ -317,7 +353,7 @@ fn slh_dsa_n(ps: u32) -> usize {
 /// 64-byte µ; `internal` ⇒ `*.Verify_internal`.
 #[allow(clippy::too_many_arguments)]
 pub fn verify_pqc(
-    _session: u32,
+    session: u32,
     key_handle: u32,
     mechanism: u32,
     data: &[u8],
@@ -326,13 +362,20 @@ pub fn verify_pqc(
     internal: bool,
     external_mu: bool,
 ) -> Result<(), CkRv> {
-    if !check_can_sign(key_handle, CKA_VERIFY) {
+    let access = resolve_session_access(session)?;
+    let (can_verify, mech_ok, pk, ps) = with_object_checked(&access, key_handle, |attrs| {
+        (
+            read_bool_attr(attrs, CKA_VERIFY),
+            check_mechanism_allowed_from(attrs, mechanism),
+            get_object_value_from(attrs),
+            get_object_param_set_from(attrs),
+        )
+    })?;
+    if !can_verify {
         return Err(CKR_KEY_FUNCTION_NOT_PERMITTED);
     }
-    // PKCS#11 v3.2 §4.8 Table 13 — CKA_ALLOWED_MECHANISMS.
-    crate::state::check_mechanism_allowed(key_handle, mechanism)?;
-    let pk = get_object_value(key_handle).ok_or(CKR_ARGUMENTS_BAD)?;
-    let ps = get_object_param_set(key_handle);
+    mech_ok?;
+    let pk = pk.ok_or(CKR_ARGUMENTS_BAD)?;
     match mechanism {
         m if m == CKM_ML_DSA || is_prehash_ml_dsa(m) => {
             if external_mu {
@@ -354,16 +397,11 @@ pub fn verify_pqc(
     }
 }
 
-fn check_can_sign(key_handle: u32, attr_type: u32) -> bool {
-    // PKCS#11 v3.2 §5.12.4 — single-byte CK_BBOOL: 0x01 = true.
-    OBJECTS.with(|o| {
-        o.borrow()
-            .get(&key_handle)
-            .and_then(|attrs| attrs.get(&attr_type))
-            .map(|v| !v.is_empty() && v[0] == 0x01)
-            .unwrap_or(false)
-    })
-}
+// The former `check_can_sign(key_handle, attr_type)` free function (a
+// direct, ungated OBJECTS lock) is gone — CKA_SIGN/CKA_VERIFY are now
+// read via `read_bool_attr` inside the isolation gate's single borrow
+// (`with_object_checked` above), the same predicate `can_access_object`
+// already uses for CKA_PRIVATE.
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/native/split_key.rs
+++ b/rust/src/native/split_key.rs
@@ -19,7 +19,7 @@ use super::CkRv;
 use crate::constants::{CKR_ARGUMENTS_BAD, CKR_DATA_LEN_RANGE, CKR_FUNCTION_FAILED};
 use crate::crypto::split_key::{self, Gf256Polynomial, SplitKeyError, SplitKeyMethod};
 use crate::native::keygen::{alloc_in_session_slot, build_generic_secret_attrs, insert_id_and_label};
-use crate::state::get_object_value;
+use crate::state::{get_object_value_from, resolve_session_access, with_object_checked};
 
 fn map_err(e: SplitKeyError) -> CkRv {
     match e {
@@ -54,7 +54,12 @@ pub fn split(
     cka_id_prefix: &[u8],
     label: &str,
 ) -> Result<Vec<(u32, u32)>, CkRv> {
-    let secret = get_object_value(secret_handle).ok_or(CKR_ARGUMENTS_BAD)?;
+    // Isolation gate — preserves this function's existing CKR_ARGUMENTS_BAD
+    // error code for missing, cross-slot, or not-logged-in handles alike.
+    let access = resolve_session_access(session).map_err(|_| CKR_ARGUMENTS_BAD)?;
+    let secret = with_object_checked(&access, secret_handle, get_object_value_from)
+        .map_err(|_| CKR_ARGUMENTS_BAD)?
+        .ok_or(CKR_ARGUMENTS_BAD)?;
 
     let register_share = |index: u32, bytes: Vec<u8>| -> u32 {
         // Distinguish each share's CKA_ID from the others and from the
@@ -126,9 +131,16 @@ pub fn join(
     cka_id: &[u8],
     label: &str,
 ) -> Result<u32, CkRv> {
+    // Isolation gate on EVERY share handle — the multi-handle case: all
+    // shares must pass the same-tenant check, first failure aborts the
+    // whole reconstruction (CKR_ARGUMENTS_BAD, matching this function's
+    // existing error vocabulary).
+    let access = resolve_session_access(session).map_err(|_| CKR_ARGUMENTS_BAD)?;
     let mut bytes_by_index: HashMap<u32, Vec<u8>> = HashMap::new();
     for &(idx, handle) in shares {
-        let bytes = get_object_value(handle).ok_or(CKR_ARGUMENTS_BAD)?;
+        let bytes = with_object_checked(&access, handle, get_object_value_from)
+            .map_err(|_| CKR_ARGUMENTS_BAD)?
+            .ok_or(CKR_ARGUMENTS_BAD)?;
         bytes_by_index.insert(idx, bytes);
     }
 

--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -48,14 +48,29 @@ pub fn set_initialized(v: bool) {
     INITIALIZED.store(v, std::sync::atomic::Ordering::SeqCst);
 }
 
+// PERF-BENCH FIX (2026-07-18, B4 step 1): these three were
+// `GlobalState<u32>`/`GlobalState<u64>` (a `Mutex` behind `lazy_static!`),
+// each guarding nothing but a single integer counter with a plain
+// read-increment-write body. A `Mutex` here buys no correctness the
+// hardware's own atomic RMW doesn't already give — converting to
+// `AtomicU32`/`AtomicU64` removes three more global lock acquisitions
+// from the handle/session/object-creation hot path (keygen, session open,
+// every C_CreateObject) with no behavior change: NEXT_HANDLE keeps its
+// saturate-at-MAX semantics (`fetch_update`, a safe CAS-retry loop, so
+// concurrent callers can't race past u32::MAX), and the other two keep
+// their plain wrapping-increment semantics (`fetch_add`, matching the
+// original `u32`/`u64` release-mode wrapping arithmetic exactly).
+// `AtomicU32::new`/`AtomicU64::new` are `const fn`, so these no longer
+// need `lazy_static!` at all — a plain `pub static` suffices.
+pub static NEXT_HANDLE: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(100);
+/// PKCS#11 v3.2 §4.4.1 — CKA_UNIQUE_ID source. Process-monotonic and never
+/// reset (not even by C_Finalize) so identifiers stay unique across
+/// initialize/finalize cycles within one process.
+pub static UNIQUE_ID_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+pub static NEXT_SESSION_HANDLE: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(1);
+
 lazy_static! {
     pub static ref OBJECTS: GlobalState<HashMap<u32, Attributes>> = GlobalState::new(HashMap::new());
-    pub static ref NEXT_HANDLE: GlobalState<u32> = GlobalState::new(100);
-    /// PKCS#11 v3.2 §4.4.1 — CKA_UNIQUE_ID source. Process-monotonic and never
-    /// reset (not even by C_Finalize) so identifiers stay unique across
-    /// initialize/finalize cycles within one process.
-    pub static ref UNIQUE_ID_COUNTER: GlobalState<u64> = GlobalState::new(1);
-    pub static ref NEXT_SESSION_HANDLE: GlobalState<u32> = GlobalState::new(1);
     pub static ref SIGN_STATE: GlobalState<HashMap<u32, (u32, u32, Vec<u8>, bool)>> = GlobalState::new(HashMap::new());
     pub static ref VERIFY_STATE: GlobalState<HashMap<u32, (u32, u32, Vec<u8>, bool)>> = GlobalState::new(HashMap::new());
     pub static ref VERIFY_SIG_STATE: GlobalState<HashMap<u32, VerifySigCtx>> = GlobalState::new(HashMap::new());
@@ -698,12 +713,7 @@ pub fn allocate_handle(mut attrs: Attributes) -> u32 {
     // enter OBJECTS, so the attribute is guaranteed on every surface (FFI,
     // native, KMIP). Unconditional insert: the attribute is read-only and any
     // caller-supplied value has already been rejected/skipped upstream.
-    let uid = UNIQUE_ID_COUNTER.with(|c| {
-        let mut c = c.borrow_mut();
-        let v = *c;
-        *c += 1;
-        v
-    });
+    let uid = UNIQUE_ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     // §4.4.1 — render the monotonic counter as a canonical 36-char UUID
     // (8-4-4-4-12, v4 version/variant nibbles) so CKA_UNIQUE_ID is a portable,
     // fixed-width identifier. The KMIP store keeps its own UniqueIdentifier, so
@@ -714,19 +724,21 @@ pub fn allocate_handle(mut attrs: Attributes) -> u32 {
         uid & 0xffff_ffff_ffff,
     );
     attrs.insert(CKA_UNIQUE_ID, uuid.into_bytes());
-    NEXT_HANDLE.with(|h| {
-        let mut handle = h.borrow_mut();
-        if *handle == u32::MAX {
-            // Saturate at MAX rather than wrapping; callers get 0 as sentinel for failure.
-            return 0;
-        }
-        let current = *handle;
-        *handle += 1;
-        OBJECTS.with(|objs| {
-            objs.borrow_mut().insert(current, attrs);
-        });
-        current
-    })
+    // Saturate at MAX rather than wrapping; callers get 0 as sentinel for
+    // failure. `fetch_update` is a safe CAS-retry loop: concurrent callers
+    // cannot race past u32::MAX the way a naive load-then-store could.
+    let current = match NEXT_HANDLE.fetch_update(
+        std::sync::atomic::Ordering::Relaxed,
+        std::sync::atomic::Ordering::Relaxed,
+        |h| if h == u32::MAX { None } else { Some(h + 1) },
+    ) {
+        Ok(prev) => prev,
+        Err(_) => return 0,
+    };
+    OBJECTS.with(|objs| {
+        objs.borrow_mut().insert(current, attrs);
+    });
+    current
 }
 
 pub(crate) fn get_object_value(handle: u32) -> Option<Vec<u8>> {

--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -480,6 +480,125 @@ pub fn can_access_object(h_session: u32, attrs: &Attributes) -> bool {
     session_logged_in(h_session)
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// Isolation gate for `native::*` (rust-hsm-perf-bench-scenario-plan-07182026.md
+// Part F, added 2026-07-18). `ffi::C_*` has enforced `can_access_object` at
+// 8 call sites all along; `native::*` — the surface KMIP uses exclusively —
+// never did. These are ADDITIVE: `can_access_object` above is untouched
+// (zero risk to existing ffi behavior), and every native::* by-handle
+// function is being migrated onto the primitives below.
+//
+// Design note: `can_access_object(h_session, attrs)` independently locks
+// SESSIONS (via `session_slot`) and TOKEN_STORE (via `session_logged_in`)
+// on every call. Native crypto ops call several by-handle accessors per
+// operation (e.g. sign: usage check, mechanism check, value fetch, param
+// fetch — 4 separate OBJECTS locks today), so re-deriving slot/login state
+// from scratch inside each one would multiply SESSIONS/TOKEN_STORE lock
+// traffic too. Instead: resolve the session's slot + login state ONCE
+// per operation (`resolve_session_access`, one SESSIONS lock + one
+// TOKEN_STORE lock), then fold the access check into the SAME OBJECTS
+// borrow every accessor already needs (`with_object_checked[_mut]`,
+// `take_object_checked`) — collapsing native sign's 4 OBJECTS locks to 1
+// while adding the gate, not trading contention for correctness.
+//
+// Lock ordering (load-bearing — audited 2026-07-18 across every native/*
+// call site that uses these primitives, see F5 in the plan): SESSIONS
+// and/or TOKEN_STORE are always acquired and FULLY RELEASED (not nested)
+// before OBJECTS is acquired — `resolve_session_access` runs to
+// completion and returns an owned `SessionAccess` before
+// `with_object_checked` et al. ever touch OBJECTS. This is stricter than
+// `ffi.rs`'s existing pattern (e.g. `C_GetObjectSize`), which nests a
+// `can_access_object` call — and its own SESSIONS/TOKEN_STORE locks —
+// INSIDE an open OBJECTS borrow. That nested pattern is untouched and
+// presumed safe (no reverse-order site was found), but new code should
+// prefer this module's sequential resolve-then-access shape.
+
+/// Pre-resolved session identity for the isolation gate — computed ONCE
+/// per operation so the OBJECTS-locked accessors below never need to
+/// touch SESSIONS or TOKEN_STORE.
+#[derive(Clone, Copy)]
+pub struct SessionAccess {
+    pub slot: u32,
+    pub logged_in: bool,
+}
+
+/// Resolve a session handle to the slot/login state the isolation gate
+/// needs. `Err(CKR_SESSION_HANDLE_INVALID)` for an unknown handle — this
+/// is new, correct validation for `native::*` callers (which today mostly
+/// ignore their session parameter entirely and never reject a bogus
+/// handle); it does not change any `ffi::*` behavior, since `ffi::*`
+/// does not call this function.
+pub fn resolve_session_access(h_session: u32) -> Result<SessionAccess, u32> {
+    let slot = session_slot(h_session).ok_or(CKR_SESSION_HANDLE_INVALID)?;
+    let logged_in = session_logged_in(h_session);
+    Ok(SessionAccess { slot, logged_in })
+}
+
+/// Same predicate as [`can_access_object`], evaluated against a
+/// pre-resolved [`SessionAccess`] instead of re-locking SESSIONS/TOKEN_STORE.
+/// Kept in exact lockstep with `can_access_object`'s logic.
+pub fn can_access_object_with(access: &SessionAccess, attrs: &Attributes) -> bool {
+    if object_slot_of(attrs) != access.slot {
+        return false;
+    }
+    if !read_bool_attr(attrs, CKA_PRIVATE) {
+        return true;
+    }
+    access.logged_in
+}
+
+/// Fetch `handle`'s attributes, apply the isolation gate, and run `f` over
+/// the borrowed attributes — all under ONE `OBJECTS` lock acquisition.
+/// `Err(CKR_OBJECT_HANDLE_INVALID)` uniformly for an unknown handle OR a
+/// cross-slot / not-logged-in-for-private object (PKCS#11 v3.2 §2.4/§4.4 —
+/// no existence oracle, same choke point `ffi::*` already uses).
+pub fn with_object_checked<R>(
+    access: &SessionAccess,
+    handle: u32,
+    f: impl FnOnce(&Attributes) -> R,
+) -> Result<R, u32> {
+    OBJECTS.with(|o| {
+        let store = o.borrow();
+        let attrs = store.get(&handle).ok_or(CKR_OBJECT_HANDLE_INVALID)?;
+        if !can_access_object_with(access, attrs) {
+            return Err(CKR_OBJECT_HANDLE_INVALID);
+        }
+        Ok(f(attrs))
+    })
+}
+
+/// Mutable counterpart of [`with_object_checked`] — for in-place attribute
+/// writes (e.g. HSS/XMSS stateful-key state advancement) under one
+/// `OBJECTS` write-lock acquisition.
+pub fn with_object_checked_mut<R>(
+    access: &SessionAccess,
+    handle: u32,
+    f: impl FnOnce(&mut Attributes) -> R,
+) -> Result<R, u32> {
+    OBJECTS.with(|o| {
+        let mut store = o.borrow_mut();
+        let attrs = store.get_mut(&handle).ok_or(CKR_OBJECT_HANDLE_INVALID)?;
+        if !can_access_object_with(access, attrs) {
+            return Err(CKR_OBJECT_HANDLE_INVALID);
+        }
+        Ok(f(attrs))
+    })
+}
+
+/// Gate-checked object removal (for `destroy_object`) — verifies access
+/// BEFORE removing, under one `OBJECTS` write-lock acquisition, so a
+/// failed check never mutates the map.
+pub fn take_object_checked(access: &SessionAccess, handle: u32) -> Result<Attributes, u32> {
+    OBJECTS.with(|o| {
+        let mut store = o.borrow_mut();
+        let attrs = store.get(&handle).ok_or(CKR_OBJECT_HANDLE_INVALID)?;
+        if !can_access_object_with(access, attrs) {
+            return Err(CKR_OBJECT_HANDLE_INVALID);
+        }
+        Ok(store.remove(&handle).expect("presence just confirmed under the same lock"))
+    })
+}
+
 /// PKCS#11 v3.2 §4.8 Table 13 — `CKA_ALLOWED_MECHANISMS` restricts a key to
 /// a caller-specified mechanism whitelist. Absent attribute (the common
 /// case) means unrestricted, per the spec's default. Call AFTER key-handle
@@ -490,13 +609,8 @@ pub fn can_access_object(h_session: u32, attrs: &Attributes) -> bool {
 /// Shared by both the FFI (`ffi.rs`) and native (`native/*.rs`) entry
 /// points — KMIP calls the engine through the native surface, not FFI, so
 /// this can't live only on one side.
-pub fn check_mechanism_allowed(h_key: u32, mech_type: u32) -> Result<(), u32> {
-    let allowed = OBJECTS.with(|o| {
-        o.borrow()
-            .get(&h_key)
-            .and_then(|attrs| attrs.get(&CKA_ALLOWED_MECHANISMS).cloned())
-    });
-    match allowed {
+pub fn check_mechanism_allowed_from(attrs: &Attributes, mech_type: u32) -> Result<(), u32> {
+    match attrs.get(&CKA_ALLOWED_MECHANISMS) {
         None => Ok(()),
         Some(bytes) => {
             let is_allowed = bytes
@@ -508,6 +622,13 @@ pub fn check_mechanism_allowed(h_key: u32, mech_type: u32) -> Result<(), u32> {
                 Err(CKR_MECHANISM_INVALID)
             }
         }
+    }
+}
+
+pub fn check_mechanism_allowed(h_key: u32, mech_type: u32) -> Result<(), u32> {
+    match OBJECTS.with(|o| o.borrow().get(&h_key).map(|attrs| check_mechanism_allowed_from(attrs, mech_type))) {
+        Some(result) => result,
+        None => Ok(()), // unknown handle: preserve prior behavior (caller's later fetch fails closed)
     }
 }
 
@@ -741,12 +862,81 @@ pub fn allocate_handle(mut attrs: Attributes) -> u32 {
     current
 }
 
-pub(crate) fn get_object_value(handle: u32) -> Option<Vec<u8>> {
-    OBJECTS.with(|objs| {
-        objs.borrow()
-            .get(&handle)
-            .and_then(|attrs| attrs.get(&CKA_VALUE).cloned())
+// ── `_from` pure variants (operate on an already-borrowed `&Attributes`,
+// take no lock) — added alongside the isolation gate (Part F) so a
+// gated `native::*` call can fetch several attributes inside the ONE
+// `OBJECTS` borrow `with_object_checked` already holds, instead of each
+// handle-taking accessor below re-locking OBJECTS on its own. Every
+// handle-taking accessor is now a thin `OBJECTS.with(...)` wrapper over
+// its `_from` twin — same signature, same behavior, zero call-site churn
+// for the ~50+ existing (ungated) callers across the crate. ──────────────
+
+pub fn get_object_value_from(attrs: &Attributes) -> Option<Vec<u8>> {
+    attrs.get(&CKA_VALUE).cloned()
+}
+
+/// PKCS#11 v3.2 §2.3.3 — strip the DER OCTET STRING header some CKA_EC_POINT
+/// values carry around the raw SEC1 point. See [`get_ec_point_sec1_from`].
+fn strip_ec_point_der(ec_point: Vec<u8>) -> Vec<u8> {
+    // Two encodings exist:
+    //   - Short form  : 0x04 <len ≤ 127> <data>            (len = data.len())
+    //   - Long form 1B: 0x04 0x81 <len> <data>             (P-521 path — data=133)
+    // P-256 / P-384 / secp256k1 fit short form (65 / 97 / 65 ≤ 127).
+    // P-521's 133-byte SEC1 point requires long form.
+    if ec_point.len() > 2 && ec_point[0] == 0x04 {
+        if ec_point[1] as usize == ec_point.len() - 2 {
+            return ec_point[2..].to_vec();
+        }
+        if ec_point.len() > 3 && ec_point[1] == 0x81 && ec_point[2] as usize == ec_point.len() - 3
+        {
+            return ec_point[3..].to_vec();
+        }
+    }
+    ec_point
+}
+
+/// Return the raw SEC1 point bytes for an EC public key object. Some
+/// internal paths (C_GenerateKeyPair) store the raw SEC1 bytes directly
+/// without the DER header — [`strip_ec_point_der`] handles both formats.
+pub fn get_ec_point_sec1_from(attrs: &Attributes) -> Option<Vec<u8>> {
+    attrs.get(&CKA_EC_POINT).cloned().map(strip_ec_point_der)
+}
+
+/// Return (modulus, public_exponent) bytes for an RSA public key object.
+pub fn get_rsa_public_components_from(attrs: &Attributes) -> Option<(Vec<u8>, Vec<u8>)> {
+    let n = attrs.get(&CKA_MODULUS)?.clone();
+    let e = attrs.get(&CKA_PUBLIC_EXPONENT)?.clone();
+    Some((n, e))
+}
+
+pub fn get_object_param_set_from(attrs: &Attributes) -> u32 {
+    attrs
+        .get(&CKA_PRIV_PARAM_SET)
+        .map(|v| if v.len() >= 4 { u32::from_le_bytes([v[0], v[1], v[2], v[3]]) } else { 0 })
+        .unwrap_or(0)
+}
+
+pub fn get_object_attr_bytes_from(attrs: &Attributes, attr_type: u32) -> Option<Vec<u8>> {
+    attrs.get(&attr_type).cloned()
+}
+
+pub fn get_object_attr_u32_from(attrs: &Attributes, attr_type: u32) -> Option<u32> {
+    get_object_attr_bytes_from(attrs, attr_type)
+        .and_then(|v| if v.len() >= 4 { Some(u32::from_le_bytes([v[0], v[1], v[2], v[3]])) } else { None })
+}
+
+pub fn get_object_attr_u64_from(attrs: &Attributes, attr_type: u32) -> Option<u64> {
+    get_object_attr_bytes_from(attrs, attr_type).and_then(|v| {
+        if v.len() >= 8 {
+            Some(u64::from_le_bytes([v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7]]))
+        } else {
+            None
+        }
     })
+}
+
+pub(crate) fn get_object_value(handle: u32) -> Option<Vec<u8>> {
+    OBJECTS.with(|objs| objs.borrow().get(&handle).and_then(get_object_value_from))
 }
 
 /// Return the raw SEC1 point bytes for an EC public key object.
@@ -755,113 +945,42 @@ pub(crate) fn get_object_value(handle: u32) -> Option<Vec<u8>> {
 /// Some internal paths (C_GenerateKeyPair) store the raw SEC1 bytes directly
 /// without the DER header. This function handles both formats.
 pub fn get_ec_point_sec1(handle: u32) -> Option<Vec<u8>> {
-    OBJECTS
-        .with(|objs| {
-            objs.borrow()
-                .get(&handle)
-                .and_then(|attrs| attrs.get(&CKA_EC_POINT).cloned())
-        })
-        .map(|ec_point| {
-            // CKA_EC_POINT stores a DER OCTET STRING wrapping the SEC1 point
-            // (PKCS#11 v3.2 §2.3.3). Strip the header to return the raw SEC1
-            // bytes. Two encodings exist:
-            //   - Short form  : 0x04 <len ≤ 127> <data>            (len = data.len())
-            //   - Long form 1B: 0x04 0x81 <len> <data>             (P-521 path — data=133)
-            // P-256 / P-384 / secp256k1 fit short form (65 / 97 / 65 ≤ 127).
-            // P-521's 133-byte SEC1 point requires long form.
-            if ec_point.len() > 2 && ec_point[0] == 0x04 {
-                if ec_point[1] as usize == ec_point.len() - 2 {
-                    // Short form
-                    return ec_point[2..].to_vec();
-                }
-                if ec_point.len() > 3
-                    && ec_point[1] == 0x81
-                    && ec_point[2] as usize == ec_point.len() - 3
-                {
-                    // Long form, 1-byte length (covers all SEC1 points up to 255 B)
-                    return ec_point[3..].to_vec();
-                }
-            }
-            ec_point
-        })
+    OBJECTS.with(|objs| objs.borrow().get(&handle).and_then(get_ec_point_sec1_from))
 }
 
 /// Return (modulus, public_exponent) bytes for an RSA public key object.
 /// PKCS#11 v3.2: RSA public key material is in CKA_MODULUS + CKA_PUBLIC_EXPONENT.
 /// CKA_VALUE is NOT defined for CKO_PUBLIC_KEY/CKK_RSA objects.
 pub fn get_rsa_public_components(handle: u32) -> Option<(Vec<u8>, Vec<u8>)> {
-    OBJECTS.with(|objs| {
-        let store = objs.borrow();
-        let attrs = store.get(&handle)?;
-        let n = attrs.get(&CKA_MODULUS)?.clone();
-        let e = attrs.get(&CKA_PUBLIC_EXPONENT)?.clone();
-        Some((n, e))
-    })
+    OBJECTS.with(|objs| objs.borrow().get(&handle).and_then(get_rsa_public_components_from))
 }
 
 pub fn get_object_param_set(handle: u32) -> u32 {
-    OBJECTS.with(|objs| {
-        objs.borrow()
-            .get(&handle)
-            .and_then(|attrs| attrs.get(&CKA_PRIV_PARAM_SET))
-            .map(|v| {
-                if v.len() >= 4 {
-                    u32::from_le_bytes([v[0], v[1], v[2], v[3]])
-                } else {
-                    0
-                }
-            })
-            .unwrap_or(0)
-    })
+    OBJECTS.with(|objs| objs.borrow().get(&handle).map(get_object_param_set_from).unwrap_or(0))
 }
 
 pub fn get_object_algo_family(handle: u32) -> u32 {
     OBJECTS.with(|objs| {
         objs.borrow()
             .get(&handle)
-            .and_then(|attrs| attrs.get(&CKA_PRIV_ALGO_FAMILY))
-            .map(|v| {
-                if v.len() >= 4 {
-                    u32::from_le_bytes([v[0], v[1], v[2], v[3]])
-                } else {
-                    0
-                }
-            })
+            .and_then(|attrs| get_object_attr_u32_from(attrs, CKA_PRIV_ALGO_FAMILY))
             .unwrap_or(0)
     })
 }
 
 /// Read an arbitrary attribute from an existing object in the store.
 pub(crate) fn get_object_attr_bytes(handle: u32, attr_type: u32) -> Option<Vec<u8>> {
-    OBJECTS.with(|objs| {
-        objs.borrow()
-            .get(&handle)
-            .and_then(|attrs| attrs.get(&attr_type).cloned())
-    })
+    OBJECTS.with(|objs| objs.borrow().get(&handle).and_then(|attrs| get_object_attr_bytes_from(attrs, attr_type)))
 }
 
 /// Read a u32 attribute (4-byte LE) from an existing object in the store.
 pub(crate) fn get_object_attr_u32(handle: u32, attr_type: u32) -> Option<u32> {
-    get_object_attr_bytes(handle, attr_type).and_then(|v| {
-        if v.len() >= 4 {
-            Some(u32::from_le_bytes([v[0], v[1], v[2], v[3]]))
-        } else {
-            None
-        }
-    })
+    OBJECTS.with(|objs| objs.borrow().get(&handle).and_then(|attrs| get_object_attr_u32_from(attrs, attr_type)))
 }
 
 /// Read a u64 attribute (8-byte LE) from an existing object in the store.
 pub(crate) fn get_object_attr_u64(handle: u32, attr_type: u32) -> Option<u64> {
-    get_object_attr_bytes(handle, attr_type).and_then(|v| {
-        if v.len() >= 8 {
-            Some(u64::from_le_bytes([
-                v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7],
-            ]))
-        } else {
-            None
-        }
-    })
+    OBJECTS.with(|objs| objs.borrow().get(&handle).and_then(|attrs| get_object_attr_u64_from(attrs, attr_type)))
 }
 
 /// Overwrite an attribute on an existing object in the store. Returns true on success.

--- a/rust/tests/multitenant_concurrency.rs
+++ b/rust/tests/multitenant_concurrency.rs
@@ -1,0 +1,320 @@
+//! Concurrency regression suite, grown from the P0b/P0c feasibility spikes
+//! for the hsm-perf-bench plan (rev 2, Part B — see
+//! rust-hsm-perf-bench-scenario-plan-07182026.md in the workspace root).
+//!
+//!   P0b — can 4 independent tenant tokens be brought online in one process
+//!         and used concurrently without cross-tenant interference? PASSES
+//!         for keygen/sign/verify; records a CONFIRMED, still-open gap:
+//!         `native::*` does not enforce `state::can_access_object`
+//!         token-scoping (only `ffi::C_*` does), so a native caller (e.g.
+//!         KMIP, which uses `native::*` exclusively) can reach across
+//!         tenants by handle. Not fixed here — flagged for a scoped
+//!         decision (touches KMIP's authorization model).
+//!   P0c — 20 threads hammering ONE shared token concurrently (real
+//!         contention on the global `OBJECTS` mutex), every thread's
+//!         signature verified against its own key. PASSES after a real bug
+//!         fix: see `login_exclusivity_holds_under_concurrent_attempts`
+//!         below and the `C_Login` fix in `src/ffi.rs`.
+
+use softhsmrustv3::native;
+use softhsmrustv3::state;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+use std::time::{Duration, Instant};
+
+const CKM_ML_DSA: u32 = 0x0000_001D;
+const CKP_ML_DSA_65: u32 = 0x2;
+const CKF_SERIAL_SESSION: u32 = 0x0000_0004;
+const CKF_RW_SESSION: u32 = 0x0000_0002;
+
+/// All three tests below drive the engine's process-wide global state
+/// directly (native::init/finalize, TOKEN_STORE, OBJECTS) — they are NOT
+/// safe to run concurrently WITH EACH OTHER (e.g. login_exclusivity's
+/// per-round native::finalize() would wipe state out from under p0b/p0c
+/// mid-flight). cargo test's default parallel-within-a-binary execution
+/// requires this file to self-serialize; can't reuse the engine's own
+/// `native::test_lock` (it's `pub(crate)`, invisible from this external
+/// integration-test crate). Acquire at the top of every #[test] body.
+fn serialize() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Open a session on an ALREADY-logged-in token without attempting our own
+/// login (native::open_session always logs in, which is per-token
+/// exclusive — see the p0c setup comment). Mirrors
+/// native::session::open_session_inner minus the C_Login call.
+fn open_session_only(slot: u32) -> u32 {
+    let mut handle: u32 = 0;
+    let rv = softhsmrustv3::ffi::C_OpenSession(
+        slot,
+        CKF_SERIAL_SESSION | CKF_RW_SESSION,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        &mut handle,
+    );
+    assert_eq!(rv, 0, "C_OpenSession failed: {rv}");
+    handle
+}
+
+fn bring_up_tenant(slot: u32) -> u32 {
+    state::ensure_slot(slot);
+    native::init_token(slot, "12345678", &format!("tenant-{slot}")).expect("init_token");
+    let so = native::open_session_so(slot, "12345678").expect("open SO session");
+    native::init_pin(so, "87654321").expect("init_pin");
+    native::logout(so).expect("logout SO");
+    native::close_session(so).expect("close SO session");
+    native::open_session(slot, "87654321").expect("open user session")
+}
+
+#[test]
+fn p0b_four_independent_tenant_tokens() {
+    let _guard = serialize();
+    native::init().expect("engine init");
+
+    let sessions: Vec<u32> = (1..=4).map(bring_up_tenant).collect();
+    assert_eq!(sessions.len(), 4);
+
+    // Each tenant gets its own ML-DSA-65 keypair, correctly slot-tagged
+    // (tag_object_slot derives CKA_PRIV_SLOT_ID from the creating session).
+    let mut keys = Vec::new();
+    for &sess in &sessions {
+        let (pubh, privh) =
+            native::generate_ml_dsa_keypair(sess, CKP_ML_DSA_65, b"p0b", "p0b-key").expect("keygen");
+        keys.push((pubh, privh));
+    }
+
+    for (i, &sess) in sessions.iter().enumerate() {
+        let (_pubh, privh) = keys[i];
+        let msg = b"p0b cross-tenant isolation check";
+        let sig = native::sign_pqc(sess, privh, CKM_ML_DSA, msg, &[], true, false, false, None)
+            .unwrap_or_else(|e| panic!("tenant {} sign failed: {:?}", i, e));
+        // Own tenant can verify its own signature.
+        native::verify_pqc(sess, keys[i].0, CKM_ML_DSA, msg, &sig, &[], false, false)
+            .unwrap_or_else(|e| panic!("tenant {} self-verify failed: {:?}", i, e));
+
+        // KNOWN GAP found 2026-07-18 (see rust-hsm-perf-bench-scenario-plan
+        // §B1b): `state::can_access_object` — the token-scoping gate that
+        // enforces CKA_PRIV_SLOT_ID isolation — is called ONLY from
+        // `ffi::C_*` (8 call sites, all in ffi.rs). It is NEVER called from
+        // `native::*`. So the standard PKCS#11 C ABI (ffi/ck_abi, what a
+        // real dlopen'd application uses) correctly rejects cross-tenant
+        // handle use, but the `native::*` typed surface — which the KMIP
+        // server uses exclusively, with ONE shared engine_session for every
+        // client — does not. This test records TODAY'S actual (undesired)
+        // behavior: cross-tenant access via native:: currently SUCCEEDS.
+        // Grep confirmed no compensating check exists in kmip/src either
+        // (no owner/Identity field in the KeyStore trait, no ownership
+        // check in the dispatcher) — so KMIP has no object-level tenant
+        // isolation today. This must be closed (either by adding the
+        // can_access_object gate to native::*, or by KMIP tracking
+        // per-Identity object ownership) before "one token per tenant"
+        // multi-tenancy can be considered real over the KMIP access path.
+        let other = sessions[(i + 1) % sessions.len()];
+        let cross = native::verify_pqc(other, keys[i].0, CKM_ML_DSA, msg, &sig, &[], false, false);
+        assert!(
+            cross.is_ok(),
+            "cross-tenant isolation now enforced in native::* — great, but this test (and the plan's \
+             gap note) is stale and must be updated to assert isolation HOLDS, not that the gap exists"
+        );
+    }
+
+    println!(
+        "P0b: 4 independent tenant tokens created, correctly slot-tagged, each signs/verifies its own \
+         key. CONFIRMED GAP: native::* does not enforce can_access_object — cross-tenant handle access \
+         succeeds today. The ffi::C_* / ck_abi::C_* PKCS#11 ABI surface DOES enforce it (8 call sites, \
+         source-verified) — the gap is specific to native::* / KMIP."
+    );
+}
+
+#[test]
+fn p0c_twenty_threads_one_shared_token() {
+    let _guard = serialize();
+    native::init().expect("engine init");
+    state::ensure_slot(9);
+    native::init_token(9, "12345678", "shared").expect("init_token");
+    let so = native::open_session_so(9, "12345678").expect("open SO session");
+    native::init_pin(so, "87654321").expect("init_pin");
+    native::logout(so).expect("logout SO");
+    native::close_session(so).expect("close SO session");
+
+    // PKCS#11 login state is per-TOKEN, not per-session (§5.6) — log in
+    // ONCE here; every thread below opens its own session on the
+    // already-logged-in token (the real-world multi-threaded usage
+    // pattern: an application logs in once, then opens many concurrent
+    // sessions). Each thread calling native::open_session (which attempts
+    // its own login) would be a MISUSE of the API and correctly gets
+    // CKR_USER_ALREADY_LOGGED_IN after the C_Login atomicity fix below.
+    let setup_session = native::open_session(9, "87654321").expect("initial login+session");
+    native::close_session(setup_session).ok();
+
+    const THREADS: usize = 20;
+    const OPS_PER_THREAD: usize = 200;
+
+    let ok_count = Arc::new(AtomicU64::new(0));
+    let err_count = Arc::new(AtomicU64::new(0));
+    let start = Instant::now();
+
+    std::thread::scope(|scope| {
+        for t in 0..THREADS {
+            let ok_count = Arc::clone(&ok_count);
+            let err_count = Arc::clone(&err_count);
+            scope.spawn(move || {
+                // Each thread opens its OWN session on the SAME shared,
+                // already-logged-in token — this is the real
+                // multi-tenant-on-one-token contention pattern, all
+                // hammering the same OBJECTS mutex.
+                let sess = open_session_only(9);
+                let (pubh, privh) = native::generate_ml_dsa_keypair(
+                    sess,
+                    CKP_ML_DSA_65,
+                    format!("thread-{t}").as_bytes(),
+                    &format!("t{t}-key"),
+                )
+                .unwrap_or_else(|e| panic!("thread {t} keygen failed: {e:?}"));
+
+                let msg = format!("payload from thread {t}").into_bytes();
+                for i in 0..OPS_PER_THREAD {
+                    let sig_result = native::sign_pqc(
+                        sess, privh, CKM_ML_DSA, &msg, &[], true, false, false, None,
+                    );
+                    match sig_result {
+                        Ok(sig) => {
+                            // The critical correctness check: MY signature
+                            // must verify against MY key, every single
+                            // time, under maximum concurrent contention.
+                            // Any cross-thread state corruption (wrong key
+                            // bytes read, wrong context) shows up here.
+                            match native::verify_pqc(
+                                sess, pubh, CKM_ML_DSA, &msg, &sig, &[], false, false,
+                            ) {
+                                Ok(()) => {
+                                    ok_count.fetch_add(1, Ordering::Relaxed);
+                                }
+                                Err(e) => {
+                                    err_count.fetch_add(1, Ordering::Relaxed);
+                                    eprintln!(
+                                        "thread {t} op {i}: signature did NOT verify against own key: {e:?}"
+                                    );
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            err_count.fetch_add(1, Ordering::Relaxed);
+                            eprintln!("thread {t} op {i}: sign failed: {e:?}");
+                        }
+                    }
+                }
+                native::close_session(sess).ok();
+            });
+        }
+    });
+
+    let elapsed: Duration = start.elapsed();
+    let ok = ok_count.load(Ordering::Relaxed);
+    let err = err_count.load(Ordering::Relaxed);
+    let total = ok + err;
+    let ops_per_sec = total as f64 / elapsed.as_secs_f64();
+
+    println!(
+        "P0c: {THREADS} threads x {OPS_PER_THREAD} sign+verify ops on ONE shared token \
+         in {elapsed:?} ({ops_per_sec:.0} ops/sec) — ok={ok} err={err}"
+    );
+
+    assert_eq!(err, 0, "{err} operations failed or corrupted under 20-thread contention");
+    assert_eq!(ok, (THREADS * OPS_PER_THREAD) as u64);
+}
+
+/// Regression test for the TOCTOU race found 2026-07-18 while writing
+/// P0c above: `ffi::C_Login` used to read the token's `login_state` from
+/// a `.cloned()` snapshot taken under one `TOKEN_STORE` lock acquisition,
+/// then write the new state in a SEPARATE, later lock acquisition. Under
+/// concurrent `C_Login` calls on the same token, many threads could all
+/// read the pre-login snapshot before any of them wrote — so all of them
+/// passed the "not already logged in" exclusivity check and all
+/// "succeeded", silently violating PKCS#11 v3.2 §5.6 (only one login
+/// wins; every other caller must get `CKR_USER_ALREADY_LOGGED_IN`).
+///
+/// Fixed by making the read-check-write one atomic critical section
+/// (single lock acquisition) in `C_Login`. This test drives 20 threads at
+/// `C_Login(CKU_USER)` on the same fresh token simultaneously and asserts
+/// EXACTLY one succeeds — repeated across several rounds, since the
+/// original bug was a race (probabilistic, not deterministic every run).
+#[test]
+fn login_exclusivity_holds_under_concurrent_attempts() {
+    let _guard = serialize();
+    const ROUNDS: u32 = 20;
+    const THREADS: usize = 20;
+
+    for round in 0..ROUNDS {
+        native::finalize().ok();
+        native::init().expect("engine init");
+        let slot = 20 + round; // fresh slot per round, avoids cross-round state
+        state::ensure_slot(slot);
+        native::init_token(slot, "12345678", "race-check").expect("init_token");
+        let so = native::open_session_so(slot, "12345678").expect("open SO session");
+        native::init_pin(so, "87654321").expect("init_pin");
+        native::logout(so).expect("logout SO");
+        native::close_session(so).expect("close SO session");
+
+        let ok_count = Arc::new(AtomicU64::new(0));
+        let already_count = Arc::new(AtomicU64::new(0));
+        let unexpected = Arc::new(AtomicU64::new(0));
+
+        std::thread::scope(|scope| {
+            for _ in 0..THREADS {
+                let ok_count = Arc::clone(&ok_count);
+                let already_count = Arc::clone(&already_count);
+                let unexpected = Arc::clone(&unexpected);
+                scope.spawn(move || {
+                    let session = open_session_only(slot);
+                    let mut pin: Vec<u8> = b"87654321".to_vec();
+                    const CKU_USER: u32 = 1;
+                    let rv = softhsmrustv3::ffi::C_Login(
+                        session,
+                        CKU_USER,
+                        pin.as_mut_ptr(),
+                        pin.len() as u32,
+                    );
+                    const CKR_OK: u32 = 0;
+                    const CKR_USER_ALREADY_LOGGED_IN: u32 = 0x0000_0100;
+                    match rv {
+                        CKR_OK => {
+                            ok_count.fetch_add(1, Ordering::Relaxed);
+                        }
+                        CKR_USER_ALREADY_LOGGED_IN => {
+                            already_count.fetch_add(1, Ordering::Relaxed);
+                        }
+                        other => {
+                            unexpected.fetch_add(1, Ordering::Relaxed);
+                            eprintln!("round {round}: unexpected C_Login rv={other}");
+                        }
+                    }
+                });
+            }
+        });
+
+        let ok = ok_count.load(Ordering::Relaxed);
+        let already = already_count.load(Ordering::Relaxed);
+        let bad = unexpected.load(Ordering::Relaxed);
+
+        assert_eq!(bad, 0, "round {round}: {bad} C_Login calls returned an unexpected code");
+        assert_eq!(
+            ok, 1,
+            "round {round}: exactly one thread should win C_Login's exclusivity check, got {ok} \
+             (TOCTOU race regressed — see fix in ffi::C_Login)"
+        );
+        assert_eq!(
+            already,
+            (THREADS - 1) as u64,
+            "round {round}: the other {} threads should all see CKR_USER_ALREADY_LOGGED_IN, got {}",
+            THREADS - 1,
+            already
+        );
+    }
+
+    println!(
+        "login_exclusivity_holds_under_concurrent_attempts PASS: {ROUNDS} rounds x {THREADS} \
+         concurrent C_Login(USER) calls, exactly 1 winner every round"
+    );
+}

--- a/rust/tests/multitenant_concurrency.rs
+++ b/rust/tests/multitenant_concurrency.rs
@@ -4,12 +4,12 @@
 //!
 //!   P0b — can 4 independent tenant tokens be brought online in one process
 //!         and used concurrently without cross-tenant interference? PASSES
-//!         for keygen/sign/verify; records a CONFIRMED, still-open gap:
-//!         `native::*` does not enforce `state::can_access_object`
-//!         token-scoping (only `ffi::C_*` does), so a native caller (e.g.
-//!         KMIP, which uses `native::*` exclusively) can reach across
-//!         tenants by handle. Not fixed here — flagged for a scoped
-//!         decision (touches KMIP's authorization model).
+//!         for keygen/sign/verify AND for isolation: `native::*` originally
+//!         did not enforce `state::can_access_object` token-scoping (only
+//!         `ffi::C_*` did), so a native caller (e.g. KMIP, which uses
+//!         `native::*` exclusively) could reach across tenants by handle.
+//!         Closed in Part F (2026-07-18): every by-handle `native::*`
+//!         function now gates through the same predicate.
 //!   P0c — 20 threads hammering ONE shared token concurrently (real
 //!         contention on the global `OBJECTS` mutex), every thread's
 //!         signature verified against its own key. PASSES after a real bug
@@ -93,37 +93,30 @@ fn p0b_four_independent_tenant_tokens() {
         native::verify_pqc(sess, keys[i].0, CKM_ML_DSA, msg, &sig, &[], false, false)
             .unwrap_or_else(|e| panic!("tenant {} self-verify failed: {:?}", i, e));
 
-        // KNOWN GAP found 2026-07-18 (see rust-hsm-perf-bench-scenario-plan
-        // §B1b): `state::can_access_object` — the token-scoping gate that
-        // enforces CKA_PRIV_SLOT_ID isolation — is called ONLY from
-        // `ffi::C_*` (8 call sites, all in ffi.rs). It is NEVER called from
-        // `native::*`. So the standard PKCS#11 C ABI (ffi/ck_abi, what a
-        // real dlopen'd application uses) correctly rejects cross-tenant
-        // handle use, but the `native::*` typed surface — which the KMIP
-        // server uses exclusively, with ONE shared engine_session for every
-        // client — does not. This test records TODAY'S actual (undesired)
-        // behavior: cross-tenant access via native:: currently SUCCEEDS.
-        // Grep confirmed no compensating check exists in kmip/src either
-        // (no owner/Identity field in the KeyStore trait, no ownership
-        // check in the dispatcher) — so KMIP has no object-level tenant
-        // isolation today. This must be closed (either by adding the
-        // can_access_object gate to native::*, or by KMIP tracking
-        // per-Identity object ownership) before "one token per tenant"
-        // multi-tenancy can be considered real over the KMIP access path.
+        // GAP CLOSED 2026-07-18 (rust-hsm-perf-bench-scenario-plan-07182026.md
+        // Part F): `state::can_access_object` used to be called ONLY from
+        // `ffi::C_*` (8 call sites); `native::*` never called it, so the
+        // KMIP server (which uses `native::*` exclusively) had no
+        // object-level tenant isolation even though the ffi/ck_abi C ABI
+        // always enforced it correctly. Every by-handle `native::*`
+        // function (sign/verify/encrypt/decrypt/encapsulate/decapsulate/
+        // agree/get+set attribute/destroy/split+join/hybrid) now routes
+        // through the same gate (`with_object_checked` /
+        // `resolve_session_access` in state.rs) — cross-tenant handle use
+        // must fail exactly like the ffi surface always has.
         let other = sessions[(i + 1) % sessions.len()];
         let cross = native::verify_pqc(other, keys[i].0, CKM_ML_DSA, msg, &sig, &[], false, false);
         assert!(
-            cross.is_ok(),
-            "cross-tenant isolation now enforced in native::* — great, but this test (and the plan's \
-             gap note) is stale and must be updated to assert isolation HOLDS, not that the gap exists"
+            cross.is_err(),
+            "tenant {} object was reachable from a different tenant's session — isolation gate regressed",
+            i
         );
     }
 
     println!(
         "P0b: 4 independent tenant tokens created, correctly slot-tagged, each signs/verifies its own \
-         key. CONFIRMED GAP: native::* does not enforce can_access_object — cross-tenant handle access \
-         succeeds today. The ffi::C_* / ck_abi::C_* PKCS#11 ABI surface DOES enforce it (8 call sites, \
-         source-verified) — the gap is specific to native::* / KMIP."
+         key, and cross-tenant handle access is now uniformly denied by native::* — the same isolation \
+         ffi::C_* / ck_abi::C_* always enforced."
     );
 }
 


### PR DESCRIPTION
## Summary

27 commits backing the pqctoday-sandbox hsm-perf-bench scenario (39):

- New `bench-harness` Rust binary: real fixed-duration PKCS#11-direct
  throughput/latency measurement, full 16-algorithm matrix + separate
  keygen row, Topology B (independent multi-process instances) via real
  multi-process orchestration, per-tenant/per-instance JSONL streaming,
  `--algorithms` filter, `--list-algorithms`.
- SLH-DSA completion (12/12 FIPS 205 param sets), RSA-PSS signing,
  RSA-OAEP key-transport (ECDH-derive + ML-KEM encap/decap already real).
- Fixed `CK_RSA_PKCS_OAEP_PARAMS` being parsed at a hardcoded 4-byte width
  instead of native width (root-cause fix, not a harness workaround).
- KMIP tenant-registry + per-tenant session/owner enforcement wired end to
  end across CreateKeyPair/Sign/Encapsulate/ReKeyKeyPair/Encrypt/Decrypt/
  Certify/Register/Import/Export/ReKey, with cross-tenant isolation proofs
  for each. Fixed a C_Login TOCTOU race, an async job Cancel/executor race,
  and a cross-tenant isolation test that panicked when Ed25519 wasn't
  selected.
- Added `--tenancy` flag to the KMIP server binary.

## Test plan

- [x] `cargo build --release --workspace` — clean, no errors
- [x] `cargo test --release --workspace` — 309 passed, 0 failed, 9 ignored
- [x] Live-verified downstream in pqctoday-sandbox: a real hsm-perf-bench
  job through the rebuilt Docker image's Flask API produced actual
  measured throughput (not simulated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)