### PR TITLE
openssh-pkcs11: backport SLH-DSA-SHA2-128s to realign with the sandbox

### DIFF
--- a/openssh-pkcs11/CHANGELOG.md
+++ b/openssh-pkcs11/CHANGELOG.md
@@ -7,6 +7,46 @@ file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
+### Added — SLH-DSA-SHA2-128s SSH authentication, realigning this connector with the sandbox (2026-07-27)
+
+This connector's patch set had silently fallen behind the copy it was forked
+from, leaving every build that consumes it with less SSH PQC capability than
+the sandbox's own network image.
+
+- **`ssh-slhdsa.c` + the full SLH-DSA patch block are now here.**
+  `patches/apply_mldsa_patches.py` gains 12 further patch steps implementing
+  SLH-DSA-SHA2-128s host-key and user authentication
+  (`draft-josefsson-ssh-sphincs-02`), alongside the existing ML-DSA-65
+  (`draft-sfluhrer-ssh-mldsa-06`) support. Signature verification runs through
+  OpenSSL's `SLH-DSA-SHA2-128s` provider (requires OpenSSL ≥ 3.5; the WASM
+  build already links 3.6.x).
+- **`build-wasm.sh` now copies `ssh-slhdsa.c` alongside `ssh-mldsa.c`.** This is
+  required, not cosmetic: the patch script's S1 step rewrites `Makefile.in` to
+  reference both `ssh-mldsa.o` and `ssh-slhdsa.o`, so omitting the source file
+  fails the build at link time rather than at patch time.
+
+**Why it drifted.** This connector was imported from `pqctoday-sandbox` on
+2026-04-18, one day after ML-DSA-65 SSH auth landed there. The sandbox added
+SLH-DSA on 2026-05-25; this copy was never updated, so it stayed ML-DSA-only
+for roughly nine weeks with nothing recording the difference.
+
+**Guarding against a recurrence.** `patches/apply_mldsa_patches.py` is now
+**byte-identical** to `pqctoday-sandbox/docker/apply_mldsa_patches.py`. A plain
+`diff` between the two files is the drift check — please keep them identical
+when either side changes.
+
+**Verification.** Applied against a clean `V_10_3_P1` checkout: 24 edits,
+exit 0. All nine touched files (`Makefile.in`, `myproposal.h`, `sshkey.h`,
+`sshkey.c`, `ssh-pkcs11.c`, `sshd-auth.c`, `sshd.c`, `ssh-mldsa.c`,
+`ssh-slhdsa.c`) are byte-identical to a sandbox-patched tree. Not yet compiled
+or WASM-rebuilt.
+
+**Known follow-up.** On a future OpenSSH 10.4 bump, the `sshkey.h` anchor in
+step 3 needs widening to `\s+KEY_ED25519_SK_CERT,\n(?:\s+KEY_\w+,\n)*\s+KEY_UNSPEC`
+— upstream 10.4 inserts `KEY_MLDSA44_ED25519[_CERT]` between the current anchor
+lines. Because the two copies are now identical, that fix can be made once and
+copied across.
+
 ### Added — selectable KEX + host-key profile and an in-WASM PKCS#11 trace tap (2026-06-27)
 
 For the hub playground integration:

--- a/openssh-pkcs11/patches/apply_mldsa_patches.py
+++ b/openssh-pkcs11/patches/apply_mldsa_patches.py
@@ -320,5 +320,282 @@ replace_once(
     "\t\tcase KEY_ECDSA_SK:\n\t\tcase KEY_ED25519_SK:\n\t\t/* draft-sfluhrer-ssh-mldsa-06 */\n\t\tcase KEY_MLDSA_65:\n\t\t\tif (have_agent || key != NULL)\n\t\t\t\tsensitive_data.have_ssh2_key = 1;\n\t\t\tbreak;"
 )
 
-print("All patches applied successfully.")
-print("Next: autoreconf -i && ./configure ... && make")
+# ══════════════════════════════════════════════════════════════════════════════
+# SLH-DSA-SHA2-128s patches (draft-josefsson-ssh-sphincs-02)
+# These target the ML-DSA-patched file state produced above.
+# ══════════════════════════════════════════════════════════════════════════════
+
+# ── S1. Makefile.in — add ssh-slhdsa.o ───────────────────────────────────────
+replace_once(
+    "Makefile.in",
+    r"\tssh-mldsa\.o msg\.o",
+    r"	ssh-mldsa.o ssh-slhdsa.o msg.o"
+)
+
+# ── S2. myproposal.h — add ssh-slh-dsa-sha2-128s to default PK alg list ──────
+replace_once(
+    "myproposal.h",
+    r'"ssh-mldsa-65," \\\n\t"ssh-ed25519-cert-v01@openssh\.com,"',
+    '"ssh-mldsa-65," \\\n\t"ssh-slh-dsa-sha2-128s," \\\n\t"ssh-ed25519-cert-v01@openssh.com,"'
+)
+
+# ── S3. sshkey.h — add KEY_SLH_DSA_SHA2_128S after KEY_MLDSA_65 ──────────────
+replace_once(
+    "sshkey.h",
+    r"\tKEY_MLDSA_65,\n\s+KEY_UNSPEC",
+    "\tKEY_MLDSA_65,\n\tKEY_SLH_DSA_SHA2_128S,\n\tKEY_UNSPEC"
+)
+
+# ── S4. sshkey.c — extern + register sshkey_slhdsa_sha2_128s_impl ────────────
+# 4a: extern declaration after ML-DSA extern
+replace_once(
+    "sshkey.c",
+    r"extern const struct sshkey_impl sshkey_mldsa65_impl;\n",
+    "extern const struct sshkey_impl sshkey_mldsa65_impl;\nextern const struct sshkey_impl sshkey_slhdsa_sha2_128s_impl;\n"
+)
+# 4b: register after ML-DSA entry in keyimpls[]
+replace_once(
+    "sshkey.c",
+    r"&sshkey_mldsa65_impl,\n# ifdef ENABLE_SK",
+    "&sshkey_mldsa65_impl,\n\n\t&sshkey_slhdsa_sha2_128s_impl,\n# ifdef ENABLE_SK"
+)
+
+# ── S5. ssh-pkcs11.c — SLH-DSA constants + fetch + sign + dispatch ───────────
+PKCS11_SLH_CONSTANTS = r"""
+/* SLH-DSA PKCS#11 v3.2 -- draft-josefsson-ssh-sphincs-02
+ * Constants from SoftHSMv3 src/lib/pkcs11/pkcs11t.h */
+#ifndef CKK_SLH_DSA
+#define CKK_SLH_DSA              0x0000004bUL
+#endif
+#ifndef CKM_SLH_DSA_KEY_PAIR_GEN
+#define CKM_SLH_DSA_KEY_PAIR_GEN 0x0000002dUL
+#endif
+#ifndef CKM_SLH_DSA
+#define CKM_SLH_DSA              0x0000002eUL
+#endif
+/* FIPS 205 §10 Table 2 + draft s3 */
+#define SSH_SLHDSA128S_PK_SZ  32
+#define SSH_SLHDSA128S_SIG_SZ 7856
+
+"""
+
+FETCH_SLHDSA = r"""
+/*
+ * pkcs11_fetch_slhdsa_pubkey -- draft-josefsson-ssh-sphincs-02 s4
+ *
+ * Two-path pubkey extraction (softhsmv3 populates both):
+ *   1. CKA_PUBLIC_KEY_INFO -- DER SubjectPublicKeyInfo (PKCS#11 v3.2 §4.9).
+ *      Parsed via d2i_PUBKEY(); OpenSSL 3.5+ handles SLH-DSA-SHA2-128s SPKI.
+ *   2. CKA_VALUE -- raw 32-byte pk (PKCS#11 v3.2 §6.X SLH-DSA).
+ *      Fallback: imported via EVP_PKEY_new_raw_public_key_ex(..., "SLH-DSA-SHA2-128s").
+ */
+static struct sshkey *
+pkcs11_fetch_slhdsa_pubkey(struct pkcs11_provider *p, CK_ULONG slotidx,
+    CK_OBJECT_HANDLE *obj)
+{
+	CK_ATTRIBUTE		 key_attr[3];
+	CK_SESSION_HANDLE	 session;
+	CK_FUNCTION_LIST	*f = NULL;
+	CK_RV			 rv;
+	struct sshkey		*key = NULL;
+	EVP_PKEY		*pkey = NULL;
+	int			 success = -1, i;
+	const unsigned char	*spki_p;
+
+	memset(&key_attr, 0, sizeof(key_attr));
+	key_attr[0].type = CKA_ID;
+	key_attr[1].type = CKA_PUBLIC_KEY_INFO;
+	key_attr[2].type = CKA_VALUE;
+
+	session = p->slotinfo[slotidx].session;
+	f = p->function_list;
+
+	rv = f->C_GetAttributeValue(session, *obj, key_attr, 3);
+	if (rv != CKR_OK && rv != CKR_ATTRIBUTE_TYPE_INVALID) {
+		error("C_GetAttributeValue (probe) failed: %lu", rv);
+		return NULL;
+	}
+	if (key_attr[1].ulValueLen == (CK_ULONG)-1)
+		key_attr[1].ulValueLen = 0;
+	if (key_attr[2].ulValueLen == (CK_ULONG)-1)
+		key_attr[2].ulValueLen = 0;
+	if (key_attr[1].ulValueLen == 0 && key_attr[2].ulValueLen == 0) {
+		error_f("no SLH-DSA pubkey material on token object");
+		return NULL;
+	}
+	for (i = 0; i < 3; i++)
+		if (key_attr[i].ulValueLen > 0)
+			key_attr[i].pValue = xcalloc(1, key_attr[i].ulValueLen);
+	rv = f->C_GetAttributeValue(session, *obj, key_attr, 3);
+	if (rv != CKR_OK && rv != CKR_ATTRIBUTE_TYPE_INVALID) {
+		error("C_GetAttributeValue (fetch) failed: %lu", rv);
+		goto fail;
+	}
+
+	/* Path 1: DER SPKI */
+	if (key_attr[1].ulValueLen > 0) {
+		spki_p = (const unsigned char *)key_attr[1].pValue;
+		pkey = d2i_PUBKEY(NULL, &spki_p,
+		    (long)key_attr[1].ulValueLen);
+		if (pkey == NULL)
+			debug_f("d2i_PUBKEY failed; trying CKA_VALUE fallback");
+	}
+	/* Path 2: raw 32-byte pk fallback */
+	if (pkey == NULL && key_attr[2].ulValueLen == SSH_SLHDSA128S_PK_SZ) {
+		pkey = EVP_PKEY_new_raw_public_key_ex(NULL, "SLH-DSA-SHA2-128s",
+		    NULL, key_attr[2].pValue, key_attr[2].ulValueLen);
+	}
+	if (pkey == NULL) {
+		error_f("could not materialise SLH-DSA-SHA2-128s pubkey "
+		    "(spki=%lu bytes, raw=%lu bytes)",
+		    (u_long)key_attr[1].ulValueLen,
+		    (u_long)key_attr[2].ulValueLen);
+		goto fail;
+	}
+	if ((key = sshkey_new(KEY_UNSPEC)) == NULL)
+		fatal_f("sshkey_new failed");
+	EVP_PKEY_free(key->pkey);
+	key->pkey = pkey;
+	pkey = NULL;
+	key->type = KEY_SLH_DSA_SHA2_128S;
+	key->flags |= SSHKEY_FLAG_EXT;
+	if (pkcs11_record_key(p, slotidx, &key_attr[0], key))
+		goto fail;
+	success = 0;
+fail:
+	if (success != 0) {
+		EVP_PKEY_free(pkey);
+		sshkey_free(key);
+		key = NULL;
+	}
+	for (i = 0; i < 3; i++)
+		free(key_attr[i].pValue);
+	return key;
+}
+
+"""
+
+SIGN_SLHDSA = r"""
+/*
+ * pkcs11_sign_slhdsa -- draft-josefsson-ssh-sphincs-02
+ *
+ * s5. Signature Algorithm
+ *   Pure SLH-DSA (FIPS 205 §9.2), empty context string.
+ *   CKM_SLH_DSA (0x2e) NULL_PTR param: full message to C_Sign.
+ *
+ * s6. Signature Format
+ *   string  "ssh-slh-dsa-sha2-128s"
+ *   string  signature  (7856 raw bytes)
+ */
+static int
+pkcs11_sign_slhdsa(struct sshkey *key,
+    u_char **sigp, size_t *lenp,
+    const u_char *data, size_t datalen,
+    const char *alg, const char *sk_provider,
+    const char *sk_pin, u_int compat)
+{
+	struct pkcs11_key	*k11;
+	struct pkcs11_slotinfo	*si;
+	CK_FUNCTION_LIST	*f;
+	CK_MECHANISM		 mech = { CKM_SLH_DSA, NULL_PTR, 0 };
+	CK_ULONG		 slen = SSH_SLHDSA128S_SIG_SZ;
+	CK_RV			 rv;
+	u_char			*sig = NULL;
+	struct sshbuf		*b = NULL;
+	int			 ret = SSH_ERR_INTERNAL_ERROR;
+
+	if (sigp != NULL) *sigp = NULL;
+	if (lenp != NULL) *lenp = 0;
+	if ((k11 = pkcs11_lookup_key(key)) == NULL) {
+		error_f("no key found");
+		return SSH_ERR_KEY_NOT_FOUND;
+	}
+	if (pkcs11_get_key(k11, CKM_SLH_DSA) == -1)
+		return SSH_ERR_AGENT_FAILURE;
+	f = k11->provider->function_list;
+	si = &k11->provider->slotinfo[k11->slotidx];
+	sig = xmalloc(slen);
+	rv = f->C_Sign(si->session, (CK_BYTE_PTR)data, (CK_ULONG)datalen,
+	    sig, &slen);
+	if (rv != CKR_OK) {
+		error("C_Sign failed: %lu", rv);
+		goto done;
+	}
+	if (slen != SSH_SLHDSA128S_SIG_SZ) {
+		error_f("bad signature length: %lu (expected %d)",
+		    (u_long)slen, SSH_SLHDSA128S_SIG_SZ);
+		goto done;
+	}
+	if ((b = sshbuf_new()) == NULL)
+		fatal_f("sshbuf_new failed");
+	if (sshbuf_put_cstring(b, "ssh-slh-dsa-sha2-128s") != 0 ||
+	    sshbuf_put_string(b, sig, slen) != 0)
+		fatal_f("sshbuf_put failed");
+	if (sigp != NULL) {
+		*sigp = xmalloc(sshbuf_len(b));
+		memcpy(*sigp, sshbuf_ptr(b), sshbuf_len(b));
+	}
+	if (lenp != NULL)
+		*lenp = sshbuf_len(b);
+	ret = 0;
+done:
+	sshbuf_free(b);
+	freezero(sig, slen);
+	return ret;
+}
+
+"""
+
+# S5a: insert SLH-DSA constants after ML-DSA constants block
+replace_once(
+    "ssh-pkcs11.c",
+    r"#define SSH_MLDSA65_SIG_SZ 3309\n\n",
+    "#define SSH_MLDSA65_SIG_SZ 3309\n\n" + PKCS11_SLH_CONSTANTS
+)
+
+# S5b: insert pkcs11_fetch_slhdsa_pubkey after pkcs11_fetch_mldsa_pubkey
+replace_once(
+    "ssh-pkcs11.c",
+    r"\n#\s*ifdef WITH_OPENSSL /\* libcrypto needed for certificate parsing \*/",
+    "\n" + FETCH_SLHDSA + "# ifdef WITH_OPENSSL /* libcrypto needed for certificate parsing */"
+)
+
+# S5c: add CKK_SLH_DSA case in pkcs11_fetch_keys() after CKK_ML_DSA case
+replace_once(
+    "ssh-pkcs11.c",
+    r"\t\t/\* draft-sfluhrer-ssh-mldsa-06 \*/\n\t\tcase CKK_ML_DSA:\n\t\t\tkey = pkcs11_fetch_mldsa_pubkey\(p, slotidx, &obj\);\n\t\t\tbreak;\n\t\tdefault:",
+    "\t\t/* draft-sfluhrer-ssh-mldsa-06 */\n\t\tcase CKK_ML_DSA:\n\t\t\tkey = pkcs11_fetch_mldsa_pubkey(p, slotidx, &obj);\n\t\t\tbreak;\n\t\t/* draft-josefsson-ssh-sphincs-02 */\n\t\tcase CKK_SLH_DSA:\n\t\t\tkey = pkcs11_fetch_slhdsa_pubkey(p, slotidx, &obj);\n\t\t\tbreak;\n\t\tdefault:"
+)
+
+# S5d: insert pkcs11_sign_slhdsa before pkcs11_sign()
+replace_once(
+    "ssh-pkcs11.c",
+    r"\nint\npkcs11_sign\(struct sshkey \*key,",
+    "\n" + SIGN_SLHDSA + "int\npkcs11_sign(struct sshkey *key,"
+)
+
+# S5e: add KEY_SLH_DSA_SHA2_128S case in pkcs11_sign() after ML-DSA case
+replace_once(
+    "ssh-pkcs11.c",
+    r"\t/\* draft-sfluhrer-ssh-mldsa-06 \*/\n\tcase KEY_MLDSA_65:\n\t\treturn pkcs11_sign_mldsa\(key, sigp, lenp, data, datalen,\n\t\t    alg, sk_provider, sk_pin, compat\);\n\tdefault:",
+    "\t/* draft-sfluhrer-ssh-mldsa-06 */\n\tcase KEY_MLDSA_65:\n\t\treturn pkcs11_sign_mldsa(key, sigp, lenp, data, datalen,\n\t\t    alg, sk_provider, sk_pin, compat);\n\t/* draft-josefsson-ssh-sphincs-02 */\n\tcase KEY_SLH_DSA_SHA2_128S:\n\t\treturn pkcs11_sign_slhdsa(key, sigp, lenp, data, datalen,\n\t\t    alg, sk_provider, sk_pin, compat);\n\tdefault:"
+)
+
+# ── S6. sshd-auth.c — add KEY_SLH_DSA_SHA2_128S to list_hostkey_types() ──────
+replace_once(
+    "sshd-auth.c",
+    r"\t\t/\* draft-sfluhrer-ssh-mldsa-06: agent-backed ML-DSA-65 host key \*/\n\t\tcase KEY_MLDSA_65:\n\t\t\tappend_hostkey_type\(b, sshkey_ssh_name\(key\)\);\n\t\t\tbreak;",
+    "\t\t/* draft-sfluhrer-ssh-mldsa-06: agent-backed ML-DSA-65 host key */\n\t\tcase KEY_MLDSA_65:\n\t\t/* draft-josefsson-ssh-sphincs-02: agent-backed SLH-DSA-SHA2-128s host key */\n\t\tcase KEY_SLH_DSA_SHA2_128S:\n\t\t\tappend_hostkey_type(b, sshkey_ssh_name(key));\n\t\t\tbreak;"
+)
+
+# ── S7. sshd.c — add KEY_SLH_DSA_SHA2_128S to have_ssh2_key switch ───────────
+replace_once(
+    "sshd.c",
+    r"\t\t/\* draft-sfluhrer-ssh-mldsa-06 \*/\n\t\tcase KEY_MLDSA_65:\n\t\t\tif \(have_agent \|\| key != NULL\)\n\t\t\t\tsensitive_data\.have_ssh2_key = 1;\n\t\t\tbreak;",
+    "\t\t/* draft-sfluhrer-ssh-mldsa-06 */\n\t\tcase KEY_MLDSA_65:\n\t\t/* draft-josefsson-ssh-sphincs-02 */\n\t\tcase KEY_SLH_DSA_SHA2_128S:\n\t\t\tif (have_agent || key != NULL)\n\t\t\t\tsensitive_data.have_ssh2_key = 1;\n\t\t\tbreak;"
+)
+
+print("All patches applied successfully (ML-DSA-65 + SLH-DSA-SHA2-128s).")
+print("Next: ensure ssh-mldsa.c AND ssh-slhdsa.c are in the source tree "
+      "(Makefile.in now references both objects), then "
+      "autoreconf -i && ./configure ... && make")

--- a/openssh-pkcs11/patches/ssh-slhdsa.c
+++ b/openssh-pkcs11/patches/ssh-slhdsa.c
@@ -1,0 +1,217 @@
+/*
+ * ssh-slhdsa.c -- SLH-DSA-SHA2-128s key type for OpenSSH
+ *
+ * Implements draft-josefsson-ssh-sphincs-02 (November 2025)
+ * https://datatracker.ietf.org/doc/draft-josefsson-ssh-sphincs/
+ *
+ * s3. Public Key Algorithms
+ *   "ssh-slh-dsa-sha2-128s" -- SLH-DSA-SHA2-128S (NIST Category 1, small sigs)
+ *
+ * s4. Public Key Format
+ *   string  "ssh-slh-dsa-sha2-128s"
+ *   string  key     (32 raw bytes; SLH-DSA.KeyGen pk per FIPS 205 §10.1)
+ *
+ * s5. Signature Algorithm
+ *   Pure SLH-DSA (FIPS 205 §9.2). Context string always empty.
+ *   NOTE: signing is PKCS#11-only (ssh-pkcs11.c:pkcs11_sign_slhdsa).
+ *
+ * s6. Signature Format
+ *   string  "ssh-slh-dsa-sha2-128s"
+ *   string  signature   (7856 raw bytes; FIPS 205 §10 Table 2)
+ *
+ * s8. Verification Algorithm
+ *   Step 1: Reject if sig length != 7856 bytes for SLH-DSA-SHA2-128S.
+ *   Step 2: Verify per FIPS 205 §9.3, pure SLH-DSA, empty context.
+ */
+
+#include "includes.h"
+#include <stddef.h>
+#include <string.h>
+
+#include <openssl/evp.h>
+
+#include "ssherr.h"
+#include "sshbuf.h"
+#include "sshkey.h"
+
+/* FIPS 205 §10 Table 2 -- SLH-DSA-SHA2-128s */
+#define SSH_SLHDSA128S_PK_SZ  32
+#define SSH_SLHDSA128S_SIG_SZ 7856
+
+static void
+slhdsa128s_cleanup(struct sshkey *k)
+{
+	EVP_PKEY_free(k->pkey);
+	k->pkey = NULL;
+}
+
+static int
+slhdsa128s_equal(const struct sshkey *a, const struct sshkey *b)
+{
+	u_char pka[SSH_SLHDSA128S_PK_SZ], pkb[SSH_SLHDSA128S_PK_SZ];
+	size_t la = sizeof(pka), lb = sizeof(pkb);
+
+	if (a->pkey == NULL || b->pkey == NULL)
+		return 0;
+	if (!EVP_PKEY_get_raw_public_key(a->pkey, pka, &la) ||
+	    !EVP_PKEY_get_raw_public_key(b->pkey, pkb, &lb))
+		return 0;
+	if (la != SSH_SLHDSA128S_PK_SZ || lb != SSH_SLHDSA128S_PK_SZ)
+		return 0;
+	return timingsafe_bcmp(pka, pkb, SSH_SLHDSA128S_PK_SZ) == 0;
+}
+
+/*
+ * s4: Serialize public key -- write raw key bytes as SSH string.
+ * The algorithm name string is written by the sshkey layer before this.
+ */
+static int
+slhdsa128s_serialize_public(const struct sshkey *key, struct sshbuf *b,
+    enum sshkey_serialize_rep opts)
+{
+	u_char raw[SSH_SLHDSA128S_PK_SZ];
+	size_t len = sizeof(raw);
+
+	if (key->pkey == NULL)
+		return SSH_ERR_INVALID_ARGUMENT;
+	if (!EVP_PKEY_get_raw_public_key(key->pkey, raw, &len))
+		return SSH_ERR_LIBCRYPTO_ERROR;
+	if (len != SSH_SLHDSA128S_PK_SZ)
+		return SSH_ERR_INVALID_FORMAT;
+	return sshbuf_put_string(b, raw, len);
+}
+
+/*
+ * s4: Deserialize public key.
+ * Validates exactly SSH_SLHDSA128S_PK_SZ bytes, imports via OpenSSL 3.5+.
+ */
+static int
+slhdsa128s_deserialize_public(const char *ktype, struct sshbuf *b,
+    struct sshkey *key)
+{
+	const u_char *pk;
+	size_t pklen;
+	int r;
+
+	if ((r = sshbuf_get_string_direct(b, &pk, &pklen)) != 0)
+		return r;
+	/* s8 step 1: reject if length does not match SLH-DSA-SHA2-128s */
+	if (pklen != SSH_SLHDSA128S_PK_SZ)
+		return SSH_ERR_KEY_LENGTH;
+	EVP_PKEY_free(key->pkey);
+	if ((key->pkey = EVP_PKEY_new_raw_public_key_ex(NULL, "SLH-DSA-SHA2-128s",
+	    NULL, pk, pklen)) == NULL)
+		return SSH_ERR_LIBCRYPTO_ERROR;
+	return 0;
+}
+
+static int
+slhdsa128s_copy_public(const struct sshkey *from, struct sshkey *to)
+{
+	u_char raw[SSH_SLHDSA128S_PK_SZ];
+	size_t len = sizeof(raw);
+
+	if (from->pkey == NULL)
+		return SSH_ERR_INVALID_ARGUMENT;
+	if (!EVP_PKEY_get_raw_public_key(from->pkey, raw, &len))
+		return SSH_ERR_LIBCRYPTO_ERROR;
+	EVP_PKEY_free(to->pkey);
+	if ((to->pkey = EVP_PKEY_new_raw_public_key_ex(NULL, "SLH-DSA-SHA2-128s",
+	    NULL, raw, len)) == NULL)
+		return SSH_ERR_LIBCRYPTO_ERROR;
+	return 0;
+}
+
+/*
+ * s8. Verification Algorithm
+ *
+ * Step 1: Reject if sig length != SSH_SLHDSA128S_SIG_SZ (7856).
+ * Step 2: Verify pure SLH-DSA, empty context (OpenSSL 3.5+).
+ *
+ * Wire format (s6):
+ *   string  "ssh-slh-dsa-sha2-128s"
+ *   string  signature   (7856 bytes)
+ *
+ * SLH-DSA hashes internally (like ML-DSA / Ed25519), so use EVP_DigestVerify
+ * rather than EVP_PKEY_verify (which bypasses the internal hash and always
+ * returns failure for stateless hash-based schemes).
+ */
+static int
+slhdsa128s_verify(const struct sshkey *key,
+    const u_char *sig, size_t siglen,
+    const u_char *data, size_t datalen,
+    const char *alg, u_int compat,
+    struct sshkey_sig_details **detailsp)
+{
+	struct sshbuf	*b = NULL;
+	char		*ktype = NULL;
+	const u_char	*sigblob;
+	size_t		 slen;
+	EVP_MD_CTX	*md_ctx = NULL;
+	int		 r = SSH_ERR_INTERNAL_ERROR;
+
+	if (detailsp != NULL)
+		*detailsp = NULL;
+	if (key == NULL || key->pkey == NULL || sig == NULL || siglen == 0 ||
+	    data == NULL || datalen == 0)
+		return SSH_ERR_INVALID_ARGUMENT;
+	if ((b = sshbuf_from(sig, siglen)) == NULL)
+		return SSH_ERR_ALLOC_FAIL;
+	/* s6: parse wire format */
+	if ((r = sshbuf_get_cstring(b, &ktype, NULL)) != 0)
+		goto out;
+	if (strcmp(ktype, "ssh-slh-dsa-sha2-128s") != 0) {
+		r = SSH_ERR_KEY_TYPE_MISMATCH;
+		goto out;
+	}
+	if ((r = sshbuf_get_string_direct(b, &sigblob, &slen)) != 0)
+		goto out;
+	/* s8 step 1: reject wrong signature length */
+	if (slen != SSH_SLHDSA128S_SIG_SZ) {
+		r = SSH_ERR_SIGNATURE_INVALID;
+		goto out;
+	}
+	/* s8 step 2: verify pure SLH-DSA, empty context. */
+	if ((md_ctx = EVP_MD_CTX_new()) == NULL) {
+		r = SSH_ERR_ALLOC_FAIL;
+		goto out;
+	}
+	if (EVP_DigestVerifyInit(md_ctx, NULL, NULL, NULL, key->pkey) != 1 ||
+	    EVP_DigestVerify(md_ctx, sigblob, slen, data, datalen) != 1) {
+		r = SSH_ERR_SIGNATURE_INVALID;
+		goto out;
+	}
+	r = 0;
+out:
+	sshbuf_free(b);
+	free(ktype);
+	EVP_MD_CTX_free(md_ctx);
+	return r;
+}
+
+static const struct sshkey_impl_funcs slhdsa128s_funcs = {
+	NULL,			/* size */
+	NULL,			/* alloc */
+	slhdsa128s_cleanup,
+	slhdsa128s_equal,
+	slhdsa128s_serialize_public,
+	slhdsa128s_deserialize_public,
+	NULL,			/* serialize_private */
+	NULL,			/* deserialize_private */
+	NULL,			/* generate */
+	slhdsa128s_copy_public,
+	NULL,			/* sign -- PKCS#11 only */
+	slhdsa128s_verify,
+};
+
+const struct sshkey_impl sshkey_slhdsa_sha2_128s_impl = {
+	"ssh-slh-dsa-sha2-128s",	/* name */
+	"SLHDSA128S",			/* shortname */
+	"ssh-slh-dsa-sha2-128s",	/* sigalg */
+	KEY_SLH_DSA_SHA2_128S,		/* type */
+	0,				/* nid */
+	0,				/* cert */
+	0,				/* sigonly */
+	0,				/* keybits */
+	&slhdsa128s_funcs,
+};

--- a/openssh-pkcs11/scripts/build-wasm.sh
+++ b/openssh-pkcs11/scripts/build-wasm.sh
@@ -56,8 +56,13 @@ if [[ "${SKIP_OPENSSH_FETCH:-0}" != "1" || ! -d "$OPENSSH_SRC" ]]; then
         https://github.com/openssh/openssh-portable.git "$OPENSSH_SRC"
 fi
 
-echo "[openssh-pkcs11] Applying ML-DSA-65 patches (draft-sfluhrer-ssh-mldsa-06)..."
-cp "$ROOT/patches/ssh-mldsa.c" "$OPENSSH_SRC/"
+# Both source files must be copied BEFORE running the patch script: its S1 step
+# rewrites Makefile.in to reference ssh-mldsa.o AND ssh-slhdsa.o, so a missing
+# ssh-slhdsa.c fails the build at link time rather than here.
+echo "[openssh-pkcs11] Applying ML-DSA-65 (draft-sfluhrer-ssh-mldsa-06) +"
+echo "[openssh-pkcs11] SLH-DSA-SHA2-128s (draft-josefsson-ssh-sphincs-02) patches..."
+cp "$ROOT/patches/ssh-mldsa.c"  "$OPENSSH_SRC/"
+cp "$ROOT/patches/ssh-slhdsa.c" "$OPENSSH_SRC/"
 (cd "$OPENSSH_SRC" && python3 "$ROOT/patches/apply_mldsa_patches.py")
 
 echo "[openssh-pkcs11] Copying WASM shims..."


### PR DESCRIPTION
## What

Backports the SLH-DSA-SHA2-128s block into `openssh-pkcs11/patches/`, bringing this connector back to parity with the copy it was forked from.

## Why

This connector was imported from `pqctoday-sandbox` on **2026-04-18**, one day after ML-DSA-65 SSH auth landed there. The sandbox added SLH-DSA-SHA2-128s (`draft-josefsson-ssh-sphincs-02`) on **2026-05-25**, and this copy was never updated — so it stayed ML-DSA-only for roughly nine weeks.

Because two things consume this patch set, that gap propagated:

| Artifact | Patch source | SSH PQC before | after |
|---|---|---|---|
| sandbox **network** image | `pqctoday-sandbox/docker/` | ML-DSA-65 + SLH-DSA | unchanged |
| sandbox **dev-sandbox** image | **this connector** | ML-DSA-65 only | **+ SLH-DSA** |
| hub **WASM SSH** build | **this connector** | ML-DSA-65 only | **+ SLH-DSA** |

Nothing recorded the difference, and neither the connector README nor its changelog ever claimed SLH-DSA — so this was a silent capability gap rather than a false claim.

## Changes

- `patches/apply_mldsa_patches.py` — +12 SLH-DSA patch steps (324 → 599 lines)
- `patches/ssh-slhdsa.c` — new
- `scripts/build-wasm.sh` — copies `ssh-slhdsa.c` alongside `ssh-mldsa.c`
- `CHANGELOG.md` — entry under `[Unreleased]`

**The `build-wasm.sh` change is required, not cosmetic.** The patch script's S1 step rewrites `Makefile.in` to reference both `ssh-mldsa.o` and `ssh-slhdsa.o`, so a missing source file fails at *link* time rather than at patch time.

## Drift guard

`patches/apply_mldsa_patches.py` is now **byte-identical** to `pqctoday-sandbox/docker/apply_mldsa_patches.py`. A plain `diff` between the two is the check that would have caught this. Please keep them identical.

## Verification

Applied against a clean `V_10_3_P1` checkout: **24 edits, exit 0**. A second clean tree patched with the *sandbox* script was then diffed against it — all nine touched files are byte-identical:

`Makefile.in` · `myproposal.h` · `sshkey.h` · `sshkey.c` · `ssh-pkcs11.c` · `sshd-auth.c` · `sshd.c` · `ssh-mldsa.c` · `ssh-slhdsa.c`

**Not** yet compiled or WASM-rebuilt — patch-level verification only.

## Known follow-up

A future OpenSSH 10.4 bump needs the step-3 `sshkey.h` anchor widened to `\s+KEY_ED25519_SK_CERT,\n(?:\s+KEY_\w+,\n)*\s+KEY_UNSPEC`; upstream 10.4 inserts `KEY_MLDSA44_ED25519[_CERT]` between the current anchor lines. Verified separately. Since the copies are now identical, fix once and copy.

## Pairs with

`pqctoday-sandbox#fix/ssh-slhdsa-realign` — the matching `Dockerfile.dev-sandbox` change. Merge both, or the dev-sandbox build will fail on the missing object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)