### PR TITLE
MLS interop: the peer built a program that never existed — the rig now runs

### DIFF
--- a/openmls-provider/interop/docker/Dockerfile.mls-rs
+++ b/openmls-provider/interop/docker/Dockerfile.mls-rs
@@ -1,15 +1,38 @@
 # Multi-stage build for the AWS Wickr mls-rs interop client.
 #
-# mls-rs ships an IETF mls_client.proto-compatible gRPC server under
-# `mls_rs/mls-rs-ffi/src/grpc/` (added in the `grpc-interop` feature flag
-# introduced in awslabs/mls-rs PR #193).  If the upstream doesn't yet have
-# that binary on your pinned commit, see the fallback note at the bottom.
+# CORRECTED 2026-08-09. Every detail of the previous header was wrong, and the
+# build had failed nightly since at least 08-07 as a result:
+#
+#   claimed                                    actual
+#   ------------------------------------------ ---------------------------------
+#   server at mls-rs-ffi/src/grpc/             that path has NEVER existed;
+#                                              mls-rs-ffi/src/ holds only lib.rs
+#   feature flag `grpc-interop`                no commit in the repository has
+#                                              ever mentioned it
+#   binary `mls-rs-grpc`                       same — never existed
+#   "introduced in awslabs/mls-rs PR #193"     #193 is "Add support for
+#                                              different SQLite journal modes"
+#
+# Verified with `git log -S<term> --all` over a full clone, which is what makes
+# these "never existed" rather than "was removed and we missed it".
+#
+# What upstream ACTUALLY ships is `harness_client`, a workspace member at
+# mls-rs/test_harness_integration/, built with DEFAULT features and taking
+# --port. It is what mls-rs drives in its own interop_tests.yml.
 #
 # Build context: none (fetches source from GitHub at build time).
-# Pin to a specific commit with --build-arg MLS_RS_REF=<sha>.
-ARG MLS_RS_REF=main
+#
+# PINNED, not tracking main. An unpinned third-party ref is precisely how this
+# broke: upstream changes shape and a green build goes red overnight with
+# nothing here having changed. Bump deliberately, with a diff to look at.
+ARG MLS_RS_REF=6fc9223d8ce2e4d8ec8ca5140422338dccc34394
 
-FROM rust:1.87-bookworm AS mls-rs-builder
+# rust:1.91, not 1.87. harness_client pulls tonic 0.14 / darling 0.23 (MSRV
+# 1.88) and the sibling openmls image needs 1.91, so all three interop images
+# share one version. Note mls-rs's own `rust-version = "1.82.0"` is NOT the
+# constraint to read here — the transitive dependencies are stricter than the
+# crate that declares them.
+FROM rust:1.91-bookworm AS mls-rs-builder
 
 ARG MLS_RS_REF
 
@@ -18,24 +41,29 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
-RUN git clone --depth 1 --branch "${MLS_RS_REF}" \
-        https://github.com/awslabs/mls-rs.git . \
-    || git clone --depth 1 \
-        https://github.com/awslabs/mls-rs.git . && git checkout "${MLS_RS_REF}"
+# Fetch BY COMMIT, not by clone --branch. `--branch` only accepts a branch or
+# tag name, so it can never check out a pinned SHA, and the old fallback was no
+# better: `clone --depth 1` fetches only the default branch tip, so a following
+# `checkout <sha>` succeeds ONLY while the pin happens to equal that tip. Pinning
+# would have looked fine today and broken on upstream's next push — an illusion
+# of a pin. `fetch --depth 1 origin <ref>` accepts a SHA, a branch or a tag.
+RUN git init -q . \
+    && git remote add origin https://github.com/awslabs/mls-rs.git \
+    && git fetch --depth 1 -q origin "${MLS_RS_REF}" \
+    && git checkout -q FETCH_HEAD \
+    && echo "mls-rs at $(git rev-parse HEAD)"
 
-# Build the gRPC interop client (feature `grpc-interop` gates the binary).
-# If the feature or binary doesn't exist on the pinned ref, the build fails
-# loudly here rather than silently at docker-compose up time.
-RUN cargo build --release \
-        --features grpc-interop \
-        -p mls-rs \
-        --bin mls-rs-grpc \
+# Build upstream's real interop server. No feature flag: harness_client builds
+# with default features, exactly as mls-rs's own interop_tests.yml does.
+RUN cargo build --release -p harness_client \
     || ( \
         echo ""; \
-        echo "ERROR: 'mls-rs-grpc' binary not found on ref ${MLS_RS_REF}."; \
-        echo "Check https://github.com/awslabs/mls-rs for the interop binary."; \
-        echo "Fallback: implement the gRPC contract inside our own binary and"; \
-        echo "call mls-rs as a library — see interop/README.md §Fallbacks."; \
+        echo "ERROR: could not build 'harness_client' at ref ${MLS_RS_REF}."; \
+        echo "It lives at mls-rs/test_harness_integration/ and is a workspace"; \
+        echo "member — check it still exists and still builds with default"; \
+        echo "features:  https://github.com/awslabs/mls-rs"; \
+        echo "Do NOT reintroduce --features grpc-interop or --bin mls-rs-grpc;"; \
+        echo "neither has ever existed upstream (see the header)."; \
         echo ""; \
         exit 1; \
     )
@@ -54,7 +82,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=mls-rs-builder /src/target/release/mls-rs-grpc /usr/local/bin/mls-rs-grpc
+COPY --from=mls-rs-builder /src/target/release/harness_client /usr/local/bin/mls-rs-grpc
 
 EXPOSE 50054
 ENTRYPOINT ["/usr/local/bin/mls-rs-grpc"]

--- a/openmls-provider/interop/docker/Dockerfile.openmls
+++ b/openmls-provider/interop/docker/Dockerfile.openmls
@@ -4,7 +4,12 @@
 # Pin the commit via --build-arg OPENMLS_REF=<sha>.
 ARG OPENMLS_REF=main
 
-FROM rust:1.87-bookworm AS openmls-builder
+# rust:1.91, not 1.87 (2026-08-09). Two separate MSRV floors apply and the
+# HIGHER one governs: tonic 0.14 / darling 0.23 need 1.88, and openmls
+# 0.9.0-rc.1 and its companion crates need 1.91. Cargo refuses at dependency
+# RESOLUTION, before compiling anything. Set to one version across all three
+# images deliberately — bumping them one at a time just moves the failure.
+FROM rust:1.91-bookworm AS openmls-builder
 
 ARG OPENMLS_REF
 

--- a/openmls-provider/interop/docker/Dockerfile.pqctoday
+++ b/openmls-provider/interop/docker/Dockerfile.pqctoday
@@ -43,7 +43,12 @@ RUN cmake -S . -B build \
     && cmake --build build --target softhsmv3 -j"$(nproc)"
 
 # ── Stage 2: build the pqctoday-mls-grpc binary ───────────────────────────────
-FROM rust:1.87-bookworm AS grpc-builder
+# rust:1.91, not 1.87 (2026-08-09). Two separate MSRV floors apply and the
+# HIGHER one governs: tonic 0.14 / darling 0.23 need 1.88, and openmls
+# 0.9.0-rc.1 and its companion crates need 1.91. Cargo refuses at dependency
+# RESOLUTION, before compiling anything. Set to one version across all three
+# images deliberately — bumping them one at a time just moves the failure.
+FROM rust:1.91-bookworm AS grpc-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config libsqlite3-dev \

--- a/openmls-provider/interop/docker/Dockerfile.test-runner
+++ b/openmls-provider/interop/docker/Dockerfile.test-runner
@@ -3,7 +3,10 @@
 #
 # The test runner drives pairwise scenarios across any two gRPC clients
 # that implement the mls_client.proto contract.
-ARG MLS_IMPL_REF=main
+# PINNED, not tracking main. This is the very commit awslabs/mls-rs pins in its
+# own interop_tests.yml, so it is a ref upstream itself runs against rather than
+# one chosen here. Bump deliberately.
+ARG MLS_IMPL_REF=7066309c555bfc11fbc74f8288a8563c927637b2
 
 FROM golang:1.22-bookworm AS runner-builder
 
@@ -17,8 +20,14 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.33.0 \
     && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
 
 WORKDIR /src
-RUN git clone --depth 1 https://github.com/mlswg/mls-implementations.git . \
-    && git checkout "${MLS_IMPL_REF}"
+# Fetch BY COMMIT — see the same note in Dockerfile.mls-rs. `clone --depth 1`
+# brings down only the default branch tip, so the following `checkout <sha>`
+# worked only while the pin equalled that tip; against any real pin it fails.
+RUN git init -q . \
+    && git remote add origin https://github.com/mlswg/mls-implementations.git \
+    && git fetch --depth 1 -q origin "${MLS_IMPL_REF}" \
+    && git checkout -q FETCH_HEAD \
+    && echo "mls-implementations at $(git rev-parse HEAD)"
 
 # Generate Go protobuf stubs that the test-runner imports.
 RUN protoc --go_out=. --go-grpc_out=. \

--- a/openmls-provider/interop/docker/docker-compose.yml
+++ b/openmls-provider/interop/docker/docker-compose.yml
@@ -77,7 +77,10 @@ services:
       context: .
       dockerfile: Dockerfile.mls-rs
       args:
-        MLS_RS_REF: main
+        # PINNED here as well as in the Dockerfile — this build arg OVERRIDES
+        # the Dockerfile's default, so pinning only there would have achieved
+        # nothing while looking like it had.
+        MLS_RS_REF: 6fc9223d8ce2e4d8ec8ca5140422338dccc34394
     ports:
       - "50054:50054"
     healthcheck:


### PR DESCRIPTION
The nightly OpenMLS Interop job has failed every night since at least 2026-08-07, and not for a conformance reason — it died during **image build**, before a single scenario ran. MLS interop has had **zero coverage** while presenting as a gate.

## The peer asked upstream for three things that do not exist

| Claimed | Actual |
|---|---|
| server at `mls-rs-ffi/src/grpc/` | that path has **never existed**; the directory holds only `lib.rs` |
| feature `grpc-interop` | no commit in `awslabs/mls-rs` has ever mentioned it |
| binary `mls-rs-grpc` | same — never existed |
| *"introduced in mls-rs PR #193"* | #193 is **"Add support for different SQLite journal modes"** |

Established with `git log -S<term> --all` over a full clone, which is what makes these *never existed* rather than *removed and we missed it*.

Upstream's real interop server is **`harness_client`**, a workspace member at `mls-rs/test_harness_integration/`, built with **default features** — exactly what mls-rs drives in its own `interop_tests.yml`.

## Three more defects found while making it work

**1. The pinning was an illusion.** Both peers did `clone --depth 1` then `checkout <ref>`. A shallow clone fetches only the default-branch tip, so checking out a pinned SHA succeeds *only while the pin equals that tip* — correct today, broken on upstream's next push. Both now use `fetch --depth 1 origin <ref>`, which accepts a SHA, branch or tag, and echo the resolved commit so the build log says what it actually got.

**2. The compose file overrode the pin.** It passed `MLS_RS_REF: main` as a build arg, which beats the Dockerfile default — so pinning only the Dockerfile would have achieved nothing while looking right. Pinned in both places.

**3. Rust 1.87 could not resolve the dependency set at all.** Two MSRV floors apply and the higher governs: tonic 0.14 / darling 0.23 need 1.88, openmls 0.9.0-rc.1 needs 1.91. All three interop images move to 1.91 together — bumping one at a time just relocates the failure.

Pins: mls-rs `6fc9223`, mls-implementations `7066309` (the very commit awslabs pins in its own interop workflow, so a ref upstream itself runs against).

## Verified by running it, not by a green build

All three clients came up healthy and the IETF WG test runner drove `welcome_join` across pqctoday and mls-rs:

**104 cases — 44 passed, 60 failed.**

**Four of the passes are cross-vendor** (pqctoday + mls-rs together). That is real interoperability demonstrated by the working group's own runner, rather than by the hand-rolled stand-in we had been relying on. Ciphersuites 1–3 pass; 4–7 fail.

## The 60 failures are first observations, not regressions

Nothing here ever ran before, so there is no baseline to have regressed from. Three distinct classes, left for triage rather than papered over:

| Count | Error |
|---|---|
| 32 | `HSM signer gen: UnsupportedSignatureScheme` — ours, on ciphersuites 4–7 |
| 16 | `KeyPackage validate: the lifetime of the leaf node is not valid` |
| 12 | `openmls error: Lifetime is not acceptable` |

The two lifetime classes (28 between them) look like one shared clock/validity-window problem rather than two separate bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)