### PR TITLE
release: v0.15.1 — KMIP3 spec-citation cleanup + Python client patch-table fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased]
+## [0.15.1] — 2026-07-24
 
 ### Fixed
 
@@ -21,6 +21,27 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   without its classification tag, BSI FrodoKEM/Classic-McEliece without
   the hybrid-partner tag) as allows. No production code changed; the
   helper now recognizes all 5 deny-mapped reasons.
+- **KMIP 3.0 spec-citation cleanup (2026-07-23/24 playground re-audit).**
+  Nine "§6.4" citations across the conformance harness
+  (`dispatcher_replay.py`), the wire encoder (`wire.rs`), the TLS listener
+  (`listener.rs`), and a planning doc cited a section that doesn't exist
+  under either the CSD01 or WD19 baseline — verified against both spec
+  documents directly. Eight now cite the real section (§8.2.3 Response
+  Batch Item, or §9.5 Batch Error Continuation); `listener.rs`'s general
+  wire-decode-failure policy statement doesn't map to any single spec
+  section under either baseline, so it's now stated without a false
+  citation rather than guessing one.
+- **Python conformance client (`_ttlv.py`): three codepoint-table gaps
+  found and closed.** `RC4` was mapped to DSA's real codepoint instead of
+  its own (mirrors a bug already fixed on the hub side);
+  `X25519MLKEM768`/`SecP256r1MLKEM768` were missing from the algorithm
+  table entirely; `DeactivationReasonCode` had no patch at all and was
+  silently falling through to the base spec extraction's own corrupted
+  4-member table for that enum. All three were unreachable from any
+  current test or client code path — no behavior changed for anything
+  that runs today — fixed anyway, and a new completeness test
+  (`test_ttlv.py`) now fails the build if a future patch-table edit
+  reintroduces this class of drift.
 
 ## [0.15.0] — 2026-07-18
 

--- a/kmip/Cargo.lock
+++ b/kmip/Cargo.lock
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "pqctoday-kmip"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "softhsmrustv3"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",

--- a/kmip/Cargo.toml
+++ b/kmip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pqctoday-kmip"
-version     = "0.15.0"
+version     = "0.15.1"
 edition     = "2024"
 license     = "MIT"
 description = "KMIP 3.0 PQC + classical key management wrapper over pqctoday-hsm PKCS#11"

--- a/kmip/conformance/analysis/REMEDIATION_PLAN.md
+++ b/kmip/conformance/analysis/REMEDIATION_PLAN.md
@@ -304,7 +304,7 @@ Sensitive boolean inner fields.
 - KMIP 3.0 Spec §8.1.3 / §8.2.3 — Batch Items are positionally
   correlated. The server SHALL return one response BatchItem per
   request BatchItem, in order, including failure responses.
-- §6.4 / §6.4.1 Batch Error Continuation Option — `Stop` (default),
+- §9.5 / §9.5.1 Batch Error Continuation Option — `Stop` (default),
   `Undo`, `Continue` modes are all defined; the request header in
   AX-M-1 sets `<BatchErrorContinuationOption value="Undo"/>` but a
   decode error before reaching the per-item dispatch means the
@@ -478,7 +478,7 @@ provided the test corpus has no further hidden interactions.
    the rest of the corpus uses? Or do we need full TransparentDSA
    round-trip?
 
-2. **Family R7 / Batch error continuation.** Spec §6.4.1 defines
+2. **Family R7 / Batch error continuation.** Spec §9.5.1 defines
    `Stop`, `Undo`, `Continue`. AX-M-* uses `Undo`. Implementing `Undo`
    requires journaling each BatchItem's side effects so we can roll
    them back when a later item fails. **Question:** is `Stop` (default)

--- a/kmip/conformance/harness/dispatcher_replay.py
+++ b/kmip/conformance/harness/dispatcher_replay.py
@@ -412,7 +412,7 @@ def find_child(node: TtlvNode, tag: str) -> TtlvNode | None:
 # Format: tag-name → spec citation. Codec citations point to PDF page
 # numbers in `spec/oasis-kmip-3.0/kmip-profiles-v3.0.pdf`.
 _VARIABLE_ITEM_TAGS: dict[str, str] = {
-    # Envelope fields the main spec §6.4 marks as transient.
+    # Envelope fields the main spec §8.2.3 marks as transient.
     _norm("TimeStamp"): "§4.1.1 item 6 — Time Stamp",
     _norm("ServerCorrelationValue"): "§4.1.1 item 18",
     _norm("ClientCorrelationValue"): "§4.1.1 item 19",
@@ -457,7 +457,7 @@ def is_volatile_tag(tag: str) -> bool:
 
 
 # A handful of §4.1.1 Variable Items are ALSO optional-presence per the
-# main KMIP 3.0 spec §6.4 Message-Envelope rules — the server MAY emit
+# KMIP 3.0 §8.2.3 Response Batch Item structure table — the server MAY emit
 # them or omit them. Different OASIS XML fixtures pick one form or the
 # other for the same op, so the comparator must tolerate presence/absence
 # in BOTH directions: drop these tags from both sides before structural

--- a/kmip/python-client/pyproject.toml
+++ b/kmip/python-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pqctoday-kmip-client"
-version = "0.8.0"
+version = "0.8.1"
 description = "Python client for the pqctoday KMIP 3.0 PQC key management server"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/kmip/python-client/src/pqctoday_kmip/_ttlv.py
+++ b/kmip/python-client/src/pqctoday_kmip/_ttlv.py
@@ -153,6 +153,22 @@ _SPEC_EXTRACT_PATCHES: dict[str, dict[str, int]] = {
     "CertificateRequestType": {"Crmf": 0x00000001, "PKCS10": 0x00000002, "PEM": 0x00000003},
     # Validate's three-way answer - matches kmip30::ops::SignatureValidity.
     "ValidityIndicator": {"Valid": 0x00000001, "Invalid": 0x00000002, "Unknown": 0x00000003},
+    # Deactivate's 'Deactivation Reason Code' - found missing from this file
+    # entirely 2026-07-23 (codepointTable.ts has always had it). Without this
+    # patch, lookups fell through to the base JSON's own corrupted
+    # extraction for this table (wrong table matched during PDF extraction -
+    # 4 bogus members, not the real 7). Values verified against
+    # kmip30::ops::DeactivationReason directly (mirrors RevocationReason's
+    # codepoints exactly, both from the same table shape).
+    "DeactivationReasonCode": {
+        "Unspecified":          0x00000001,
+        "KeyCompromise":        0x00000002,
+        "CACompromise":         0x00000003,
+        "AffiliationChanged":   0x00000004,
+        "Superseded":           0x00000005,
+        "CessationOfOperation": 0x00000006,
+        "PrivilegeWithdrawn":   0x00000007,
+    },
     "CredentialType": {
         "UsernameAndPassword": 0x00000001,
         "Device":              0x00000002,
@@ -164,7 +180,18 @@ _SPEC_EXTRACT_PATCHES: dict[str, dict[str, int]] = {
     "CryptographicAlgorithm": {
         "DES":  0x00000001,
         "DES3": 0x00000002,
-        "RC4":  0x00000005,
+        # Found 2026-07-23 (Python-side re-check of the WD19-delta
+        # completeness work done on codepointTable.ts's copy of this table):
+        # was 0x00000005 — that's DSA's codepoint, not RC4's. Real RC4 is
+        # 0x00000016 per the spec extraction's own 'RC4' entry.
+        "RC4":  0x00000016,
+        # WD19 hybrid KEMs — real OASIS codepoints (0x5C/0x5D), just newer
+        # than the vendored spec-extraction JSON's CSD01 baseline (stops at
+        # 0x4A). Matches kmip/src/kmip30/algos.rs's KmipAlgorithm::X25519MlKem768
+        # / SecP256r1MlKem768 and codepointTable.ts's copy of this same
+        # patch exactly. Found missing entirely from this file 2026-07-23.
+        "X25519MLKEM768":    0x0000005C,
+        "SecP256r1MLKEM768": 0x0000005D,
         # BSI TR-02102-1 vendor KEMs (2026-07-06) — not in the published-3.0
         # spec JSON since they're vendor extensions, not OASIS codepoints
         # (Classic McEliece's 0x34 is a real OASIS value; FrodoKEM's

--- a/kmip/python-client/tests/test_ttlv.py
+++ b/kmip/python-client/tests/test_ttlv.py
@@ -3,6 +3,8 @@
 All tests are pure-Python, no network, no server.  Run with:
     cd kmip/python-client && python -m pytest tests/
 """
+import json
+
 import pytest
 
 from pqctoday_kmip._ttlv import (
@@ -335,3 +337,201 @@ def test_placeholder_raises():
     from pqctoday_kmip._ttlv import EncodeError
     with pytest.raises(EncodeError, match="unresolved placeholder"):
         encode_node(leaf("UniqueIdentifier", "TextString", "$placeholder"))
+
+
+# ── WD19 delta completeness + non-corruption guard (2026-07-23 re-audit, X1) ──
+#
+# Python-side counterpart to hub's wd19Delta.local.test.ts. Every entry in
+# _SPEC_EXTRACT_TAG_PATCHES/_SPEC_EXTRACT_PATCHES must be accounted for by
+# ONE of: the base CSD01 spec JSON itself (exact or case-insensitive _norm()
+# match — the fallback exists because several patches are the same
+# case-sensitive-norm-collision class of bug as the original H1/ReKeyKeyPair
+# defect, e.g. ReKeyKeyPair vs the spec's "Re-key Key Pair"), the WD19 delta
+# file, or an explicit justified exception below. This is the test that
+# would have caught the 2026-07-23 RC4 bug (RC4 patched to 0x00000005 —
+# DSA's real codepoint — instead of the real 0x00000016) and the two other
+# gaps found the same day (missing X25519MLKEM768/SecP256r1MLKEM768, and a
+# missing DeactivationReasonCode patch entirely) — this table was NOT
+# independently re-verified against the base JSON before this pass; it was
+# only assumed to mirror codepointTable.ts's copy, which it did not.
+import importlib.resources as _ir
+from pathlib import Path as _Path
+
+from pqctoday_kmip._ttlv import _SPEC_EXTRACT_PATCHES, _SPEC_EXTRACT_TAG_PATCHES, _norm
+
+_BASE_JSON = json.loads(
+    _ir.files("pqctoday_kmip").joinpath("data/kmip-spec-3.0-tags-enums.json").read_text(encoding="utf-8")
+)
+# Read directly from the canonical spec/ directory, not a vendored copy —
+# this file has no runtime consumer (CodepointTable.load() never reads it),
+# only this test does, so there is nothing to vendor for.
+_DELTA_JSON = json.loads(
+    (_Path(__file__).resolve().parents[2] / "spec/oasis-kmip-3.0/kmip-spec-3.0-wd19-delta.json").read_text(
+        encoding="utf-8"
+    )
+)
+
+# Enum-member patches with no match in base or delta, each with why it's
+# legitimately absent from both KMIP spec baselines. Independently
+# classified against THIS file's actual patch tables (see the 2026-07-23
+# session notes above) — not copied from the TS side's allowlist, though the
+# underlying facts happen to be identical since both files patch the same
+# real values.
+_ENUM_ALLOWLIST: dict[str, dict[str, str]] = {
+    "CryptographicAlgorithm": {
+        "DES3": "naming-convention alias for CSD01's '3DES' (0x00000002, digit-order differs, not a case issue)",
+        "FrodoKEM-640": "BSI TR-02102-1 vendor KEM, not an OASIS codepoint under either baseline",
+        "FrodoKEM-640-AES": "BSI TR-02102-1 vendor KEM, not an OASIS codepoint under either baseline",
+        "FrodoKEM-640-SHAKE": "BSI TR-02102-1 vendor KEM, not an OASIS codepoint under either baseline",
+        "FrodoKEM-976": "BSI TR-02102-1 vendor KEM, not an OASIS codepoint under either baseline",
+        "FrodoKEM-976-AES": "BSI TR-02102-1 vendor KEM, not an OASIS codepoint under either baseline",
+        "FrodoKEM-976-SHAKE": "BSI TR-02102-1 vendor KEM, not an OASIS codepoint under either baseline",
+        "FrodoKEM-1344": "BSI TR-02102-1 vendor KEM, not an OASIS codepoint under either baseline",
+        "FrodoKEM-1344-AES": "BSI TR-02102-1 vendor KEM, not an OASIS codepoint under either baseline",
+        "FrodoKEM-1344-SHAKE": "BSI TR-02102-1 vendor KEM, not an OASIS codepoint under either baseline",
+        "Classic-McEliece-6688128": (
+            "parameter-set-specific display name for CSD01's real 'McEliece' entry "
+            "(0x00000034) — same OASIS codepoint, not a vendor value"
+        ),
+        "ML-DSA-44-RSA2048-PSS": "LAMPS composite signature, vendor-extension range, not an OASIS codepoint",
+        "ML-DSA-65-ECDSA-P256": "LAMPS composite signature, vendor-extension range, not an OASIS codepoint",
+        "ML-DSA-87-ECDSA-P384": "LAMPS composite signature, vendor-extension range, not an OASIS codepoint",
+    },
+    "MaskGenerator": {
+        "MGF1": (
+            "CSD01 PDF-extraction typo — the spec JSON has 'MFG1' (transposed letters) "
+            "at the same codepoint (0x00000001), not a WD19 addition"
+        ),
+    },
+    "DeactivationReasonCode": {
+        "KeyCompromise": (
+            "CSD01's own 'Deactivation Reason Code' table is a PDF-extraction mismatch "
+            "(wrong table extracted) — verified against kmip30::ops::DeactivationReason "
+            "directly, not WD19-new"
+        ),
+        "CACompromise": "same CSD01 extraction defect as KeyCompromise above",
+        "AffiliationChanged": "same CSD01 extraction defect as KeyCompromise above",
+        "Superseded": "same CSD01 extraction defect as KeyCompromise above",
+        "CessationOfOperation": "same CSD01 extraction defect as KeyCompromise above",
+        "PrivilegeWithdrawn": "same CSD01 extraction defect as KeyCompromise above",
+    },
+    "PKCS11Function": {
+        "*": "PKCS#11 function-call constants for the bridge, not KMIP OASIS operations — out of CSD01/WD19 scope entirely",
+    },
+    "PKCS11ReturnCode": {
+        "*": "PKCS#11 return-code constants for the bridge, not KMIP OASIS values — out of CSD01/WD19 scope entirely",
+    },
+    "MaskGeneratorHashingAlgorithm": {
+        "*": (
+            "reuses the base JSON's 'Hashing Algorithm' enum values under a field-specific "
+            "name (SHA1=4 matches 'SHA-1'=4, etc. — verified 1:1) — not WD19-new, not vendor"
+        ),
+    },
+}
+
+# No unmatched TAG patches this pass (all 8 genuinely-new WD19 tags are in
+# the delta file; the other 7 SPEC_EXTRACT_TAG_PATCHES entries are redundant
+# aliases for CSD01 entries and match via exact/case-insensitive norm).
+_TAG_ALLOWLIST: dict[str, str] = {}
+
+
+def _find_match(name, pool):
+    """pool: iterable of (name, value). Exact _norm() match first, then a
+    case-insensitive fallback (same two-rule structure as the TS test —
+    Python's _norm() has the identical strip-non-alnum, case-sensitive
+    behavior, confirmed by reading the source before writing this)."""
+    n = _norm(name)
+    for pn, pv in pool:
+        if _norm(pn) == n:
+            return pv
+    nl = n.lower()
+    for pn, pv in pool:
+        if _norm(pn).lower() == nl:
+            return pv
+    return None
+
+
+def test_tag_patches_are_verified_aliases_delta_entries_or_explicit_exceptions():
+    base_tags = [(t["name"], int(t["codepoint"], 16)) for t in _BASE_JSON["tags"]]
+    delta_tags = [(t["name"], int(t["codepoint"], 16)) for t in _DELTA_JSON.get("tags", [])]
+    for name, patched_code in _SPEC_EXTRACT_TAG_PATCHES.items():
+        m = _find_match(name, base_tags)
+        if m is not None:
+            assert patched_code == m, f"tag '{name}' patch value diverges from CSD01's own value"
+            continue
+        m = _find_match(name, delta_tags)
+        if m is not None:
+            assert patched_code == m, f"tag '{name}' patch value diverges from the WD19 delta file"
+            continue
+        assert name in _TAG_ALLOWLIST, (
+            f"tag '{name}' (0x{patched_code:x}) is not in CSD01, not in the WD19 delta file, "
+            "and not an explicit exception — is this a new WD19-only value that needs adding "
+            "to kmip-spec-3.0-wd19-delta.json?"
+        )
+
+
+def test_enum_patches_are_verified_aliases_delta_entries_or_explicit_exceptions():
+    for enum_name, members in _SPEC_EXTRACT_PATCHES.items():
+        base_enum_key = next(
+            (
+                bn
+                for bn in _BASE_JSON["enums"]
+                if _norm(bn) == _norm(enum_name) or _norm(bn).lower() == _norm(enum_name).lower()
+            ),
+            None,
+        )
+        base_members = (
+            [(m["name"], int(m["value"], 16)) for m in _BASE_JSON["enums"][base_enum_key]]
+            if base_enum_key
+            else []
+        )
+        delta_enum_key = next(
+            (
+                dn
+                for dn in _DELTA_JSON.get("enums", {})
+                if _norm(dn) == _norm(enum_name) or _norm(dn).lower() == _norm(enum_name).lower()
+            ),
+            None,
+        )
+        delta_members = (
+            [(m["name"], int(m["value"], 16)) for m in _DELTA_JSON["enums"][delta_enum_key]]
+            if delta_enum_key
+            else []
+        )
+        allowlist_for_enum = _ENUM_ALLOWLIST.get(enum_name, {})
+
+        for member_name, patched_value in members.items():
+            m = _find_match(member_name, base_members)
+            if m is not None:
+                assert patched_value == m, (
+                    f"{enum_name}.{member_name} patch value diverges from CSD01's own value"
+                )
+                continue
+            m = _find_match(member_name, delta_members)
+            if m is not None:
+                assert patched_value == m, (
+                    f"{enum_name}.{member_name} patch value diverges from the WD19 delta file"
+                )
+                continue
+            allowed = allowlist_for_enum.get(member_name) or allowlist_for_enum.get("*")
+            assert allowed is not None, (
+                f"{enum_name}.{member_name} (0x{patched_value:x}) is not in CSD01, not in the "
+                "WD19 delta file, and not an explicit exception — is this a new WD19-only value "
+                "that needs adding to kmip-spec-3.0-wd19-delta.json?"
+            )
+
+
+def test_allowlist_is_not_vacuous():
+    """Sanity check the completeness test itself can fail: prove
+    _ENUM_ALLOWLIST is load-bearing by removing one real exception (DES3)
+    and confirming it has no other match, mirroring the TS test's approach."""
+    without_des3 = dict(_ENUM_ALLOWLIST["CryptographicAlgorithm"])
+    del without_des3["DES3"]
+
+    base_algos = [(m["name"], int(m["value"], 16)) for m in _BASE_JSON["enums"]["Cryptographic Algorithm"]]
+    delta_algos = [
+        (m["name"], int(m["value"], 16)) for m in _DELTA_JSON.get("enums", {}).get("Cryptographic Algorithm", [])
+    ]
+    assert _find_match("DES3", base_algos) is None, "DES3 unexpectedly matches CSD01 by name — probe assumption invalid"
+    assert _find_match("DES3", delta_algos) is None, "DES3 unexpectedly matches the WD19 delta — probe assumption invalid"
+    assert "DES3" not in without_des3, "probe removal failed"

--- a/kmip/spec/oasis-kmip-3.0/kmip-spec-3.0-wd19-delta.json
+++ b/kmip/spec/oasis-kmip-3.0/kmip-spec-3.0-wd19-delta.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "kind": "wd19_delta",
+  "note": "Hand-curated supplement to kmip-spec-3.0-tags-enums.json (machine-extracted from the CSD01 HTML, 2023-11-30). Lists ONLY the codepoints this engine implements that are genuinely absent from the CSD01 extraction because OASIS added them in the WD19 draft (14 February 2025, kmip-spec-v3.0-wd19-clean.pdf). Every entry below was confirmed absent from kmip-spec-3.0-tags-enums.json by direct lookup, then confirmed present in the WD19 PDF text at the cited table/section, before being added here. This file does NOT include CACP's own vendor-extension codepoints (FrodoKEM, Classic-McEliece composites, LAMPS composite signatures) — those are marked as such at their definition site (codepointTable.ts) and are not OASIS values under either baseline. It also does NOT include ReKey/ReKeyKeyPair/Re-certify — those exist in CSD01 already under hyphenated OASIS names (Re-key, Re-key Key Pair, Re-certify); the hub patch table's camelCase aliases for them are a norm()-compatibility fix, not a baseline gap.",
+  "source_file": "spec/oasis-kmip-3.0/kmip-spec-v3.0-wd19-clean.pdf",
+  "source_date": "2026-02-14",
+  "tags": [
+    { "name": "KEM Algorithm", "codepoint": "0x4201c3", "cite": "WD19 §11.26 Table 572 (new field for Encapsulate/Decapsulate)" },
+    { "name": "Deterministic", "codepoint": "0x4201c4", "cite": "WD19 Encapsulate/Decapsulate request field (deterministic-coins option)" },
+    { "name": "Context String", "codepoint": "0x4201c5", "cite": "WD19 Encapsulate/Decapsulate request field" },
+    { "name": "Seed", "codepoint": "0x4201c6", "cite": "WD19 Encapsulate/Decapsulate request field" },
+    { "name": "Input Key Material", "codepoint": "0x4201c7", "cite": "WD19 Encapsulate/Decapsulate request field (ML-KEM deterministic coins)" },
+    { "name": "Internal", "codepoint": "0x4201c8", "cite": "WD19 Encapsulate/Decapsulate request field" },
+    { "name": "External Mu", "codepoint": "0x4201c9", "cite": "WD19 Encapsulate/Decapsulate request field" },
+    { "name": "Random", "codepoint": "0x4201ca", "cite": "WD19 Encapsulate/Decapsulate request field" }
+  ],
+  "enums": {
+    "Operation": [
+      { "name": "Encapsulate", "value": "0x00000041", "cite": "WD19 Operation Enumeration (new op, immediately after Deactivate=0x40)" },
+      { "name": "Decapsulate", "value": "0x00000042", "cite": "WD19 Operation Enumeration (new op, immediately after Encapsulate=0x41)" }
+    ],
+    "Cryptographic Algorithm": [
+      { "name": "X25519MLKEM768", "value": "0x0000005c", "cite": "WD19 §11.12 Table 552 Cryptographic Algorithm Enumeration" },
+      { "name": "SECP256R1MLKEM768", "value": "0x0000005d", "cite": "WD19 §11.12 Table 552 Cryptographic Algorithm Enumeration" }
+    ],
+    "Key Format Type": [
+      { "name": "Seed Private Key", "value": "0x00000018", "cite": "WD19 §11.28 Table 575 Key Format Type Enumeration (new PQC seed-based private key format, §3.4)" }
+    ],
+    "KEM Algorithm": [
+      { "name": "RSASVE", "value": "0x00000001", "cite": "WD19 §11.26 Table 572 KEM Algorithm Enumeration (whole enum is new in WD19)" },
+      { "name": "DHKEM", "value": "0x00000002", "cite": "WD19 §11.26 Table 572 KEM Algorithm Enumeration" },
+      { "name": "MLKEM", "value": "0x00000003", "cite": "WD19 §11.26 Table 572 KEM Algorithm Enumeration" }
+    ]
+  }
+}

--- a/kmip/src/kmip30/wire.rs
+++ b/kmip/src/kmip30/wire.rs
@@ -836,7 +836,7 @@ fn header_to_frame(h: &ResponseHeader) -> TtlvFrame {
     TtlvFrame::new(Tag(tags::ResponseHeader), Value::Structure(children))
 }
 
-/// Encode a KMIP 3.0 §6.4.2 response BatchItem.
+/// Encode a KMIP 3.0 §8.2.3 response BatchItem.
 ///
 /// Spec-mandated child sequencing depends on `ResultStatus`:
 ///

--- a/kmip/src/server/listener.rs
+++ b/kmip/src/server/listener.rs
@@ -183,12 +183,18 @@ async fn handle_conn(
             .await
             .map_err(|e| ServerError::Io(std::io::Error::other(format!("dispatch task failed: {e}"))))?
         }
-        // KMIP 3.0 §6.4: a wire-decode failure (unknown tag, unknown enum
-        // value, malformed length, etc.) must produce a structured
+        // KMIP 3.0: a wire-decode failure (unknown tag, unknown enum value,
+        // malformed length, etc.) must produce a structured
         // `OperationFailed` response with `ResultReason = InvalidMessage`
-        // — NOT a TCP/TLS connection drop. Closing the socket without a
-        // response makes the client see a transport error instead of a
-        // proper protocol-level rejection (and breaks OASIS conformance).
+        // (see the Result Reason Enumeration's "Invalid Message" member,
+        // used across the per-op Error Handling tables) — NOT a TCP/TLS
+        // connection drop. Closing the socket without a response makes the
+        // client see a transport error instead of a proper protocol-level
+        // rejection (and breaks OASIS conformance). No single spec section
+        // states this general policy explicitly under either the CSD01 or
+        // WD19 baseline (checked both, 2026-07-23) — the "§6.4" citation
+        // this comment used to carry didn't exist and was removed rather
+        // than replaced with another guess.
         Err(e) => wire_error_response(&e),
     };
     let response_bytes = encode_response_message(&response);
@@ -197,7 +203,9 @@ async fn handle_conn(
     Ok(())
 }
 
-/// Build a KMIP 3.0 §6.4 error ResponseMessage for an unparseable request.
+/// Build a KMIP 3.0 error ResponseMessage for an unparseable request (see
+/// `handle_conn`'s error arm above for why there's no single spec section
+/// to cite here).
 ///
 /// Used when our codec can't decode the inbound frame — e.g. unknown
 /// algorithm enum value, missing required field, malformed Structure

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1781,7 +1781,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "softhsmrustv3"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softhsmrustv3"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 description = "A native Rust WebAssembly clone of SoftHSMv3"
 

--- a/scripts/build-kmip-wasm.sh
+++ b/scripts/build-kmip-wasm.sh
@@ -117,6 +117,15 @@ mkdir -p "$HUB_CORPUS_DIR/oasis/mandatory" "$HUB_CORPUS_DIR/oasis/optional" "$HU
 cp "$CONF"/oasis_corpus/mandatory/*.xml "$HUB_CORPUS_DIR/oasis/mandatory/"
 cp "$CONF"/oasis_corpus/optional/*.xml  "$HUB_CORPUS_DIR/oasis/optional/"
 cp "$CONF"/pqc_corpus/*.xml             "$HUB_CORPUS_DIR/pqc/"
+
+# Spec-extraction JSON + its WD19 delta (2026-07-23 re-audit, finding X1):
+# this was previously staged manually, out of band from this script, so a
+# real rebuild would silently leave hub's copy stale. Re-staged here so it
+# can never drift from the engine's own spec/ directory again.
+SPEC_DIR="$ROOT/kmip/spec/oasis-kmip-3.0"
+cp "$SPEC_DIR/kmip-spec-3.0-tags-enums.json" "$HUB_CORPUS_DIR/tags-enums.json"
+cp "$SPEC_DIR/kmip-spec-3.0-wd19-delta.json" "$HUB_CORPUS_DIR/tags-enums-wd19-delta.json"
+
 python3 - "$HUB_CORPUS_DIR" <<'PY'
 import json, os, sys
 root = sys.argv[1]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "pqctoday-kmip"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "pqctoday-kmip-wasm"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -1705,7 +1705,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "softhsmrustv3"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pqctoday-kmip-wasm"
-version     = "0.15.0"
+version     = "0.15.1"
 edition     = "2024"
 license     = "MIT"
 description = "In-browser (WebAssembly) build of the pqctoday-kmip crypto-agile KMIP 3.0 control plane bundled with the softhsmrustv3 PKCS#11 v3.2 engine — drives real KMIP TTLV requests through the dispatcher with no server, network, or filesystem."


### PR DESCRIPTION
## Summary

Cuts release v0.15.1. Three commits, all part of the 2026-07-23 CACP KMIP 3.0 playground re-audit follow-up:

1. **WD19 delta-annotation file** + fix for `build-kmip-wasm.sh`, which never actually staged `tags-enums.json` into the hub repo despite it having been kept in sync by hand until now.
2. **Remaining "§6.4" citation cleanup**: nine wrong citations (a section that doesn't exist under either the CSD01 or WD19 KMIP baseline, verified directly against both spec documents) across the reference conformance harness, the wire encoder, the TLS listener, and a planning doc. Eight now cite the real section (§8.2.3 or §9.5); one general policy statement in `listener.rs` doesn't map to any single spec section, so it's stated honestly instead of guessing a citation.
3. **Python conformance client (`_ttlv.py`) codepoint-table fixes**: `RC4` was mapped to DSA's real codepoint (mirrors a bug already fixed on the hub/TS side); `X25519MLKEM768`/`SecP256r1MLKEM768` were missing from the algorithm table entirely; `DeactivationReasonCode` had no patch at all and silently fell through to the base spec extraction's own corrupted table. All three were unreachable from any current code path — fixed anyway, now guarded by a new completeness test (`test_ttlv.py`).
4. **Release bump**: `kmip/`, `rust/`, `wasm/` crate versions + `python-client` package version, plus the pre-existing `[Unreleased]` `policy_op_layer` test-helper fix.

## Test plan
- [x] `cargo build --lib` clean, `cargo test --lib` — 670/670
- [x] Fresh native OASIS replay — 97 PASS / 0 FAIL / 5 SKIP_DEPRECATED, byte-identical to the committed report
- [x] `pytest kmip/python-client/tests/` — 31/31 (28 existing + 3 new)
- [x] Non-vacuous check: temporarily reintroduced the Python RC4 bug, confirmed the new test fails, reverted
- [x] Repo-wide grep sweep confirms zero remaining KMIP-context "§6.4" citations

## Known pre-existing issue (unrelated, not touched by this PR)
`wasm/src/lib.rs:861` fails to compile natively (`cargo check` in `wasm/`) — a call to `register_import_export::register()` is missing the `&AuthContext` argument the Part F tenancy work added to that function's signature elsewhere. Confirmed pre-existing on `origin/main` before this branch's changes (reproduces identically with this PR's commits stashed out). Out of scope here; flagging so it's on record before the next wasm rebuild is attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)