### PR TITLE
docs: HSS/XMSS mechanisms are PKCS#11 v3.2 §6.65/§6.66, not §6.14

### DIFF
--- a/src/lib/SoftHSM_slots.cpp
+++ b/src/lib/SoftHSM_slots.cpp
@@ -585,7 +585,7 @@ void SoftHSM::prepareSupportedMechanisms(std::map<std::string, CK_MECHANISM_TYPE
 	t["CKM_ML_KEM"]			= CKM_ML_KEM;
 
 	// LMS / HSS stateful hash-based signatures (G10)
-	// CKM_HSS / CKM_HSS_KEY_PAIR_GEN are standard PKCS#11 v3.2 §6.14
+	// CKM_HSS / CKM_HSS_KEY_PAIR_GEN are standard PKCS#11 v3.2 §6.65
 	t["CKM_HSS_KEY_PAIR_GEN"]	= CKM_HSS_KEY_PAIR_GEN;
 	t["CKM_HSS"]			= CKM_HSS;
 	t["CKM_XMSS_KEY_PAIR_GEN"]      = 0x00004034;
@@ -1111,7 +1111,7 @@ CK_RV SoftHSM::C_GetMechanismInfo(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type, CK_
 			pInfo->flags = CKF_ENCAPSULATE | CKF_DECAPSULATE;
 			break;
 		// LMS / HSS stateful hash-based signatures (G10)
-		// Standard PKCS#11 v3.2 §6.14 entries (HSS + keygen)
+		// Standard PKCS#11 v3.2 §6.65 entries (HSS + keygen)
 		case CKM_HSS_KEY_PAIR_GEN:
 			pInfo->ulMinKeySize = 0;
 			pInfo->ulMaxKeySize = 0;

--- a/src/lib/vendor_mechanisms.h
+++ b/src/lib/vendor_mechanisms.h
@@ -86,7 +86,7 @@
 #define CKP_LMOTS_SHAKE_N24_W4   0x0000000FUL
 #define CKP_LMOTS_SHAKE_N24_W8   0x00000010UL
 
-// ── Standard PKCS#11 v3.2 §6.14: HSS/LMS/XMSS mechanisms ────────────────────
+// ── Standard PKCS#11 v3.2 §6.65 (HSS) / §6.66 (XMSS) mechanisms ────────────────────
 
 #define CKM_HSS_KEY_PAIR_GEN   0x00004032UL
 #define CKM_HSS                0x00004033UL
@@ -98,7 +98,7 @@
 #define CKK_XMSSMT             0x00000048UL
 
 // Standard CKR extension
-#define CKR_KEY_EXHAUSTED      0x00000203UL  /* PKCS#11 v3.2 §6.14 */
+#define CKR_KEY_EXHAUSTED      0x00000203UL  /* PKCS#11 v3.2 §5.1 error code */
 
 // ── HSS key generation parameters (CKM_HSS_KEY_PAIR_GEN mechanism parameter) ─
 


### PR DESCRIPTION
Comment-only lockstep fix with pqctoday-sandbox PR #54: the ratified v3.2 OS TOC places HSS at §6.65 and XMSS/XMSSMT at §6.66 (§6.14 is AES CMAC); CKR_KEY_EXHAUSTED is a §5.1 error-code assignment. Two files, four comment lines, zero behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)